### PR TITLE
fix library dependencies

### DIFF
--- a/TESTING/CMakeLists.txt
+++ b/TESTING/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${SuperLU_SOURCE_DIR}/SRC)
 
 # Libs linked to all of the tests
-set(test_link_libs superlu matgen ${BLAS_LIB} m)
+set(test_link_libs matgen)
 
 add_subdirectory(MATGEN)
 

--- a/TESTING/MATGEN/CMakeLists.txt
+++ b/TESTING/MATGEN/CMakeLists.txt
@@ -97,3 +97,4 @@ if(enable_complex16)
 endif()
 
 add_library(matgen ${sources})
+target_link_libraries(matgen superlu)


### PR DESCRIPTION
Link errors revealed by

```
-DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_SHARED_LINKER_FLAGS -Wl,--no-undefined"
```
