### PR TITLE
Small fixes from SciPy work

### DIFF
--- a/INSTALL/superlu_timer.c
+++ b/INSTALL/superlu_timer.c
@@ -57,9 +57,6 @@ double SuperLU_timer_()
 #include <unistd.h>
 #endif
 
-#ifndef CLK_TCK
-#define CLK_TCK 60
-#endif
 /*! \brief Timer function
  */ 
 double SuperLU_timer_()
@@ -77,7 +74,6 @@ double SuperLU_timer_()
     tmp = use.tms_utime;
     tmp += use.tms_stime;
 #endif
-    /*return (double)(tmp) / CLK_TCK;*/
     return (double)(tmp) / clocks_per_sec;
 }
 

--- a/SRC/colamd.c
+++ b/SRC/colamd.c
@@ -35,7 +35,7 @@ at the top-level directory.
 	conventional partial pivoting with row interchanges.  Colamd is the
 	column ordering method used in SuperLU, part of the ScaLAPACK library.
 	It is also available as built-in function in MATLAB Version 6,
-	available from MathWorks, Inc. (http://www.mathworks.com).  This
+	available from MathWorks, Inc. (https://www.mathworks.com).  This
 	routine can be used in place of colmmd in MATLAB.
 
     	Symamd computes a permutation P of a symmetric matrix A such that the
@@ -79,9 +79,9 @@ at the top-level directory.
 
 	The colamd/symamd library is available at
 
-	    http://www.cise.ufl.edu/research/sparse/colamd/
+	    https://web.archive.org/web/20141010162709/http://www.cise.ufl.edu/research/sparse/colamd/
 
-	This is the http://www.cise.ufl.edu/research/sparse/colamd/colamd.c
+	This is the https://web.archive.org/web/20040113022019/http://www.cise.ufl.edu/research/sparse/colamd/colamd.c
 	file.  It requires the colamd.h file.  It is required by the colamdmex.c
 	and symamdmex.c files, for the MATLAB interface to colamd and symamd.
 

--- a/SRC/superlu_timer.c
+++ b/SRC/superlu_timer.c
@@ -57,9 +57,6 @@ double SuperLU_timer_()
 #include <unistd.h>
 #endif
 
-#ifndef CLK_TCK
-#define CLK_TCK 60
-#endif
 /*! \brief Timer function
  */ 
 double SuperLU_timer_()
@@ -77,7 +74,6 @@ double SuperLU_timer_()
     tmp = use.tms_utime;
     tmp += use.tms_stime;
 #endif
-    /*return (double)(tmp) / CLK_TCK;*/
     return (double)(tmp) / clocks_per_sec;
 }
 


### PR DESCRIPTION
The link changes were identified in SciPy

The `CLK_TCK` is an effort to cleanup warning generated during SciPy Build.

Happy to break these into two pulls if you prefer.