### PR TITLE
Fix several Clang 11 warnings

### DIFF
--- a/SRC/ccolumn_bmod.c
+++ b/SRC/ccolumn_bmod.c
@@ -293,7 +293,8 @@ ccolumn_bmod (
     /* Copy the SPA dense into L\U[*,j] */
     new_next = nextlu + xlsub[fsupc+1] - xlsub[fsupc];
     while ( new_next > nzlumax ) {
-	if (mem_error = cLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu))
+	mem_error = cLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu);
+	if (mem_error)
 	    return (mem_error);
 	lusup = (complex *) Glu->lusup;
 	lsub = Glu->lsub;

--- a/SRC/ccolumn_dfs.c
+++ b/SRC/ccolumn_dfs.c
@@ -136,7 +136,8 @@ ccolumn_dfs(
    	if ( kperm == EMPTY ) {
 	    lsub[nextl++] = krow; 	/* krow is indexed into A */
 	    if ( nextl >= nzlmax ) {
-		if ( mem_error = cLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		mem_error = cLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		if (mem_error)
 		    return (mem_error);
 		lsub = Glu->lsub;
 	    }
@@ -178,8 +179,8 @@ ccolumn_dfs(
 		   	    if ( chperm == EMPTY ) {
 			    	lsub[nextl++] = kchild;
 				if ( nextl >= nzlmax ) {
-				    if ( mem_error =
-					 cLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu) )
+				    mem_error = cLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu);
+				    if (mem_error)
 					return (mem_error);
 				    lsub = Glu->lsub;
 				}

--- a/SRC/ccopy_to_ucol.c
+++ b/SRC/ccopy_to_ucol.c
@@ -84,10 +84,12 @@ ccopy_to_ucol(
 
 		new_next = nextu + segsze;
 		while ( new_next > nzumax ) {
-		    if (mem_error = cLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu))
+		    mem_error = cLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    ucol = (complex *) Glu->ucol;
-		    if (mem_error = cLUMemXpand(jcol, nextu, USUB, &nzumax, Glu))
+		    mem_error = cLUMemXpand(jcol, nextu, USUB, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    usub = Glu->usub;
 		    lsub = Glu->lsub;

--- a/SRC/cgscon.c
+++ b/SRC/cgscon.c
@@ -99,7 +99,7 @@ cgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
     /* Test the input parameters. */
     *info = 0;
     onenrm = *(unsigned char *)norm == '1' || strncmp(norm, "O", 1)==0;
-    if (! onenrm && ! strncmp(norm, "I", 1)==0) *info = -1;
+    if (! onenrm && strncmp(norm, "I", 1)!=0) *info = -1;
     else if (L->nrow < 0 || L->nrow != L->ncol ||
              L->Stype != SLU_SC || L->Dtype != SLU_C || L->Mtype != SLU_TRLU)
 	 *info = -2;

--- a/SRC/creadMM.c
+++ b/SRC/creadMM.c
@@ -57,7 +57,7 @@ creadMM(FILE *fp, int *m, int *n, int *nonz,
 
      if (sscanf(line, "%s %s %s %s %s", banner, mtx, crd, arith, sym) != 5) {
        printf("Invalid header (first line does not contain 5 tokens)\n");
-       exit;
+       exit(-1);
      }
  
      if(strcmp(banner,"%%matrixmarket")) {

--- a/SRC/creadMM.c
+++ b/SRC/creadMM.c
@@ -137,13 +137,14 @@ creadMM(FILE *fp, int *m, int *n, int *nonz,
     /* 4/ Read triplets of values */
     for (nnz = 0, nz = 0; nnz < *nonz; ++nnz) {
 
-	if ( nnz == 0 ) /* first nonzero */
+	if ( nnz == 0 ) { /* first nonzero */
 	    if ( row[0] == 0 || col[0] == 0 ) {
 		zero_base = 1;
 		printf("triplet file: row/col indices are zero-based.\n");
 	    } else {
 		printf("triplet file: row/col indices are one-based.\n");
             }
+	}
 
 	if ( !zero_base ) {
 	    /* Change to 0-based indexing. */

--- a/SRC/csnode_bmod.c
+++ b/SRC/csnode_bmod.c
@@ -33,6 +33,7 @@ at the top-level directory.
 
 
 #include "slu_cdefs.h"
+#include "ccolumn_bmod.c"
 
 
 /*! \brief Performs numeric block updates within the relaxed snode. 

--- a/SRC/csnode_dfs.c
+++ b/SRC/csnode_dfs.c
@@ -88,7 +88,8 @@ csnode_dfs (
 		marker[krow] = kcol;
 		lsub[nextl++] = krow;
 		if ( nextl >= nzlmax ) {
-		    if ( mem_error = cLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		    mem_error = cLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    lsub = Glu->lsub;
 		}
@@ -101,7 +102,8 @@ csnode_dfs (
     if ( jcol < kcol ) {
 	new_next = nextl + (nextl - xlsub[jcol]);
 	while ( new_next > nzlmax ) {
-	    if ( mem_error = cLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+	    mem_error = cLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+	    if (mem_error)
 		return (mem_error);
 	    lsub = Glu->lsub;
 	}

--- a/SRC/dcolumn_bmod.c
+++ b/SRC/dcolumn_bmod.c
@@ -280,7 +280,8 @@ dcolumn_bmod (
     /* Copy the SPA dense into L\U[*,j] */
     new_next = nextlu + xlsub[fsupc+1] - xlsub[fsupc];
     while ( new_next > nzlumax ) {
-	if (mem_error = dLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu))
+	mem_error = dLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu);
+	if (mem_error)
 	    return (mem_error);
 	lusup = (double *) Glu->lusup;
 	lsub = Glu->lsub;

--- a/SRC/dcolumn_dfs.c
+++ b/SRC/dcolumn_dfs.c
@@ -136,7 +136,8 @@ dcolumn_dfs(
    	if ( kperm == EMPTY ) {
 	    lsub[nextl++] = krow; 	/* krow is indexed into A */
 	    if ( nextl >= nzlmax ) {
-		if ( mem_error = dLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		mem_error = dLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		if (mem_error)
 		    return (mem_error);
 		lsub = Glu->lsub;
 	    }
@@ -178,8 +179,8 @@ dcolumn_dfs(
 		   	    if ( chperm == EMPTY ) {
 			    	lsub[nextl++] = kchild;
 				if ( nextl >= nzlmax ) {
-				    if ( mem_error =
-					 dLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu) )
+				    mem_error = dLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu);
+				    if (mem_error)
 					return (mem_error);
 				    lsub = Glu->lsub;
 				}

--- a/SRC/dcopy_to_ucol.c
+++ b/SRC/dcopy_to_ucol.c
@@ -84,10 +84,12 @@ dcopy_to_ucol(
 
 		new_next = nextu + segsze;
 		while ( new_next > nzumax ) {
-		    if (mem_error = dLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu))
+		    mem_error = dLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    ucol = (double *) Glu->ucol;
-		    if (mem_error = dLUMemXpand(jcol, nextu, USUB, &nzumax, Glu))
+		    mem_error = dLUMemXpand(jcol, nextu, USUB, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    usub = Glu->usub;
 		    lsub = Glu->lsub;

--- a/SRC/dgscon.c
+++ b/SRC/dgscon.c
@@ -100,7 +100,7 @@ dgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
     /* Test the input parameters. */
     *info = 0;
     onenrm = *(unsigned char *)norm == '1' || strncmp(norm, "O", 1)==0;
-    if (! onenrm && ! strncmp(norm, "I", 1)==0) *info = -1;
+    if (! onenrm && strncmp(norm, "I", 1)!=0) *info = -1;
     else if (L->nrow < 0 || L->nrow != L->ncol ||
              L->Stype != SLU_SC || L->Dtype != SLU_D || L->Mtype != SLU_TRLU)
 	 *info = -2;

--- a/SRC/dreadMM.c
+++ b/SRC/dreadMM.c
@@ -57,7 +57,7 @@ dreadMM(FILE *fp, int *m, int *n, int *nonz,
 
      if (sscanf(line, "%s %s %s %s %s", banner, mtx, crd, arith, sym) != 5) {
        printf("Invalid header (first line does not contain 5 tokens)\n");
-       exit;
+       exit(-1);
      }
  
      if(strcmp(banner,"%%matrixmarket")) {

--- a/SRC/dreadMM.c
+++ b/SRC/dreadMM.c
@@ -142,13 +142,14 @@ dreadMM(FILE *fp, int *m, int *n, int *nonz,
 	fscanf(fp, "%d%d%lf\n", &row[nz], &col[nz], &val[nz]);
 #endif
 
-	if ( nnz == 0 ) /* first nonzero */
+	if ( nnz == 0 ) { /* first nonzero */
 	    if ( row[0] == 0 || col[0] == 0 ) {
 		zero_base = 1;
 		printf("triplet file: row/col indices are zero-based.\n");
 	    } else {
 		printf("triplet file: row/col indices are one-based.\n");
             }
+	}
 
 	if ( !zero_base ) {
 	    /* Change to 0-based indexing. */

--- a/SRC/dsnode_bmod.c
+++ b/SRC/dsnode_bmod.c
@@ -33,6 +33,7 @@ at the top-level directory.
 
 
 #include "slu_ddefs.h"
+#include "dcolumn_bmod.c"
 
 
 /*! \brief Performs numeric block updates within the relaxed snode. 

--- a/SRC/dsnode_dfs.c
+++ b/SRC/dsnode_dfs.c
@@ -88,7 +88,8 @@ dsnode_dfs (
 		marker[krow] = kcol;
 		lsub[nextl++] = krow;
 		if ( nextl >= nzlmax ) {
-		    if ( mem_error = dLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		    mem_error = dLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    lsub = Glu->lsub;
 		}
@@ -101,7 +102,8 @@ dsnode_dfs (
     if ( jcol < kcol ) {
 	new_next = nextl + (nextl - xlsub[jcol]);
 	while ( new_next > nzlmax ) {
-	    if ( mem_error = dLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+	    mem_error = dLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+	    if (mem_error)
 		return (mem_error);
 	    lsub = Glu->lsub;
 	}

--- a/SRC/scolumn_bmod.c
+++ b/SRC/scolumn_bmod.c
@@ -280,7 +280,8 @@ scolumn_bmod (
     /* Copy the SPA dense into L\U[*,j] */
     new_next = nextlu + xlsub[fsupc+1] - xlsub[fsupc];
     while ( new_next > nzlumax ) {
-	if (mem_error = sLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu))
+	mem_error = sLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu);
+	if (mem_error)
 	    return (mem_error);
 	lusup = (float *) Glu->lusup;
 	lsub = Glu->lsub;

--- a/SRC/scolumn_dfs.c
+++ b/SRC/scolumn_dfs.c
@@ -136,7 +136,8 @@ scolumn_dfs(
    	if ( kperm == EMPTY ) {
 	    lsub[nextl++] = krow; 	/* krow is indexed into A */
 	    if ( nextl >= nzlmax ) {
-		if ( mem_error = sLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		mem_error = sLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		if (mem_error)
 		    return (mem_error);
 		lsub = Glu->lsub;
 	    }
@@ -178,8 +179,8 @@ scolumn_dfs(
 		   	    if ( chperm == EMPTY ) {
 			    	lsub[nextl++] = kchild;
 				if ( nextl >= nzlmax ) {
-				    if ( mem_error =
-					 sLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu) )
+				    mem_error = sLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu);
+				    if (mem_error)
 					return (mem_error);
 				    lsub = Glu->lsub;
 				}

--- a/SRC/scopy_to_ucol.c
+++ b/SRC/scopy_to_ucol.c
@@ -84,10 +84,12 @@ scopy_to_ucol(
 
 		new_next = nextu + segsze;
 		while ( new_next > nzumax ) {
-		    if (mem_error = sLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu))
+		    mem_error = sLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    ucol = (float *) Glu->ucol;
-		    if (mem_error = sLUMemXpand(jcol, nextu, USUB, &nzumax, Glu))
+		    mem_error = sLUMemXpand(jcol, nextu, USUB, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    usub = Glu->usub;
 		    lsub = Glu->lsub;

--- a/SRC/sgscon.c
+++ b/SRC/sgscon.c
@@ -100,7 +100,7 @@ sgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
     /* Test the input parameters. */
     *info = 0;
     onenrm = *(unsigned char *)norm == '1' || strncmp(norm, "O", 1)==0;
-    if (! onenrm && ! strncmp(norm, "I", 1)==0) *info = -1;
+    if (! onenrm && strncmp(norm, "I", 1)!=0) *info = -1;
     else if (L->nrow < 0 || L->nrow != L->ncol ||
              L->Stype != SLU_SC || L->Dtype != SLU_S || L->Mtype != SLU_TRLU)
 	 *info = -2;

--- a/SRC/sreadMM.c
+++ b/SRC/sreadMM.c
@@ -137,13 +137,14 @@ sreadMM(FILE *fp, int *m, int *n, int *nonz,
     /* 4/ Read triplets of values */
     for (nnz = 0, nz = 0; nnz < *nonz; ++nnz) {
 
-	if ( nnz == 0 ) /* first nonzero */
+	if ( nnz == 0 ) { /* first nonzero */
 	    if ( row[0] == 0 || col[0] == 0 ) {
 		zero_base = 1;
 		printf("triplet file: row/col indices are zero-based.\n");
 	    } else {
 		printf("triplet file: row/col indices are one-based.\n");
             }
+	}
 
 	if ( !zero_base ) {
 	    /* Change to 0-based indexing. */

--- a/SRC/sreadMM.c
+++ b/SRC/sreadMM.c
@@ -57,7 +57,7 @@ sreadMM(FILE *fp, int *m, int *n, int *nonz,
 
      if (sscanf(line, "%s %s %s %s %s", banner, mtx, crd, arith, sym) != 5) {
        printf("Invalid header (first line does not contain 5 tokens)\n");
-       exit;
+       exit(-1);
      }
  
      if(strcmp(banner,"%%matrixmarket")) {

--- a/SRC/ssnode_bmod.c
+++ b/SRC/ssnode_bmod.c
@@ -33,7 +33,7 @@ at the top-level directory.
 
 
 #include "slu_sdefs.h"
-
+#include "scolumn_bmod.c"
 
 /*! \brief Performs numeric block updates within the relaxed snode. 
  */

--- a/SRC/ssnode_dfs.c
+++ b/SRC/ssnode_dfs.c
@@ -88,7 +88,8 @@ ssnode_dfs (
 		marker[krow] = kcol;
 		lsub[nextl++] = krow;
 		if ( nextl >= nzlmax ) {
-		    if ( mem_error = sLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		    mem_error = sLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    lsub = Glu->lsub;
 		}
@@ -101,7 +102,8 @@ ssnode_dfs (
     if ( jcol < kcol ) {
 	new_next = nextl + (nextl - xlsub[jcol]);
 	while ( new_next > nzlmax ) {
-	    if ( mem_error = sLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+	    mem_error = sLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+	    if (mem_error)
 		return (mem_error);
 	    lsub = Glu->lsub;
 	}

--- a/SRC/zcolumn_bmod.c
+++ b/SRC/zcolumn_bmod.c
@@ -295,7 +295,8 @@ zcolumn_bmod (
     /* Copy the SPA dense into L\U[*,j] */
     new_next = nextlu + xlsub[fsupc+1] - xlsub[fsupc];
     while ( new_next > nzlumax ) {
-	if (mem_error = zLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu))
+	mem_error = zLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu);
+	if (mem_error)
 	    return (mem_error);
 	lusup = (doublecomplex *) Glu->lusup;
 	lsub = Glu->lsub;

--- a/SRC/zcolumn_dfs.c
+++ b/SRC/zcolumn_dfs.c
@@ -136,7 +136,8 @@ zcolumn_dfs(
    	if ( kperm == EMPTY ) {
 	    lsub[nextl++] = krow; 	/* krow is indexed into A */
 	    if ( nextl >= nzlmax ) {
-		if ( mem_error = zLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		mem_error = zLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		if (mem_error)
 		    return (mem_error);
 		lsub = Glu->lsub;
 	    }
@@ -178,8 +179,8 @@ zcolumn_dfs(
 		   	    if ( chperm == EMPTY ) {
 			    	lsub[nextl++] = kchild;
 				if ( nextl >= nzlmax ) {
-				    if ( mem_error =
-					 zLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu) )
+				    mem_error = zLUMemXpand(jcol,nextl,LSUB,&nzlmax,Glu);
+				    if (mem_error)
 					return (mem_error);
 				    lsub = Glu->lsub;
 				}

--- a/SRC/zcopy_to_ucol.c
+++ b/SRC/zcopy_to_ucol.c
@@ -84,10 +84,12 @@ zcopy_to_ucol(
 
 		new_next = nextu + segsze;
 		while ( new_next > nzumax ) {
-		    if (mem_error = zLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu))
+		    mem_error = zLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    ucol = (doublecomplex *) Glu->ucol;
-		    if (mem_error = zLUMemXpand(jcol, nextu, USUB, &nzumax, Glu))
+		    mem_error = zLUMemXpand(jcol, nextu, USUB, &nzumax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    usub = Glu->usub;
 		    lsub = Glu->lsub;

--- a/SRC/zgscon.c
+++ b/SRC/zgscon.c
@@ -99,7 +99,7 @@ zgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
     /* Test the input parameters. */
     *info = 0;
     onenrm = *(unsigned char *)norm == '1' || strncmp(norm, "O", 1)==0;
-    if (! onenrm && ! strncmp(norm, "I", 1)==0) *info = -1;
+    if (! onenrm && strncmp(norm, "I", 1)!=0) *info = -1;
     else if (L->nrow < 0 || L->nrow != L->ncol ||
              L->Stype != SLU_SC || L->Dtype != SLU_Z || L->Mtype != SLU_TRLU)
 	 *info = -2;

--- a/SRC/zreadMM.c
+++ b/SRC/zreadMM.c
@@ -142,13 +142,14 @@ zreadMM(FILE *fp, int *m, int *n, int *nonz,
 	fscanf(fp, "%d%d%lf%lf\n", &row[nz], &col[nz], &val[nz].r, &val[nz].i);
 #endif
 
-	if ( nnz == 0 ) /* first nonzero */
+	if ( nnz == 0 ) { /* first nonzero */
 	    if ( row[0] == 0 || col[0] == 0 ) {
 		zero_base = 1;
 		printf("triplet file: row/col indices are zero-based.\n");
 	    } else {
 		printf("triplet file: row/col indices are one-based.\n");
             }
+	}
 
 	if ( !zero_base ) {
 	    /* Change to 0-based indexing. */

--- a/SRC/zreadMM.c
+++ b/SRC/zreadMM.c
@@ -57,7 +57,7 @@ zreadMM(FILE *fp, int *m, int *n, int *nonz,
 
      if (sscanf(line, "%s %s %s %s %s", banner, mtx, crd, arith, sym) != 5) {
        printf("Invalid header (first line does not contain 5 tokens)\n");
-       exit;
+       exit(-1);
      }
  
      if(strcmp(banner,"%%matrixmarket")) {

--- a/SRC/zsnode_bmod.c
+++ b/SRC/zsnode_bmod.c
@@ -33,6 +33,7 @@ at the top-level directory.
 
 
 #include "slu_zdefs.h"
+#include "zcolumn_bmod.c"
 
 
 /*! \brief Performs numeric block updates within the relaxed snode. 

--- a/SRC/zsnode_dfs.c
+++ b/SRC/zsnode_dfs.c
@@ -88,7 +88,8 @@ zsnode_dfs (
 		marker[krow] = kcol;
 		lsub[nextl++] = krow;
 		if ( nextl >= nzlmax ) {
-		    if ( mem_error = zLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+		    mem_error = zLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+		    if (mem_error)
 			return (mem_error);
 		    lsub = Glu->lsub;
 		}
@@ -101,7 +102,8 @@ zsnode_dfs (
     if ( jcol < kcol ) {
 	new_next = nextl + (nextl - xlsub[jcol]);
 	while ( new_next > nzlmax ) {
-	    if ( mem_error = zLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu) )
+	    mem_error = zLUMemXpand(jcol, nextl, LSUB, &nzlmax, Glu);
+	    if (mem_error)
 		return (mem_error);
 	    lsub = Glu->lsub;
 	}

--- a/TESTING/MATGEN/csymv.c
+++ b/TESTING/MATGEN/csymv.c
@@ -118,7 +118,7 @@
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]
 
     info = 0;
-    if ( strncmp(uplo, "U", 1)!=0 && ! strncmp(uplo, "L", 1)!=0) {
+    if (strncmp(uplo, "U", 1)!=0 && strncmp(uplo, "L", 1)!=0) {
 	info = 1;
     } else if (*n < 0) {
 	info = 2;


### PR DESCRIPTION
Fixed multiple warnings from Clang 11, but not all. Some remove ambiguities, some are more personal coding style. The negations around strncmp are actual bugs.
If you like to merge only selected commits, I can remove the ones you do not like.