### PR TITLE
add declarations to avoid implicit declarations

### DIFF
--- a/SRC/clacon2.c
+++ b/SRC/clacon2.c
@@ -106,6 +106,11 @@ clacon2_(int *n, complex *v, complex *x, float *est, int *kase, int isave[3])
     extern float smach(char *);
     extern int icmax1_slu(int *, complex *, int *);
     extern double scsum1_slu(int *, complex *, int *);
+#ifdef _CRAY
+    extern int CCOPY(int *, complex *, int *, complex [], int *);
+#else
+    extern int ccopy_(int *, complex *, int *, complex [], int *);
+#endif
 
     safmin = smach("Safe minimum");  /* lamch_("Safe minimum"); */
     if ( *kase == 0 ) {

--- a/SRC/dmach.c
+++ b/SRC/dmach.c
@@ -11,6 +11,7 @@ at the top-level directory.
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
+#include <string.h>
 
 double dmach(char *cmach)
 {

--- a/SRC/ilu_cdrop_row.c
+++ b/SRC/ilu_cdrop_row.c
@@ -28,6 +28,7 @@ extern void caxpy_(int *, complex *, complex [], int *, complex [], int *);
 extern void ccopy_(int *, complex [], int *, complex [], int *);
 extern float scasum_(int *, complex *, int *);
 extern float scnrm2_(int *, complex *, int *);
+extern void scopy_(int *, float [], int *, float [], int *);
 extern double dnrm2_(int *, double [], int *);
 extern int icamax_(int *, complex [], int *);
 

--- a/SRC/ilu_zdrop_row.c
+++ b/SRC/ilu_zdrop_row.c
@@ -29,6 +29,7 @@ extern void zcopy_(int *, doublecomplex [], int *, doublecomplex [], int *);
 extern double dzasum_(int *, doublecomplex *, int *);
 extern double dznrm2_(int *, doublecomplex *, int *);
 extern double dnrm2_(int *, double [], int *);
+extern void dcopy_(int *, double [], int *, double [], int *);
 extern int izamax_(int *, doublecomplex [], int *);
 
 static double *A;  /* used in _compare_ only */

--- a/SRC/slacon2.c
+++ b/SRC/slacon2.c
@@ -157,7 +157,7 @@ L40:
 #ifdef _CRAY
     isave[1] = ISAMAX(n, &x[0], &c__1);   /* j */
 #else
-    isave[1] = idamax_(n, &x[0], &c__1);  /* j */
+    isave[1] = isamax_(n, &x[0], &c__1);  /* j */
 #endif
     --isave[1];  /* --j; */
     isave[2] = 2;  /* iter = 2; */

--- a/SRC/smach.c
+++ b/SRC/smach.c
@@ -11,6 +11,7 @@ at the top-level directory.
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
+#include <string.h>
 
 float smach(char *cmach)
 {

--- a/SRC/sp_ienv.c
+++ b/SRC/sp_ienv.c
@@ -24,6 +24,7 @@ at the top-level directory.
  * History:             Modified from lapack routine ILAENV
  */
 #include "slu_Cnames.h"
+extern int input_error(char *, int *);
 
 /*! \brief
 

--- a/SRC/zlacon2.c
+++ b/SRC/zlacon2.c
@@ -106,6 +106,11 @@ zlacon2_(int *n, doublecomplex *v, doublecomplex *x, double *est, int *kase, int
     extern double dmach(char *);
     extern int izmax1_slu(int *, doublecomplex *, int *);
     extern double dzsum1_slu(int *, doublecomplex *, int *);
+#ifdef _CRAY
+    extern int CCOPY(int *, doublecomplex *, int *, doublecomplex *, int *);
+#else
+    extern int zcopy_(int *, doublecomplex *, int *, doublecomplex *, int *);
+#endif
 
     safmin = dmach("Safe minimum");  /* lamch_("Safe minimum"); */
     if ( *kase == 0 ) {


### PR DESCRIPTION
Declarations of external routines, found by adding gcc flag "-Wimplicit-function-declaration". 
From our gentoo linux QA.
