### PR TITLE
Update FSF address in example files

### DIFF
--- a/EXAMPLE/cfgmr.c
+++ b/EXAMPLE/cfgmr.c
@@ -22,11 +22,11 @@ the terms of  the GNU General Public License as  published by the Free
 Software Foundation [version 2 of  the License, or any later version]
 For details, see 
 
-http://www.gnu.org/copyleft/gpl.html
+http://www.gnu.org/licenses/gpl-2.0.txt
 
 A copy of the GNU licencing agreement is attached to the ITSOL package
 in the file GNU.  For additional information contact the Free Software
-Foundation Inc., 65 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 DISCLAIMER
 ----------

--- a/EXAMPLE/dfgmr.c
+++ b/EXAMPLE/dfgmr.c
@@ -22,11 +22,11 @@ the terms of  the GNU General Public License as  published by the Free
 Software Foundation [version 2 of  the License, or any later version]
 For details, see 
 
-http://www.gnu.org/copyleft/gpl.html
+http://www.gnu.org/licenses/gpl-2.0.txt
 
 A copy of the GNU licencing agreement is attached to the ITSOL package
 in the file GNU.  For additional information contact the Free Software
-Foundation Inc., 65 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 DISCLAIMER
 ----------

--- a/EXAMPLE/sfgmr.c
+++ b/EXAMPLE/sfgmr.c
@@ -22,11 +22,11 @@ the terms of  the GNU General Public License as  published by the Free
 Software Foundation [version 2 of  the License, or any later version]
 For details, see 
 
-http://www.gnu.org/copyleft/gpl.html
+http://www.gnu.org/licenses/gpl-2.0.txt
 
 A copy of the GNU licencing agreement is attached to the ITSOL package
 in the file GNU.  For additional information contact the Free Software
-Foundation Inc., 65 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 DISCLAIMER
 ----------

--- a/EXAMPLE/zfgmr.c
+++ b/EXAMPLE/zfgmr.c
@@ -22,11 +22,11 @@ the terms of  the GNU General Public License as  published by the Free
 Software Foundation [version 2 of  the License, or any later version]
 For details, see 
 
-http://www.gnu.org/copyleft/gpl.html
+http://www.gnu.org/licenses/gpl-2.0.txt
 
 A copy of the GNU licencing agreement is attached to the ITSOL package
 in the file GNU.  For additional information contact the Free Software
-Foundation Inc., 65 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 DISCLAIMER
 ----------


### PR DESCRIPTION
rpmlint complains upon building RPM packages.
Their new address is according to http://www.fsf.org/about/contact/
 Free Software Foundation
 51 Franklin Street, Fifth Floor
 Boston, MA 02110-1301
 USA

GPLv2 moved to http://www.gnu.org/licenses/gpl-2.0.txt