### PR TITLE
Explicitly declare function return type as int

### DIFF
--- a/SRC/cutil.c
+++ b/SRC/cutil.c
@@ -474,7 +474,7 @@ cPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_complex_vec(char *what, int n, complex *vec)
 {
     int i;

--- a/SRC/dutil.c
+++ b/SRC/dutil.c
@@ -470,7 +470,7 @@ dPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_double_vec(char *what, int n, double *vec)
 {
     int i;

--- a/SRC/sutil.c
+++ b/SRC/sutil.c
@@ -470,7 +470,7 @@ sPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_float_vec(char *what, int n, float *vec)
 {
     int i;

--- a/SRC/zutil.c
+++ b/SRC/zutil.c
@@ -474,7 +474,7 @@ zPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 
-
+int
 print_doublecomplex_vec(char *what, int n, doublecomplex *vec)
 {
     int i;

--- a/TESTING/cdrive.c
+++ b/TESTING/cdrive.c
@@ -37,7 +37,7 @@ parse_command_line(int argc, char *argv[], char *matrix_type,
 		   int *n, int *w, int *relax, int *nrhs, int *maxsuper,
 		   int *rowblk, int *colblk, int *lwork, double *u, FILE **fp);
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 /* 
  * Purpose

--- a/TESTING/ddrive.c
+++ b/TESTING/ddrive.c
@@ -37,7 +37,7 @@ parse_command_line(int argc, char *argv[], char *matrix_type,
 		   int *n, int *w, int *relax, int *nrhs, int *maxsuper,
 		   int *rowblk, int *colblk, int *lwork, double *u, FILE **fp);
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 /* 
  * Purpose

--- a/TESTING/sdrive.c
+++ b/TESTING/sdrive.c
@@ -37,7 +37,7 @@ parse_command_line(int argc, char *argv[], char *matrix_type,
 		   int *n, int *w, int *relax, int *nrhs, int *maxsuper,
 		   int *rowblk, int *colblk, int *lwork, double *u, FILE **fp);
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 /* 
  * Purpose

--- a/TESTING/zdrive.c
+++ b/TESTING/zdrive.c
@@ -37,7 +37,7 @@ parse_command_line(int argc, char *argv[], char *matrix_type,
 		   int *n, int *w, int *relax, int *nrhs, int *maxsuper,
 		   int *rowblk, int *colblk, int *lwork, double *u, FILE **fp);
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 /* 
  * Purpose


### PR DESCRIPTION
Newer compilers emits according warnings.