### PR TITLE
Fix a few remaining issues with CMake build and git (SDK-26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 *~
+
+# You have to ignore this genrated file or git will complain that it is an
+# unknown file!
+/make.inc
+
+# If the instructions are telling people to create this build dir under the
+# source tree, you had better put in an ignore for this.
 /build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,15 @@ set(NOFORTRAN FALSE)
 set(SUPERLU_VERSION "${PROJECT_VERSION}")
 set(SUPERLU_REV "${PROJECT_REV}")
 
+# The XSDK standard does not allow using internally built BLAS
+if (USE_XSDK_DEFAULTS)
+  set(enable_blaslib_DEFAULT OFF)
+else()
+  set(enable_blaslib_DEFAULT ON)
+endif()
+
 # setup options
-option(enable_blaslib   "Build the CBLAS library" ON)
+option(enable_blaslib   "Build the CBLAS library" ${enable_blaslib_DEFAULT})
 option(enable_matlabmex "Build the Matlab mex library" OFF)
 option(enable_tests     "Build tests" ON)
 option(enable_doc       "Build doxygen documentation" OFF)


### PR DESCRIPTION
Sherry,

I found a few issues with the current 'master' branch  Two of the issues mentioned below are fixed by commits in the PR:

1) The generated file `make.inc` is no longer being ignored.  (This is fixed in the new PR.)

2) The built-in CBLAS is not on by default and ignores TPL_BLAS_LIBRARIES.  That is incompatible with the XSDK configure standard and kills library interoperability.  When USE_XSDK_DEFAULTS=ON, it must *not* use the use the built-in CBLAS by default.  (This is fixed in the new PR.)

3) There is no auotmated testing for the user example at all, even for the narrow use cases where it currently works.  That is asking for the examples to be broken when users try to use it. (I did not fix this but this is not an issues for xSDK.)

Can you please just accept my new pull request?  This is just two simple commits fixing the issues described above.  That way I will get some credit for contributing to SuperLU.

-Ross