### PR TITLE
use GNUInstallDirs

### DIFF
--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(headers 
+set(headers
     supermatrix.h
     slu_Cnames.h
     slu_dcomplex.h
@@ -232,10 +232,13 @@ target_link_libraries(superlu ${BLAS_LIB} m)
 set_target_properties(superlu PROPERTIES
   VERSION ${PROJECT_VERSION} SOVERSION ${VERSION_MAJOR}
   )
+
+include(GNUInstallDirs)
+
 install(TARGETS superlu
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(FILES ${headers}
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
Using [GnuInstallDirs](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html) has several advantages:

 * The correct directories are used, including on Debian (where libs go into, e.g, /usr/lib/<multiarch-tuple>). This is the only change from the previous behavior, and it will only occur on Debian systems.

 * One can easily override the default directories by specifying, e.g., `-DCMAKE_INSTALL_INCLUDEDIR=/my/custom/path` at configuration.