### PR TITLE
CBLAS cleanup

### DIFF
--- a/CBLAS/caxpy.c
+++ b/CBLAS/caxpy.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
+
     real r__1, r__2;
     complex q__1, q__2;
 
@@ -56,11 +56,7 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = iy;
-	i__3 = iy;
-	i__4 = ix;
 	q__2.r = ca->r * CX(ix).r - ca->i * CX(ix).i, q__2.i = ca->r * CX(
 		ix).i + ca->i * CX(ix).r;
 	q__1.r = CY(iy).r + q__2.r, q__1.i = CY(iy).i + q__2.i;
@@ -74,11 +70,7 @@
 /*        code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = i;
-	i__3 = i;
-	i__4 = i;
 	q__2.r = ca->r * CX(i).r - ca->i * CX(i).i, q__2.i = ca->r * CX(
 		i).i + ca->i * CX(i).r;
 	q__1.r = CY(i).r + q__2.r, q__1.i = CY(i).i + q__2.i;

--- a/CBLAS/caxpy.c
+++ b/CBLAS/caxpy.c
@@ -20,7 +20,7 @@
     double r_imag(complex *);
 
     /* Local variables */
-    static integer i, ix, iy;
+    integer i, ix, iy;
 
 
 /*     constant times a vector plus a vector.   

--- a/CBLAS/ccopy.c
+++ b/CBLAS/ccopy.c
@@ -15,7 +15,7 @@
     integer i__1, i__2, i__3;
 
     /* Local variables */
-    static integer i, ix, iy;
+    integer i, ix, iy;
 
 
 /*     copies a vector, x, to a vector, y.   

--- a/CBLAS/ccopy.c
+++ b/CBLAS/ccopy.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3;
+
 
     /* Local variables */
     integer i, ix, iy;
@@ -48,10 +48,7 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = iy;
-	i__3 = ix;
 	CY(iy).r = CX(ix).r, CY(iy).i = CX(ix).i;
 	ix += *incx;
 	iy += *incy;
@@ -62,10 +59,7 @@
 /*        code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = i;
-	i__3 = i;
 	CY(i).r = CX(i).r, CY(i).i = CX(i).i;
 /* L30: */
     }

--- a/CBLAS/cdotc.c
+++ b/CBLAS/cdotc.c
@@ -9,7 +9,7 @@
 	*incx, complex *cy, integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2;
+ 
     complex q__1, q__2, q__3;
 
     /* Builtin functions */
@@ -53,10 +53,8 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	r_cnjg(&q__3, &cx[ix]);
-	i__2 = iy;
 	q__2.r = q__3.r * cy[iy].r - q__3.i * cy[iy].i, q__2.i = q__3.r * 
 		cy[iy].i + q__3.i * cy[iy].r;
 	q__1.r = ctemp.r + q__2.r, q__1.i = ctemp.i + q__2.i;
@@ -71,10 +69,8 @@
 /*        code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	r_cnjg(&q__3, &cx[i]);
-	i__2 = i;
 	q__2.r = q__3.r * cy[i].r - q__3.i * cy[i].i, q__2.i = q__3.r * 
 		cy[i].i + q__3.i * cy[i].r;
 	q__1.r = ctemp.r + q__2.r, q__1.i = ctemp.i + q__2.i;

--- a/CBLAS/cdotc.c
+++ b/CBLAS/cdotc.c
@@ -16,9 +16,9 @@
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer i;
-    static complex ctemp;
-    static integer ix, iy;
+    integer i;
+    complex ctemp;
+    integer ix, iy;
 
 
 /*     forms the dot product of two vectors, conjugating the first   

--- a/CBLAS/cgemv.c
+++ b/CBLAS/cgemv.c
@@ -13,7 +13,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     complex q__1, q__2, q__3;
 
     /* Builtin functions */
@@ -190,17 +190,12 @@
     if (beta->r != 1.f || beta->i != 0.f) {
 	if (*incy == 1) {
 	    if (beta->r == 0.f && beta->i == 0.f) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = i;
 		    Y(i).r = 0.f, Y(i).i = 0.f;
 /* L10: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = i;
-		    i__3 = i;
 		    q__1.r = beta->r * Y(i).r - beta->i * Y(i).i, 
 			    q__1.i = beta->r * Y(i).i + beta->i * Y(i)
 			    .r;
@@ -211,18 +206,13 @@
 	} else {
 	    iy = ky;
 	    if (beta->r == 0.f && beta->i == 0.f) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = iy;
 		    Y(iy).r = 0.f, Y(iy).i = 0.f;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = iy;
-		    i__3 = iy;
 		    q__1.r = beta->r * Y(iy).r - beta->i * Y(iy).i, 
 			    q__1.i = beta->r * Y(iy).i + beta->i * Y(iy)
 			    .r;
@@ -242,20 +232,13 @@
 
 	jx = kx;
 	if (*incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		if (X(jx).r != 0.f || X(jx).i != 0.f) {
-		    i__2 = jx;
 		    q__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    q__1.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
 		    temp.r = q__1.r, temp.i = q__1.i;
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = i;
-			i__4 = i;
-			i__5 = i + j * a_dim1;
 			q__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				q__2.i = temp.r * A(i,j).i + temp.i * A(i,j)
 				.r;
@@ -269,21 +252,14 @@
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		if (X(jx).r != 0.f || X(jx).i != 0.f) {
-		    i__2 = jx;
 		    q__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    q__1.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
 		    temp.r = q__1.r, temp.i = q__1.i;
 		    iy = ky;
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = iy;
-			i__4 = iy;
-			i__5 = i + j * a_dim1;
 			q__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				q__2.i = temp.r * A(i,j).i + temp.i * A(i,j)
 				.r;
@@ -305,14 +281,10 @@
 
 	jy = ky;
 	if (*incx == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp.r = 0.f, temp.i = 0.f;
 		if (noconj) {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i;
 			q__2.r = A(i,j).r * X(i).r - A(i,j).i * X(i)
 				.i, q__2.i = A(i,j).r * X(i).i + A(i,j)
 				.i * X(i).r;
@@ -321,10 +293,8 @@
 /* L90: */
 		    }
 		} else {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			r_cnjg(&q__3, &A(i,j));
-			i__3 = i;
 			q__2.r = q__3.r * X(i).r - q__3.i * X(i).i, 
 				q__2.i = q__3.r * X(i).i + q__3.i * X(i)
 				.r;
@@ -333,8 +303,6 @@
 /* L100: */
 		    }
 		}
-		i__2 = jy;
-		i__3 = jy;
 		q__2.r = alpha->r * temp.r - alpha->i * temp.i, q__2.i = 
 			alpha->r * temp.i + alpha->i * temp.r;
 		q__1.r = Y(jy).r + q__2.r, q__1.i = Y(jy).i + q__2.i;
@@ -343,15 +311,11 @@
 /* L110: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp.r = 0.f, temp.i = 0.f;
 		ix = kx;
 		if (noconj) {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = ix;
 			q__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(ix)
 				.i, q__2.i = A(i,j).r * X(ix).i + A(i,j)
 				.i * X(ix).r;
@@ -361,10 +325,8 @@
 /* L120: */
 		    }
 		} else {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			r_cnjg(&q__3, &A(i,j));
-			i__3 = ix;
 			q__2.r = q__3.r * X(ix).r - q__3.i * X(ix).i, 
 				q__2.i = q__3.r * X(ix).i + q__3.i * X(ix)
 				.r;
@@ -374,8 +336,6 @@
 /* L130: */
 		    }
 		}
-		i__2 = jy;
-		i__3 = jy;
 		q__2.r = alpha->r * temp.r - alpha->i * temp.i, q__2.i = 
 			alpha->r * temp.i + alpha->i * temp.r;
 		q__1.r = Y(jy).r + q__2.r, q__1.i = Y(jy).i + q__2.i;

--- a/CBLAS/cgemv.c
+++ b/CBLAS/cgemv.c
@@ -20,11 +20,11 @@
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer info;
-    static complex temp;
-    static integer lenx, leny, i, j;
-    static integer ix, iy, jx, jy, kx, ky;
-    static logical noconj;
+    integer info;
+    complex temp;
+    integer lenx, leny, i, j;
+    integer ix, iy, jx, jy, kx, ky;
+    logical noconj;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/cgerc.c
+++ b/CBLAS/cgerc.c
@@ -19,9 +19,9 @@
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer info;
-    static complex temp;
-    static integer i, j, ix, jy, kx;
+    integer info;
+    complex temp;
+    integer i, j, ix, jy, kx;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/cgerc.c
+++ b/CBLAS/cgerc.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     complex q__1, q__2;
 
     /* Builtin functions */
@@ -141,19 +141,13 @@
 	jy = 1 - (*n - 1) * *incy;
     }
     if (*incx == 1) {
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
-	    i__2 = jy;
 	    if (Y(jy).r != 0.f || Y(jy).i != 0.f) {
 		r_cnjg(&q__2, &Y(jy));
 		q__1.r = alpha->r * q__2.r - alpha->i * q__2.i, q__1.i = 
 			alpha->r * q__2.i + alpha->i * q__2.r;
 		temp.r = q__1.r, temp.i = q__1.i;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
-		    i__3 = i + j * a_dim1;
-		    i__4 = i + j * a_dim1;
-		    i__5 = i;
 		    q__2.r = X(i).r * temp.r - X(i).i * temp.i, q__2.i =
 			     X(i).r * temp.i + X(i).i * temp.r;
 		    q__1.r = A(i,j).r + q__2.r, q__1.i = A(i,j).i + q__2.i;
@@ -170,20 +164,14 @@
 	} else {
 	    kx = 1 - (*m - 1) * *incx;
 	}
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
-	    i__2 = jy;
 	    if (Y(jy).r != 0.f || Y(jy).i != 0.f) {
 		r_cnjg(&q__2, &Y(jy));
 		q__1.r = alpha->r * q__2.r - alpha->i * q__2.i, q__1.i = 
 			alpha->r * q__2.i + alpha->i * q__2.r;
 		temp.r = q__1.r, temp.i = q__1.i;
 		ix = kx;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
-		    i__3 = i + j * a_dim1;
-		    i__4 = i + j * a_dim1;
-		    i__5 = ix;
 		    q__2.r = X(ix).r * temp.r - X(ix).i * temp.i, q__2.i =
 			     X(ix).r * temp.i + X(ix).i * temp.r;
 		    q__1.r = A(i,j).r + q__2.r, q__1.i = A(i,j).i + q__2.i;

--- a/CBLAS/chemv.c
+++ b/CBLAS/chemv.c
@@ -13,7 +13,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     doublereal d__1;
     complex q__1, q__2, q__3, q__4;
 
@@ -180,17 +180,12 @@
     if (beta->r != 1.f || beta->i != 0.f) {
 	if (*incy == 1) {
 	    if (beta->r == 0.f && beta->i == 0.f) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
 		    Y(i).r = 0.f, Y(i).i = 0.f;
 /* L10: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
-		    i__3 = i;
 		    q__1.r = beta->r * Y(i).r - beta->i * Y(i).i, 
 			    q__1.i = beta->r * Y(i).i + beta->i * Y(i)
 			    .r;
@@ -201,18 +196,13 @@
 	} else {
 	    iy = ky;
 	    if (beta->r == 0.f && beta->i == 0.f) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
 		    Y(iy).r = 0.f, Y(iy).i = 0.f;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
-		    i__3 = iy;
 		    q__1.r = beta->r * Y(iy).r - beta->i * Y(iy).i, 
 			    q__1.i = beta->r * Y(iy).i + beta->i * Y(iy)
 			    .r;
@@ -231,34 +221,24 @@
 /*        Form  y  when A is stored in upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
 		q__1.r = alpha->r * X(j).r - alpha->i * X(j).i, q__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(i).r + q__2.r, q__1.i = Y(i).i + q__2.i;
 		    Y(i).r = q__1.r, Y(i).i = q__1.i;
 		    r_cnjg(&q__3, &A(i,j));
-		    i__3 = i;
 		    q__2.r = q__3.r * X(i).r - q__3.i * X(i).i, q__2.i =
 			     q__3.r * X(i).i + q__3.i * X(i).r;
 		    q__1.r = temp2.r + q__2.r, q__1.i = temp2.i + q__2.i;
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 /* L50: */
 		}
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		q__3.r = d__1 * temp1.r, q__3.i = d__1 * temp1.i;
 		q__2.r = Y(j).r + q__3.r, q__2.i = Y(j).i + q__3.i;
@@ -271,27 +251,20 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		q__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, q__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
 		ix = kx;
 		iy = ky;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(iy).r + q__2.r, q__1.i = Y(iy).i + q__2.i;
 		    Y(iy).r = q__1.r, Y(iy).i = q__1.i;
 		    r_cnjg(&q__3, &A(i,j));
-		    i__3 = ix;
 		    q__2.r = q__3.r * X(ix).r - q__3.i * X(ix).i, q__2.i =
 			     q__3.r * X(ix).i + q__3.i * X(ix).r;
 		    q__1.r = temp2.r + q__2.r, q__1.i = temp2.i + q__2.i;
@@ -300,9 +273,6 @@
 		    iy += *incy;
 /* L70: */
 		}
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		q__3.r = d__1 * temp1.r, q__3.i = d__1 * temp1.i;
 		q__2.r = Y(jy).r + q__3.r, q__2.i = Y(jy).i + q__3.i;
@@ -320,40 +290,28 @@
 /*        Form  y  when A is stored in lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
 		q__1.r = alpha->r * X(j).r - alpha->i * X(j).i, q__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		q__2.r = d__1 * temp1.r, q__2.i = d__1 * temp1.i;
 		q__1.r = Y(j).r + q__2.r, q__1.i = Y(j).i + q__2.i;
 		Y(j).r = q__1.r, Y(j).i = q__1.i;
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(i).r + q__2.r, q__1.i = Y(i).i + q__2.i;
 		    Y(i).r = q__1.r, Y(i).i = q__1.i;
 		    r_cnjg(&q__3, &A(i,j));
-		    i__3 = i;
 		    q__2.r = q__3.r * X(i).r - q__3.i * X(i).i, q__2.i =
 			     q__3.r * X(i).i + q__3.i * X(i).r;
 		    q__1.r = temp2.r + q__2.r, q__1.i = temp2.i + q__2.i;
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 /* L90: */
 		}
-		i__2 = j;
-		i__3 = j;
 		q__2.r = alpha->r * temp2.r - alpha->i * temp2.i, q__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		q__1.r = Y(j).r + q__2.r, q__1.i = Y(j).i + q__2.i;
@@ -363,44 +321,32 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		q__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, q__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		q__2.r = d__1 * temp1.r, q__2.i = d__1 * temp1.i;
 		q__1.r = Y(jy).r + q__2.r, q__1.i = Y(jy).i + q__2.i;
 		Y(jy).r = q__1.r, Y(jy).i = q__1.i;
 		ix = jx;
 		iy = jy;
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
 		    ix += *incx;
 		    iy += *incy;
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(iy).r + q__2.r, q__1.i = Y(iy).i + q__2.i;
 		    Y(iy).r = q__1.r, Y(iy).i = q__1.i;
 		    r_cnjg(&q__3, &A(i,j));
-		    i__3 = ix;
 		    q__2.r = q__3.r * X(ix).r - q__3.i * X(ix).i, q__2.i =
 			     q__3.r * X(ix).i + q__3.i * X(ix).r;
 		    q__1.r = temp2.r + q__2.r, q__1.i = temp2.i + q__2.i;
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 /* L110: */
 		}
-		i__2 = jy;
-		i__3 = jy;
 		q__2.r = alpha->r * temp2.r - alpha->i * temp2.i, q__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		q__1.r = Y(jy).r + q__2.r, q__1.i = Y(jy).i + q__2.i;

--- a/CBLAS/chemv.c
+++ b/CBLAS/chemv.c
@@ -21,10 +21,10 @@
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer info;
-    static complex temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    complex temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/cher2.c
+++ b/CBLAS/cher2.c
@@ -20,10 +20,10 @@
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer info;
-    static complex temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    complex temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/cher2.c
+++ b/CBLAS/cher2.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+
     doublereal d__1;
     complex q__1, q__2, q__3, q__4;
 
@@ -184,33 +184,24 @@
 /*        Form  A  when A is stored in the upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
-		i__3 = j;
 		if (X(j).r != 0.f || X(j).i != 0.f || (Y(j).r != 0.f 
 			|| Y(j).i != 0.f)) {
 		    r_cnjg(&q__2, &Y(j));
 		    q__1.r = alpha->r * q__2.r - alpha->i * q__2.i, q__1.i = 
 			    alpha->r * q__2.i + alpha->i * q__2.r;
 		    temp1.r = q__1.r, temp1.i = q__1.i;
-		    i__2 = j;
 		    q__2.r = alpha->r * X(j).r - alpha->i * X(j).i, 
 			    q__2.i = alpha->r * X(j).i + alpha->i * X(j)
 			    .r;
 		    r_cnjg(&q__1, &q__2);
 		    temp2.r = q__1.r, temp2.i = q__1.i;
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = i;
 			q__3.r = X(i).r * temp1.r - X(i).i * temp1.i, 
 				q__3.i = X(i).r * temp1.i + X(i).i * 
 				temp1.r;
 			q__2.r = A(i,j).r + q__3.r, q__2.i = A(i,j).i + 
 				q__3.i;
-			i__6 = i;
 			q__4.r = Y(i).r * temp2.r - Y(i).i * temp2.i, 
 				q__4.i = Y(i).r * temp2.i + Y(i).i * 
 				temp2.r;
@@ -218,13 +209,9 @@
 			A(i,j).r = q__1.r, A(i,j).i = q__1.i;
 /* L10: */
 		    }
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = j;
 		    q__2.r = X(j).r * temp1.r - X(j).i * temp1.i, 
 			    q__2.i = X(j).r * temp1.i + X(j).i * 
 			    temp1.r;
-		    i__5 = j;
 		    q__3.r = Y(j).r * temp2.r - Y(j).i * temp2.i, 
 			    q__3.i = Y(j).r * temp2.i + Y(j).i * 
 			    temp2.r;
@@ -232,25 +219,19 @@
 		    d__1 = A(j,j).r + q__1.r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		}
 /* L20: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
-		i__3 = jy;
 		if (X(jx).r != 0.f || X(jx).i != 0.f || (Y(jy).r != 0.f 
 			|| Y(jy).i != 0.f)) {
 		    r_cnjg(&q__2, &Y(jy));
 		    q__1.r = alpha->r * q__2.r - alpha->i * q__2.i, q__1.i = 
 			    alpha->r * q__2.i + alpha->i * q__2.r;
 		    temp1.r = q__1.r, temp1.i = q__1.i;
-		    i__2 = jx;
 		    q__2.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    q__2.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
@@ -258,17 +239,12 @@
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 		    ix = kx;
 		    iy = ky;
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = ix;
 			q__3.r = X(ix).r * temp1.r - X(ix).i * temp1.i, 
 				q__3.i = X(ix).r * temp1.i + X(ix).i * 
 				temp1.r;
 			q__2.r = A(i,j).r + q__3.r, q__2.i = A(i,j).i + 
 				q__3.i;
-			i__6 = iy;
 			q__4.r = Y(iy).r * temp2.r - Y(iy).i * temp2.i, 
 				q__4.i = Y(iy).r * temp2.i + Y(iy).i * 
 				temp2.r;
@@ -278,13 +254,9 @@
 			iy += *incy;
 /* L30: */
 		    }
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = jx;
 		    q__2.r = X(jx).r * temp1.r - X(jx).i * temp1.i, 
 			    q__2.i = X(jx).r * temp1.i + X(jx).i * 
 			    temp1.r;
-		    i__5 = jy;
 		    q__3.r = Y(jy).r * temp2.r - Y(jy).i * temp2.i, 
 			    q__3.i = Y(jy).r * temp2.i + Y(jy).i * 
 			    temp2.r;
@@ -292,8 +264,6 @@
 		    d__1 = A(j,j).r + q__1.r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		}
@@ -307,46 +277,33 @@
 /*        Form  A  when A is stored in the lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
-		i__3 = j;
 		if (X(j).r != 0.f || X(j).i != 0.f || (Y(j).r != 0.f 
 			|| Y(j).i != 0.f)) {
 		    r_cnjg(&q__2, &Y(j));
 		    q__1.r = alpha->r * q__2.r - alpha->i * q__2.i, q__1.i = 
 			    alpha->r * q__2.i + alpha->i * q__2.r;
 		    temp1.r = q__1.r, temp1.i = q__1.i;
-		    i__2 = j;
 		    q__2.r = alpha->r * X(j).r - alpha->i * X(j).i, 
 			    q__2.i = alpha->r * X(j).i + alpha->i * X(j)
 			    .r;
 		    r_cnjg(&q__1, &q__2);
 		    temp2.r = q__1.r, temp2.i = q__1.i;
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = j;
 		    q__2.r = X(j).r * temp1.r - X(j).i * temp1.i, 
 			    q__2.i = X(j).r * temp1.i + X(j).i * 
 			    temp1.r;
-		    i__5 = j;
 		    q__3.r = Y(j).r * temp2.r - Y(j).i * temp2.i, 
 			    q__3.i = Y(j).r * temp2.i + Y(j).i * 
 			    temp2.r;
 		    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
 		    d__1 = A(j,j).r + q__1.r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
-		    i__2 = *n;
 		    for (i = j + 1; i <= *n; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = i;
 			q__3.r = X(i).r * temp1.r - X(i).i * temp1.i, 
 				q__3.i = X(i).r * temp1.i + X(i).i * 
 				temp1.r;
 			q__2.r = A(i,j).r + q__3.r, q__2.i = A(i,j).i + 
 				q__3.i;
-			i__6 = i;
 			q__4.r = Y(i).r * temp2.r - Y(i).i * temp2.i, 
 				q__4.i = Y(i).r * temp2.i + Y(i).i * 
 				temp2.r;
@@ -355,37 +312,27 @@
 /* L50: */
 		    }
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		}
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
-		i__3 = jy;
 		if (X(jx).r != 0.f || X(jx).i != 0.f || (Y(jy).r != 0.f 
 			|| Y(jy).i != 0.f)) {
 		    r_cnjg(&q__2, &Y(jy));
 		    q__1.r = alpha->r * q__2.r - alpha->i * q__2.i, q__1.i = 
 			    alpha->r * q__2.i + alpha->i * q__2.r;
 		    temp1.r = q__1.r, temp1.i = q__1.i;
-		    i__2 = jx;
 		    q__2.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    q__2.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
 		    r_cnjg(&q__1, &q__2);
 		    temp2.r = q__1.r, temp2.i = q__1.i;
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = jx;
 		    q__2.r = X(jx).r * temp1.r - X(jx).i * temp1.i, 
 			    q__2.i = X(jx).r * temp1.i + X(jx).i * 
 			    temp1.r;
-		    i__5 = jy;
 		    q__3.r = Y(jy).r * temp2.r - Y(jy).i * temp2.i, 
 			    q__3.i = Y(jy).r * temp2.i + Y(jy).i * 
 			    temp2.r;
@@ -394,19 +341,14 @@
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		    ix = jx;
 		    iy = jy;
-		    i__2 = *n;
 		    for (i = j + 1; i <= *n; ++i) {
 			ix += *incx;
 			iy += *incy;
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = ix;
 			q__3.r = X(ix).r * temp1.r - X(ix).i * temp1.i, 
 				q__3.i = X(ix).r * temp1.i + X(ix).i * 
 				temp1.r;
 			q__2.r = A(i,j).r + q__3.r, q__2.i = A(i,j).i + 
 				q__3.i;
-			i__6 = iy;
 			q__4.r = Y(iy).r * temp2.r - Y(iy).i * temp2.i, 
 				q__4.i = Y(iy).r * temp2.i + Y(iy).i * 
 				temp2.r;
@@ -415,8 +357,6 @@
 /* L70: */
 		    }
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.f;
 		}

--- a/CBLAS/cscal.c
+++ b/CBLAS/cscal.c
@@ -16,7 +16,7 @@
     complex q__1;
 
     /* Local variables */
-    static integer i, nincx;
+    integer i, nincx;
 
 
 /*     scales a vector by a constant.   

--- a/CBLAS/cscal.c
+++ b/CBLAS/cscal.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
+
     complex q__1;
 
     /* Local variables */
@@ -41,11 +41,7 @@
 /*        code for increment not equal to 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
-	i__3 = i;
-	i__4 = i;
 	q__1.r = ca->r * CX(i).r - ca->i * CX(i).i, q__1.i = ca->r * CX(
 		i).i + ca->i * CX(i).r;
 	CX(i).r = q__1.r, CX(i).i = q__1.i;
@@ -56,10 +52,7 @@
 /*        code for increment equal to 1 */
 
 L20:
-    i__2 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__1 = i;
-	i__3 = i;
 	q__1.r = ca->r * CX(i).r - ca->i * CX(i).i, q__1.i = ca->r * CX(
 		i).i + ca->i * CX(i).r;
 	CX(i).r = q__1.r, CX(i).i = q__1.i;

--- a/CBLAS/cswap.c
+++ b/CBLAS/cswap.c
@@ -5,7 +5,7 @@
 	cy, integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3;
+    
 
     /* Local variables */
     integer i__, ix, iy;
@@ -49,15 +49,10 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
-	i__2 = ix;
-	ctemp.r = cx[i__2].r, ctemp.i = cx[i__2].i;
-	i__2 = ix;
-	i__3 = iy;
-	cx[i__2].r = cy[i__3].r, cx[i__2].i = cy[i__3].i;
-	i__2 = iy;
-	cy[i__2].r = ctemp.r, cy[i__2].i = ctemp.i;
+    for (i__ = 1; i__ <= *n; ++i__) {
+	ctemp.r = cx[ix].r, ctemp.i = cx[ix].i;
+	cx[ix].r = cy[iy].r, cx[ix].i = cy[iy].i;
+	cy[iy].r = ctemp.r, cy[iy].i = ctemp.i;
 	ix += *incx;
 	iy += *incy;
 /* L10: */
@@ -66,15 +61,10 @@
 
 /*       code for both increments equal to 1 */
 L20:
-    i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
-	i__2 = i__;
-	ctemp.r = cx[i__2].r, ctemp.i = cx[i__2].i;
-	i__2 = i__;
-	i__3 = i__;
-	cx[i__2].r = cy[i__3].r, cx[i__2].i = cy[i__3].i;
-	i__2 = i__;
-	cy[i__2].r = ctemp.r, cy[i__2].i = ctemp.i;
+    for (i__ = 1; i__ <= *n; ++i__) {
+	ctemp.r = cx[i__].r, ctemp.i = cx[i__].i;
+	cx[i__].r = cy[i__].r, cx[i__].i = cy[i__].i;
+	cy[i__].r = ctemp.r, cy[i__].i = ctemp.i;
 /* L30: */
     }
     return 0;

--- a/CBLAS/ctrsv.c
+++ b/CBLAS/ctrsv.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     complex q__1, q__2, q__3;
 
     /* Builtin functions */
@@ -186,19 +186,13 @@
 	if (strncmp(uplo, "U", 1)==0) {
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
-		    i__1 = j;
 		    if (X(j).r != 0.f || X(j).i != 0.f) {
 			if (nounit) {
-			    i__1 = j;
 			    c_div(&q__1, &X(j), &A(j,j));
 			    X(j).r = q__1.r, X(j).i = q__1.i;
 			}
-			i__1 = j;
 			temp.r = X(j).r, temp.i = X(j).i;
 			for (i = j - 1; i >= 1; --i) {
-			    i__1 = i;
-			    i__2 = i;
-			    i__3 = i + j * a_dim1;
 			    q__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    q__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    q__1.r = X(i).r - q__2.r, q__1.i = X(i).i - 
@@ -212,21 +206,15 @@
 	    } else {
 		jx = kx + (*n - 1) * *incx;
 		for (j = *n; j >= 1; --j) {
-		    i__1 = jx;
 		    if (X(jx).r != 0.f || X(jx).i != 0.f) {
 			if (nounit) {
-			    i__1 = jx;
 			    c_div(&q__1, &X(jx), &A(j,j));
 			    X(jx).r = q__1.r, X(jx).i = q__1.i;
 			}
-			i__1 = jx;
 			temp.r = X(jx).r, temp.i = X(jx).i;
 			ix = jx;
 			for (i = j - 1; i >= 1; --i) {
 			    ix -= *incx;
-			    i__1 = ix;
-			    i__2 = ix;
-			    i__3 = i + j * a_dim1;
 			    q__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    q__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    q__1.r = X(ix).r - q__2.r, q__1.i = X(ix).i - 
@@ -241,22 +229,14 @@
 	    }
 	} else {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
-		    i__2 = j;
 		    if (X(j).r != 0.f || X(j).i != 0.f) {
 			if (nounit) {
-			    i__2 = j;
 			    c_div(&q__1, &X(j), &A(j,j));
 			    X(j).r = q__1.r, X(j).i = q__1.i;
 			}
-			i__2 = j;
 			temp.r = X(j).r, temp.i = X(j).i;
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
-			    i__3 = i;
-			    i__4 = i;
-			    i__5 = i + j * a_dim1;
 			    q__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    q__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    q__1.r = X(i).r - q__2.r, q__1.i = X(i).i - 
@@ -269,24 +249,16 @@
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
-		    i__2 = jx;
 		    if (X(jx).r != 0.f || X(jx).i != 0.f) {
 			if (nounit) {
-			    i__2 = jx;
 			    c_div(&q__1, &X(jx), &A(j,j));
 			    X(jx).r = q__1.r, X(jx).i = q__1.i;
 			}
-			i__2 = jx;
 			temp.r = X(jx).r, temp.i = X(jx).i;
 			ix = jx;
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
 			    ix += *incx;
-			    i__3 = ix;
-			    i__4 = ix;
-			    i__5 = i + j * a_dim1;
 			    q__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    q__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    q__1.r = X(ix).r - q__2.r, q__1.i = X(ix).i - 
@@ -306,15 +278,10 @@
 
 	if (strncmp(uplo, "U", 1)==0) {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
-		    i__2 = j;
 		    temp.r = X(j).r, temp.i = X(j).i;
 		    if (noconj) {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
-			    i__3 = i + j * a_dim1;
-			    i__4 = i;
 			    q__2.r = A(i,j).r * X(i).r - A(i,j).i * X(
 				    i).i, q__2.i = A(i,j).r * X(i).i + 
 				    A(i,j).i * X(i).r;
@@ -328,10 +295,8 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    } else {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
 			    r_cnjg(&q__3, &A(i,j));
-			    i__3 = i;
 			    q__2.r = q__3.r * X(i).r - q__3.i * X(i).i, 
 				    q__2.i = q__3.r * X(i).i + q__3.i * X(
 				    i).r;
@@ -346,22 +311,16 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    }
-		    i__2 = j;
 		    X(j).r = temp.r, X(j).i = temp.i;
 /* L110: */
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    ix = kx;
-		    i__2 = jx;
 		    temp.r = X(jx).r, temp.i = X(jx).i;
 		    if (noconj) {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
-			    i__3 = i + j * a_dim1;
-			    i__4 = ix;
 			    q__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(
 				    ix).i, q__2.i = A(i,j).r * X(ix).i + 
 				    A(i,j).i * X(ix).r;
@@ -376,10 +335,8 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    } else {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
 			    r_cnjg(&q__3, &A(i,j));
-			    i__3 = ix;
 			    q__2.r = q__3.r * X(ix).r - q__3.i * X(ix).i, 
 				    q__2.i = q__3.r * X(ix).i + q__3.i * X(
 				    ix).r;
@@ -395,7 +352,6 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    }
-		    i__2 = jx;
 		    X(jx).r = temp.r, X(jx).i = temp.i;
 		    jx += *incx;
 /* L140: */
@@ -404,13 +360,9 @@
 	} else {
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
-		    i__1 = j;
 		    temp.r = X(j).r, temp.i = X(j).i;
 		    if (noconj) {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
-			    i__2 = i + j * a_dim1;
-			    i__3 = i;
 			    q__2.r = A(i,j).r * X(i).r - A(i,j).i * X(
 				    i).i, q__2.i = A(i,j).r * X(i).i + 
 				    A(i,j).i * X(i).r;
@@ -424,10 +376,8 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    } else {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
 			    r_cnjg(&q__3, &A(i,j));
-			    i__2 = i;
 			    q__2.r = q__3.r * X(i).r - q__3.i * X(i).i, 
 				    q__2.i = q__3.r * X(i).i + q__3.i * X(
 				    i).r;
@@ -442,7 +392,6 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    }
-		    i__1 = j;
 		    X(j).r = temp.r, X(j).i = temp.i;
 /* L170: */
 		}
@@ -451,13 +400,9 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    ix = kx;
-		    i__1 = jx;
 		    temp.r = X(jx).r, temp.i = X(jx).i;
 		    if (noconj) {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
-			    i__2 = i + j * a_dim1;
-			    i__3 = ix;
 			    q__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(
 				    ix).i, q__2.i = A(i,j).r * X(ix).i + 
 				    A(i,j).i * X(ix).r;
@@ -472,10 +417,8 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    } else {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
 			    r_cnjg(&q__3, &A(i,j));
-			    i__2 = ix;
 			    q__2.r = q__3.r * X(ix).r - q__3.i * X(ix).i, 
 				    q__2.i = q__3.r * X(ix).i + q__3.i * X(
 				    ix).r;
@@ -491,7 +434,6 @@
 			    temp.r = q__1.r, temp.i = q__1.i;
 			}
 		    }
-		    i__1 = jx;
 		    X(jx).r = temp.r, X(jx).i = temp.i;
 		    jx -= *incx;
 /* L200: */

--- a/CBLAS/ctrsv.c
+++ b/CBLAS/ctrsv.c
@@ -19,11 +19,11 @@
     void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer info;
-    static complex temp;
-    static integer i, j;
-    static integer ix, jx, kx;
-    static logical noconj, nounit;
+    integer info;
+    complex temp;
+    integer i, j;
+    integer ix, jx, kx;
+    logical noconj, nounit;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/dasum.c
+++ b/CBLAS/dasum.c
@@ -15,9 +15,9 @@ doublereal dasum_(integer *n, doublereal *dx, integer *incx)
     doublereal ret_val, d__1, d__2, d__3, d__4, d__5, d__6;
 
     /* Local variables */
-    static integer i, m;
-    static doublereal dtemp;
-    static integer nincx, mp1;
+    integer i, m;
+    doublereal dtemp;
+    integer nincx, mp1;
 
 
 /*     takes the sum of the absolute values.   

--- a/CBLAS/dasum.c
+++ b/CBLAS/dasum.c
@@ -11,7 +11,7 @@ doublereal dasum_(integer *n, doublereal *dx, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2;
+ 
     doublereal ret_val, d__1, d__2, d__3, d__4, d__5, d__6;
 
     /* Local variables */
@@ -44,8 +44,6 @@ doublereal dasum_(integer *n, doublereal *dx, integer *incx)
 /*        code for increment not equal to 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
 	dtemp += (d__1 = DX(i), abs(d__1));
 /* L10: */
@@ -63,7 +61,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__2 = m;
     for (i = 1; i <= m; ++i) {
 	dtemp += (d__1 = DX(i), abs(d__1));
 /* L30: */
@@ -73,7 +70,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__2 = *n;
     for (i = mp1; i <= *n; i += 6) {
 	dtemp = dtemp + (d__1 = DX(i), abs(d__1)) + (d__2 = DX(i + 1), abs(
 		d__2)) + (d__3 = DX(i + 2), abs(d__3)) + (d__4 = DX(i + 3), 

--- a/CBLAS/daxpy.c
+++ b/CBLAS/daxpy.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i, m, ix, iy, mp1;
@@ -52,7 +51,6 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	DY(iy) += *da * DX(ix);
 	ix += *incx;
@@ -71,7 +69,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
     for (i = 1; i <= m; ++i) {
 	DY(i) += *da * DX(i);
 /* L30: */
@@ -81,7 +78,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
     for (i = mp1; i <= *n; i += 4) {
 	DY(i) += *da * DX(i);
 	DY(i + 1) += *da * DX(i + 1);

--- a/CBLAS/daxpy.c
+++ b/CBLAS/daxpy.c
@@ -15,7 +15,7 @@
     integer i__1;
 
     /* Local variables */
-    static integer i, m, ix, iy, mp1;
+    integer i, m, ix, iy, mp1;
 
 
 /*     constant times a vector plus a vector.   

--- a/CBLAS/dcabs1.c
+++ b/CBLAS/dcabs1.c
@@ -11,7 +11,7 @@ doublereal dcabs1_(doublecomplex *z)
 
        System generated locals */
     doublereal ret_val;
-    static doublecomplex equiv_0[1];
+    doublecomplex equiv_0[1];
 
     /* Local variables */
 #define t ((doublereal *)equiv_0)

--- a/CBLAS/dcopy.c
+++ b/CBLAS/dcopy.c
@@ -15,7 +15,7 @@
     integer i__1;
 
     /* Local variables */
-    static integer i, m, ix, iy, mp1;
+    integer i, m, ix, iy, mp1;
 
 
 /*     copies a vector, x, to a vector, y.   

--- a/CBLAS/dcopy.c
+++ b/CBLAS/dcopy.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i, m, ix, iy, mp1;
@@ -49,7 +48,6 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	DY(iy) = DX(ix);
 	ix += *incx;
@@ -68,7 +66,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
     for (i = 1; i <= m; ++i) {
 	DY(i) = DX(i);
 /* L30: */
@@ -78,7 +75,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
     for (i = mp1; i <= *n; i += 7) {
 	DY(i) = DX(i);
 	DY(i + 1) = DX(i + 1);

--- a/CBLAS/ddot.c
+++ b/CBLAS/ddot.c
@@ -16,9 +16,9 @@ doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
     doublereal ret_val;
 
     /* Local variables */
-    static integer i, m;
-    static doublereal dtemp;
-    static integer ix, iy, mp1;
+    integer i, m;
+    doublereal dtemp;
+    integer ix, iy, mp1;
 
 
 /*     forms the dot product of two vectors.   

--- a/CBLAS/ddot.c
+++ b/CBLAS/ddot.c
@@ -12,8 +12,7 @@ doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
 
 
     /* System generated locals */
-    integer i__1;
-    doublereal ret_val;
+doublereal ret_val;
 
     /* Local variables */
     integer i, m;
@@ -54,7 +53,6 @@ doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	dtemp += DX(ix) * DY(iy);
 	ix += *incx;
@@ -74,7 +72,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
     for (i = 1; i <= m; ++i) {
 	dtemp += DX(i) * DY(i);
 /* L30: */
@@ -84,7 +81,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
     for (i = mp1; i <= *n; i += 5) {
 	dtemp = dtemp + DX(i) * DY(i) + DX(i + 1) * DY(i + 1) + DX(i + 2) * 
 		DY(i + 2) + DX(i + 3) * DY(i + 3) + DX(i + 4) * DY(i + 4);

--- a/CBLAS/dgemv.c
+++ b/CBLAS/dgemv.c
@@ -16,10 +16,10 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static doublereal temp;
-    static integer lenx, leny, i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    doublereal temp;
+    integer lenx, leny, i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/dgemv.c
+++ b/CBLAS/dgemv.c
@@ -13,7 +13,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -181,13 +180,11 @@
     if (*beta != 1.) {
 	if (*incy == 1) {
 	    if (*beta == 0.) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(i) = 0.;
 /* L10: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(i) = *beta * Y(i);
 /* L20: */
@@ -196,14 +193,12 @@
 	} else {
 	    iy = ky;
 	    if (*beta == 0.) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(iy) = 0.;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(iy) = *beta * Y(iy);
 		    iy += *incy;
@@ -221,11 +216,9 @@
 
 	jx = kx;
 	if (*incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0.) {
 		    temp = *alpha * X(jx);
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			Y(i) += temp * A(i,j);
 /* L50: */
@@ -235,12 +228,10 @@
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0.) {
 		    temp = *alpha * X(jx);
 		    iy = ky;
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			Y(iy) += temp * A(i,j);
 			iy += *incy;
@@ -257,10 +248,8 @@
 
 	jy = ky;
 	if (*incx == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp = 0.;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    temp += A(i,j) * X(i);
 /* L90: */
@@ -270,11 +259,9 @@
 /* L100: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp = 0.;
 		ix = kx;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    temp += A(i,j) * X(ix);
 		    ix += *incx;

--- a/CBLAS/dger.c
+++ b/CBLAS/dger.c
@@ -16,9 +16,9 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static doublereal temp;
-    static integer i, j, ix, jy, kx;
+    integer info;
+    doublereal temp;
+    integer i, j, ix, jy, kx;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/dger.c
+++ b/CBLAS/dger.c
@@ -13,7 +13,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -136,11 +135,9 @@
 	jy = 1 - (*n - 1) * *incy;
     }
     if (*incx == 1) {
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
 	    if (Y(jy) != 0.) {
 		temp = *alpha * Y(jy);
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    A(i,j) += X(i) * temp;
 /* L10: */
@@ -155,12 +152,10 @@
 	} else {
 	    kx = 1 - (*m - 1) * *incx;
 	}
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
 	    if (Y(jy) != 0.) {
 		temp = *alpha * Y(jy);
 		ix = kx;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    A(i,j) += X(ix) * temp;
 		    ix += *incx;

--- a/CBLAS/dnrm2.c
+++ b/CBLAS/dnrm2.c
@@ -11,7 +11,7 @@ doublereal dnrm2_(integer *n, doublereal *x, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2;
+ 
     doublereal ret_val, d__1;
 
     /* Builtin functions */
@@ -52,9 +52,6 @@ doublereal dnrm2_(integer *n, doublereal *x, integer *incx)
   
           auxiliary routine:   
           CALL DLASSQ( N, X, INCX, SCALE, SSQ ) */
-
-	i__1 = (*n - 1) * *incx + 1;
-	i__2 = *incx;
 	for (ix = 1; *incx < 0 ? ix >= (*n-1)**incx+1 : ix <= (*n-1)**incx+1; ix += *incx) {
 	    if (X(ix) != 0.) {
 		absxi = (d__1 = X(ix), abs(d__1));

--- a/CBLAS/dnrm2.c
+++ b/CBLAS/dnrm2.c
@@ -18,9 +18,9 @@ doublereal dnrm2_(integer *n, doublereal *x, integer *incx)
     double sqrt(doublereal);
 
     /* Local variables */
-    static doublereal norm, scale, absxi;
-    static integer ix;
-    static doublereal ssq;
+    doublereal norm, scale, absxi;
+    integer ix;
+    doublereal ssq;
 
 
 /*  DNRM2 returns the euclidean norm of a vector via the function   

--- a/CBLAS/drot.c
+++ b/CBLAS/drot.c
@@ -15,9 +15,9 @@
     integer i__1;
 
     /* Local variables */
-    static integer i;
-    static doublereal dtemp;
-    static integer ix, iy;
+    integer i;
+    doublereal dtemp;
+    integer ix, iy;
 
 
 /*     applies a plane rotation.   

--- a/CBLAS/drot.c
+++ b/CBLAS/drot.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i;
@@ -50,7 +49,6 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	dtemp = *c * DX(ix) + *s * DY(iy);
 	DY(iy) = *c * DY(iy) - *s * DX(ix);
@@ -64,7 +62,6 @@
 /*       code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	dtemp = *c * DX(i) + *s * DY(i);
 	DY(i) = *c * DY(i) - *s * DX(i);

--- a/CBLAS/dscal.c
+++ b/CBLAS/dscal.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2;
+ 
 
     /* Local variables */
     integer i, m, nincx, mp1;
@@ -41,8 +41,6 @@
 /*        code for increment not equal to 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
 	DX(i) = *da * DX(i);
 /* L10: */
@@ -59,7 +57,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__2 = m;
     for (i = 1; i <= m; ++i) {
 	DX(i) = *da * DX(i);
 /* L30: */
@@ -69,7 +66,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__2 = *n;
     for (i = mp1; i <= *n; i += 5) {
 	DX(i) = *da * DX(i);
 	DX(i + 1) = *da * DX(i + 1);

--- a/CBLAS/dscal.c
+++ b/CBLAS/dscal.c
@@ -15,7 +15,7 @@
     integer i__1, i__2;
 
     /* Local variables */
-    static integer i, m, nincx, mp1;
+    integer i, m, nincx, mp1;
 
 
 /*     scales a vector by a constant.   

--- a/CBLAS/dswap.c
+++ b/CBLAS/dswap.c
@@ -5,7 +5,6 @@
 	doublereal *dy, integer *incy)
 {
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i__, m, ix, iy, mp1;
@@ -52,8 +51,7 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
+    for (i__ = 1; i__ <= *n; ++i__) {
 	dtemp = dx[ix];
 	dx[ix] = dy[iy];
 	dy[iy] = dtemp;
@@ -73,8 +71,7 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
-    for (i__ = 1; i__ <= i__1; ++i__) {
+    for (i__ = 1; i__ <= m; ++i__) {
 	dtemp = dx[i__];
 	dx[i__] = dy[i__];
 	dy[i__] = dtemp;
@@ -85,8 +82,7 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
-    for (i__ = mp1; i__ <= i__1; i__ += 3) {
+    for (i__ = mp1; i__ <= *n; i__ += 3) {
 	dtemp = dx[i__];
 	dx[i__] = dy[i__];
 	dy[i__] = dtemp;

--- a/CBLAS/dsymv.c
+++ b/CBLAS/dsymv.c
@@ -13,7 +13,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -171,13 +170,11 @@
     if (*beta != 1.) {
 	if (*incy == 1) {
 	    if (*beta == 0.) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(i) = 0.;
 /* L10: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(i) = *beta * Y(i);
 /* L20: */
@@ -186,14 +183,12 @@
 	} else {
 	    iy = ky;
 	    if (*beta == 0.) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(iy) = 0.;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(iy) = *beta * Y(iy);
 		    iy += *incy;
@@ -210,11 +205,9 @@
 /*        Form  y  when A is stored in upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(j);
 		temp2 = 0.;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
 		    Y(i) += temp1 * A(i,j);
 		    temp2 += A(i,j) * X(i);
@@ -226,13 +219,11 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(jx);
 		temp2 = 0.;
 		ix = kx;
 		iy = ky;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
 		    Y(iy) += temp1 * A(i,j);
 		    temp2 += A(i,j) * X(ix);
@@ -251,12 +242,10 @@
 /*        Form  y  when A is stored in lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(j);
 		temp2 = 0.;
 		Y(j) += temp1 * A(j,j);
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
 		    Y(i) += temp1 * A(i,j);
 		    temp2 += A(i,j) * X(i);
@@ -268,14 +257,12 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(jx);
 		temp2 = 0.;
 		Y(jy) += temp1 * A(j,j);
 		ix = jx;
 		iy = jy;
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
 		    ix += *incx;
 		    iy += *incy;

--- a/CBLAS/dsymv.c
+++ b/CBLAS/dsymv.c
@@ -16,10 +16,10 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static doublereal temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    doublereal temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/dsyr2.c
+++ b/CBLAS/dsyr2.c
@@ -13,7 +13,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -175,12 +174,10 @@
 /*        Form  A  when A is stored in the upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(j) != 0. || Y(j) != 0.) {
 		    temp1 = *alpha * Y(j);
 		    temp2 = *alpha * X(j);
-		    i__2 = j;
 		    for (i = 1; i <= j; ++i) {
 			A(i,j) = A(i,j) + X(i) * temp1 
 				+ Y(i) * temp2;
@@ -190,14 +187,12 @@
 /* L20: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0. || Y(jy) != 0.) {
 		    temp1 = *alpha * Y(jy);
 		    temp2 = *alpha * X(jx);
 		    ix = kx;
 		    iy = ky;
-		    i__2 = j;
 		    for (i = 1; i <= j; ++i) {
 			A(i,j) = A(i,j) + X(ix) * temp1 
 				+ Y(iy) * temp2;
@@ -216,12 +211,10 @@
 /*        Form  A  when A is stored in the lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(j) != 0. || Y(j) != 0.) {
 		    temp1 = *alpha * Y(j);
 		    temp2 = *alpha * X(j);
-		    i__2 = *n;
 		    for (i = j; i <= *n; ++i) {
 			A(i,j) = A(i,j) + X(i) * temp1 
 				+ Y(i) * temp2;
@@ -231,14 +224,12 @@
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0. || Y(jy) != 0.) {
 		    temp1 = *alpha * Y(jy);
 		    temp2 = *alpha * X(jx);
 		    ix = jx;
 		    iy = jy;
-		    i__2 = *n;
 		    for (i = j; i <= *n; ++i) {
 			A(i,j) = A(i,j) + X(ix) * temp1 
 				+ Y(iy) * temp2;

--- a/CBLAS/dsyr2.c
+++ b/CBLAS/dsyr2.c
@@ -16,10 +16,10 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static doublereal temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    doublereal temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
     extern int input_error(char *, int *);
 
 /*  Purpose   

--- a/CBLAS/dtrsv.c
+++ b/CBLAS/dtrsv.c
@@ -15,11 +15,11 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static doublereal temp;
-    static integer i, j;
-    static integer ix, jx, kx;
-    static logical nounit;
+    integer info;
+    doublereal temp;
+    integer i, j;
+    integer ix, jx, kx;
+    logical nounit;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/dtrsv.c
+++ b/CBLAS/dtrsv.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -214,14 +213,12 @@
 	    }
 	} else {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    if (X(j) != 0.) {
 			if (nounit) {
 			    X(j) /= A(j,j);
 			}
 			temp = X(j);
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
 			    X(i) -= temp * A(i,j);
 /* L50: */
@@ -231,7 +228,6 @@
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    if (X(jx) != 0.) {
 			if (nounit) {
@@ -239,7 +235,6 @@
 			}
 			temp = X(jx);
 			ix = jx;
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
 			    ix += *incx;
 			    X(ix) -= temp * A(i,j);
@@ -257,10 +252,8 @@
 
 	if (strncmp(uplo, "U", 1)==0) {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    temp = X(j);
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
 			temp -= A(i,j) * X(i);
 /* L90: */
@@ -273,11 +266,9 @@
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    temp = X(jx);
 		    ix = kx;
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
 			temp -= A(i,j) * X(ix);
 			ix += *incx;
@@ -295,7 +286,6 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    temp = X(j);
-		    i__1 = j + 1;
 		    for (i = *n; i >= j+1; --i) {
 			temp -= A(i,j) * X(i);
 /* L130: */
@@ -312,7 +302,6 @@
 		for (j = *n; j >= 1; --j) {
 		    temp = X(jx);
 		    ix = kx;
-		    i__1 = j + 1;
 		    for (i = *n; i >= j+1; --i) {
 			temp -= A(i,j) * X(ix);
 			ix -= *incx;

--- a/CBLAS/dzasum.c
+++ b/CBLAS/dzasum.c
@@ -11,8 +11,7 @@ doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx)
 
 
     /* System generated locals */
-    integer i__1;
-    doublereal ret_val;
+doublereal ret_val;
 
     /* Local variables */
     integer i;
@@ -45,7 +44,6 @@ doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx)
 /*        code for increment not equal to 1 */
 
     ix = 1;
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	stemp += dcabs1_(&ZX(ix));
 	ix += *incx;
@@ -57,7 +55,6 @@ doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx)
 /*        code for increment equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	stemp += dcabs1_(&ZX(i));
 /* L30: */

--- a/CBLAS/dzasum.c
+++ b/CBLAS/dzasum.c
@@ -15,10 +15,10 @@ doublereal dzasum_(integer *n, doublecomplex *zx, integer *incx)
     doublereal ret_val;
 
     /* Local variables */
-    static integer i;
-    static doublereal stemp;
+    integer i;
+    doublereal stemp;
     extern doublereal dcabs1_(doublecomplex *);
-    static integer ix;
+    integer ix;
 
 
 /*     takes the sum of the absolute values.   

--- a/CBLAS/dznrm2.c
+++ b/CBLAS/dznrm2.c
@@ -11,7 +11,7 @@ doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3;
+
     doublereal ret_val, d__1;
 
     /* Builtin functions */
@@ -50,13 +50,8 @@ doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx)
   
           auxiliary routine:   
           CALL ZLASSQ( N, X, INCX, SCALE, SSQ ) */
-
-	i__1 = (*n - 1) * *incx + 1;
-	i__2 = *incx;
 	for (ix = 1; *incx < 0 ? ix >= (*n-1)**incx+1 : ix <= (*n-1)**incx+1; ix += *incx) {
-	    i__3 = ix;
 	    if (X(ix).r != 0.) {
-		i__3 = ix;
 		temp = (d__1 = X(ix).r, abs(d__1));
 		if (scale < temp) {
 /* Computing 2nd power */

--- a/CBLAS/dznrm2.c
+++ b/CBLAS/dznrm2.c
@@ -18,9 +18,9 @@ doublereal dznrm2_(integer *n, doublecomplex *x, integer *incx)
     double d_imag(doublecomplex *), sqrt(doublereal);
 
     /* Local variables */
-    static doublereal temp, norm, scale;
-    static integer ix;
-    static doublereal ssq;
+    doublereal temp, norm, scale;
+    integer ix;
+    doublereal ssq;
 
 
 /*  DZNRM2 returns the euclidean norm of a vector via the function   

--- a/CBLAS/icamax.c
+++ b/CBLAS/icamax.c
@@ -3,7 +3,7 @@
 integer icamax_(integer *n, complex *cx, integer *incx)
 {
     /* System generated locals */
-    integer ret_val, i__1, i__2;
+integer ret_val, i__1, i__2;
     real r__1, r__2;
     /* Builtin functions */
     double r_imag(complex *);
@@ -33,15 +33,12 @@ integer icamax_(integer *n, complex *cx, integer *incx)
     ix = 1;
     smax = (r__1 = CX(1).r, dabs(r__1)) + (r__2 = r_imag(&CX(1)), dabs(r__2));
     ix += *incx;
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
-	i__2 = ix;
 	if ((r__1 = CX(ix).r, dabs(r__1)) + (r__2 = r_imag(&CX(ix)), dabs(
 		r__2)) <= smax) {
 	    goto L5;
 	}
 	ret_val = i;
-	i__2 = ix;
 	smax = (r__1 = CX(ix).r, dabs(r__1)) + (r__2 = r_imag(&CX(ix)), 
 		dabs(r__2));
 L5:
@@ -52,15 +49,12 @@ L5:
 /*        code for increment equal to 1 */
 L20:
     smax = (r__1 = CX(1).r, dabs(r__1)) + (r__2 = r_imag(&CX(1)), dabs(r__2));
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
-	i__2 = i;
 	if ((r__1 = CX(i).r, dabs(r__1)) + (r__2 = r_imag(&CX(i)), dabs(
 		r__2)) <= smax) {
 	    goto L30;
 	}
 	ret_val = i;
-	i__2 = i;
 	smax = (r__1 = CX(i).r, dabs(r__1)) + (r__2 = r_imag(&CX(i)), dabs(
 		r__2));
 L30:

--- a/CBLAS/icamax.c
+++ b/CBLAS/icamax.c
@@ -8,8 +8,8 @@ integer icamax_(integer *n, complex *cx, integer *incx)
     /* Builtin functions */
     double r_imag(complex *);
     /* Local variables */
-    static real smax;
-    static integer i, ix;
+    real smax;
+    integer i, ix;
 /*     finds the index of element having max. absolute value.   
        jack dongarra, linpack, 3/11/78.   
        modified 3/93 to return if incx .le. 0.   

--- a/CBLAS/idamax.c
+++ b/CBLAS/idamax.c
@@ -11,7 +11,7 @@ integer idamax_(integer *n, doublereal *dx, integer *incx)
 
 
     /* System generated locals */
-    integer ret_val, i__1;
+integer ret_val, i__1;
     doublereal d__1;
 
     /* Local variables */
@@ -48,7 +48,6 @@ integer idamax_(integer *n, doublereal *dx, integer *incx)
     ix = 1;
     dmax__ = abs(DX(1));
     ix += *incx;
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
 	if ((d__1 = DX(ix), abs(d__1)) <= dmax__) {
 	    goto L5;
@@ -65,7 +64,6 @@ L5:
 
 L20:
     dmax__ = abs(DX(1));
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
 	if ((d__1 = DX(i), abs(d__1)) <= dmax__) {
 	    goto L30;

--- a/CBLAS/idamax.c
+++ b/CBLAS/idamax.c
@@ -15,8 +15,8 @@ integer idamax_(integer *n, doublereal *dx, integer *incx)
     doublereal d__1;
 
     /* Local variables */
-    static doublereal dmax__;
-    static integer i, ix;
+    doublereal dmax__;
+    integer i, ix;
 
 
 /*     finds the index of element having max. absolute value.   

--- a/CBLAS/isamax.c
+++ b/CBLAS/isamax.c
@@ -15,8 +15,8 @@ integer isamax_(integer *n, real *sx, integer *incx)
     real r__1;
 
     /* Local variables */
-    static real smax;
-    static integer i, ix;
+    real smax;
+    integer i, ix;
 
 
 /*     finds the index of element having max. absolute value.   

--- a/CBLAS/isamax.c
+++ b/CBLAS/isamax.c
@@ -11,7 +11,7 @@ integer isamax_(integer *n, real *sx, integer *incx)
 
 
     /* System generated locals */
-    integer ret_val, i__1;
+integer ret_val, i__1;
     real r__1;
 
     /* Local variables */
@@ -48,7 +48,6 @@ integer isamax_(integer *n, real *sx, integer *incx)
     ix = 1;
     smax = dabs(SX(1));
     ix += *incx;
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
 	if ((r__1 = SX(ix), dabs(r__1)) <= smax) {
 	    goto L5;
@@ -65,7 +64,6 @@ L5:
 
 L20:
     smax = dabs(SX(1));
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
 	if ((r__1 = SX(i), dabs(r__1)) <= smax) {
 	    goto L30;

--- a/CBLAS/izamax.c
+++ b/CBLAS/izamax.c
@@ -14,10 +14,10 @@ integer izamax_(integer *n, doublecomplex *zx, integer *incx)
     integer ret_val, i__1;
 
     /* Local variables */
-    static doublereal smax;
-    static integer i;
+    doublereal smax;
+    integer i;
     extern doublereal dcabs1_(doublecomplex *);
-    static integer ix;
+    integer ix;
 
 
 /*     finds the index of element having max. absolute value.   

--- a/CBLAS/izamax.c
+++ b/CBLAS/izamax.c
@@ -11,7 +11,7 @@ integer izamax_(integer *n, doublecomplex *zx, integer *incx)
 
 
     /* System generated locals */
-    integer ret_val, i__1;
+integer ret_val, i__1;
 
     /* Local variables */
     doublereal smax;
@@ -49,7 +49,6 @@ integer izamax_(integer *n, doublecomplex *zx, integer *incx)
     ix = 1;
     smax = dcabs1_(&ZX(1));
     ix += *incx;
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
 	if (dcabs1_(&ZX(ix)) <= smax) {
 	    goto L5;
@@ -66,7 +65,6 @@ L5:
 
 L20:
     smax = dcabs1_(&ZX(1));
-    i__1 = *n;
     for (i = 2; i <= *n; ++i) {
 	if (dcabs1_(&ZX(i)) <= smax) {
 	    goto L30;

--- a/CBLAS/sasum.c
+++ b/CBLAS/sasum.c
@@ -15,9 +15,9 @@ real sasum_(integer *n, real *sx, integer *incx)
     real ret_val, r__1, r__2, r__3, r__4, r__5, r__6;
 
     /* Local variables */
-    static integer i, m, nincx;
-    static real stemp;
-    static integer mp1;
+    integer i, m, nincx;
+    real stemp;
+    integer mp1;
 
 
 /*     takes the sum of the absolute values.   

--- a/CBLAS/sasum.c
+++ b/CBLAS/sasum.c
@@ -11,7 +11,7 @@ real sasum_(integer *n, real *sx, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2;
+ 
     real ret_val, r__1, r__2, r__3, r__4, r__5, r__6;
 
     /* Local variables */
@@ -45,8 +45,6 @@ real sasum_(integer *n, real *sx, integer *incx)
 /*        code for increment not equal to 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
 	stemp += (r__1 = SX(i), dabs(r__1));
 /* L10: */
@@ -64,7 +62,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__2 = m;
     for (i = 1; i <= m; ++i) {
 	stemp += (r__1 = SX(i), dabs(r__1));
 /* L30: */
@@ -74,7 +71,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__2 = *n;
     for (i = mp1; i <= *n; i += 6) {
 	stemp = stemp + (r__1 = SX(i), dabs(r__1)) + (r__2 = SX(i + 1), dabs(
 		r__2)) + (r__3 = SX(i + 2), dabs(r__3)) + (r__4 = SX(i + 3), 

--- a/CBLAS/saxpy.c
+++ b/CBLAS/saxpy.c
@@ -15,7 +15,7 @@
     integer i__1;
 
     /* Local variables */
-    static integer i, m, ix, iy, mp1;
+    integer i, m, ix, iy, mp1;
 
 
 /*     constant times a vector plus a vector.   

--- a/CBLAS/saxpy.c
+++ b/CBLAS/saxpy.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i, m, ix, iy, mp1;
@@ -52,7 +51,6 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	SY(iy) += *sa * SX(ix);
 	ix += *incx;
@@ -71,7 +69,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
     for (i = 1; i <= m; ++i) {
 	SY(i) += *sa * SX(i);
 /* L30: */
@@ -81,7 +78,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
     for (i = mp1; i <= *n; i += 4) {
 	SY(i) += *sa * SX(i);
 	SY(i + 1) += *sa * SX(i + 1);

--- a/CBLAS/scasum.c
+++ b/CBLAS/scasum.c
@@ -18,8 +18,8 @@ real scasum_(integer *n, complex *cx, integer *incx)
     double r_imag(complex *);
 
     /* Local variables */
-    static integer i, nincx;
-    static real stemp;
+    integer i, nincx;
+    real stemp;
 
 
 /*     takes the sum of the absolute values of a complex vector and   

--- a/CBLAS/scasum.c
+++ b/CBLAS/scasum.c
@@ -11,7 +11,7 @@ real scasum_(integer *n, complex *cx, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3;
+
     real ret_val, r__1, r__2;
 
     /* Builtin functions */
@@ -47,10 +47,7 @@ real scasum_(integer *n, complex *cx, integer *incx)
 /*        code for increment not equal to 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
-	i__3 = i;
 	stemp = stemp + (r__1 = CX(i).r, dabs(r__1)) + (r__2 = r_imag(&CX(
 		i)), dabs(r__2));
 /* L10: */
@@ -61,9 +58,7 @@ real scasum_(integer *n, complex *cx, integer *incx)
 /*        code for increment equal to 1 */
 
 L20:
-    i__2 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__1 = i;
 	stemp = stemp + (r__1 = CX(i).r, dabs(r__1)) + (r__2 = r_imag(&CX(
 		i)), dabs(r__2));
 /* L30: */

--- a/CBLAS/scnrm2.c
+++ b/CBLAS/scnrm2.c
@@ -11,7 +11,7 @@ real scnrm2_(integer *n, complex *x, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3;
+
     real ret_val, r__1;
 
     /* Builtin functions */
@@ -50,13 +50,8 @@ real scnrm2_(integer *n, complex *x, integer *incx)
   
           auxiliary routine:   
           CALL CLASSQ( N, X, INCX, SCALE, SSQ ) */
-
-	i__1 = (*n - 1) * *incx + 1;
-	i__2 = *incx;
 	for (ix = 1; *incx < 0 ? ix >= (*n-1)**incx+1 : ix <= (*n-1)**incx+1; ix += *incx) {
-	    i__3 = ix;
 	    if (X(ix).r != 0.f) {
-		i__3 = ix;
 		temp = (r__1 = X(ix).r, dabs(r__1));
 		if (scale < temp) {
 /* Computing 2nd power */

--- a/CBLAS/scnrm2.c
+++ b/CBLAS/scnrm2.c
@@ -18,9 +18,9 @@ real scnrm2_(integer *n, complex *x, integer *incx)
     double r_imag(complex *), sqrt(doublereal);
 
     /* Local variables */
-    static real temp, norm, scale;
-    static integer ix;
-    static real ssq;
+    real temp, norm, scale;
+    integer ix;
+    real ssq;
 
 
 /*  SCNRM2 returns the euclidean norm of a vector via the function   

--- a/CBLAS/scopy.c
+++ b/CBLAS/scopy.c
@@ -15,7 +15,7 @@
     integer i__1;
 
     /* Local variables */
-    static integer i, m, ix, iy, mp1;
+    integer i, m, ix, iy, mp1;
 
 
 /*     copies a vector, x, to a vector, y.   

--- a/CBLAS/scopy.c
+++ b/CBLAS/scopy.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i, m, ix, iy, mp1;
@@ -49,7 +48,6 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	SY(iy) = SX(ix);
 	ix += *incx;
@@ -68,7 +66,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
     for (i = 1; i <= m; ++i) {
 	SY(i) = SX(i);
 /* L30: */
@@ -78,7 +75,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
     for (i = mp1; i <= *n; i += 7) {
 	SY(i) = SX(i);
 	SY(i + 1) = SX(i + 1);

--- a/CBLAS/sdot.c
+++ b/CBLAS/sdot.c
@@ -11,8 +11,7 @@ real sdot_(integer *n, real *sx, integer *incx, real *sy, integer *incy)
 
 
     /* System generated locals */
-    integer i__1;
-    real ret_val;
+real ret_val;
 
     /* Local variables */
     integer i, m;
@@ -53,7 +52,6 @@ real sdot_(integer *n, real *sx, integer *incx, real *sy, integer *incy)
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	stemp += SX(ix) * SY(iy);
 	ix += *incx;
@@ -73,7 +71,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
     for (i = 1; i <= m; ++i) {
 	stemp += SX(i) * SY(i);
 /* L30: */
@@ -83,7 +80,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
     for (i = mp1; i <= *n; i += 5) {
 	stemp = stemp + SX(i) * SY(i) + SX(i + 1) * SY(i + 1) + SX(i + 2) * 
 		SY(i + 2) + SX(i + 3) * SY(i + 3) + SX(i + 4) * SY(i + 4);

--- a/CBLAS/sdot.c
+++ b/CBLAS/sdot.c
@@ -15,9 +15,9 @@ real sdot_(integer *n, real *sx, integer *incx, real *sy, integer *incy)
     real ret_val;
 
     /* Local variables */
-    static integer i, m;
-    static real stemp;
-    static integer ix, iy, mp1;
+    integer i, m;
+    real stemp;
+    integer ix, iy, mp1;
 
 
 /*     forms the dot product of two vectors.   

--- a/CBLAS/sgemv.c
+++ b/CBLAS/sgemv.c
@@ -13,7 +13,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -184,13 +183,11 @@
     if (*beta != 1.f) {
 	if (*incy == 1) {
 	    if (*beta == 0.f) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(i) = 0.f;
 /* L10: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(i) = *beta * Y(i);
 /* L20: */
@@ -199,14 +196,12 @@
 	} else {
 	    iy = ky;
 	    if (*beta == 0.f) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(iy) = 0.f;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
 		    Y(iy) = *beta * Y(iy);
 		    iy += *incy;
@@ -224,11 +219,9 @@
 
 	jx = kx;
 	if (*incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0.f) {
 		    temp = *alpha * X(jx);
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			Y(i) += temp * A(i,j);
 /* L50: */
@@ -238,12 +231,10 @@
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0.f) {
 		    temp = *alpha * X(jx);
 		    iy = ky;
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			Y(iy) += temp * A(i,j);
 			iy += *incy;
@@ -260,10 +251,8 @@
 
 	jy = ky;
 	if (*incx == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp = 0.f;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    temp += A(i,j) * X(i);
 /* L90: */
@@ -273,11 +262,9 @@
 /* L100: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp = 0.f;
 		ix = kx;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    temp += A(i,j) * X(ix);
 		    ix += *incx;

--- a/CBLAS/sgemv.c
+++ b/CBLAS/sgemv.c
@@ -16,10 +16,10 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static real temp;
-    static integer lenx, leny, i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    real temp;
+    integer lenx, leny, i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/sger.c
+++ b/CBLAS/sger.c
@@ -15,9 +15,9 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static real temp;
-    static integer i, j, ix, jy, kx;
+    integer info;
+    real temp;
+    integer i, j, ix, jy, kx;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/sger.c
+++ b/CBLAS/sger.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -137,11 +136,9 @@
 	jy = 1 - (*n - 1) * *incy;
     }
     if (*incx == 1) {
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
 	    if (Y(jy) != 0.f) {
 		temp = *alpha * Y(jy);
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    A(i,j) += X(i) * temp;
 /* L10: */
@@ -156,12 +153,10 @@
 	} else {
 	    kx = 1 - (*m - 1) * *incx;
 	}
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
 	    if (Y(jy) != 0.f) {
 		temp = *alpha * Y(jy);
 		ix = kx;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
 		    A(i,j) += X(ix) * temp;
 		    ix += *incx;

--- a/CBLAS/snrm2.c
+++ b/CBLAS/snrm2.c
@@ -18,9 +18,9 @@ real snrm2_(integer *n, real *x, integer *incx)
     double sqrt(doublereal);
 
     /* Local variables */
-    static real norm, scale, absxi;
-    static integer ix;
-    static real ssq;
+    real norm, scale, absxi;
+    integer ix;
+    real ssq;
 
 
 /*  SNRM2 returns the euclidean norm of a vector via the function   

--- a/CBLAS/snrm2.c
+++ b/CBLAS/snrm2.c
@@ -11,7 +11,7 @@ real snrm2_(integer *n, real *x, integer *incx)
 
 
     /* System generated locals */
-    integer i__1, i__2;
+ 
     real ret_val, r__1;
 
     /* Builtin functions */
@@ -52,9 +52,6 @@ real snrm2_(integer *n, real *x, integer *incx)
   
           auxiliary routine:   
           CALL SLASSQ( N, X, INCX, SCALE, SSQ ) */
-
-	i__1 = (*n - 1) * *incx + 1;
-	i__2 = *incx;
 	for (ix = 1; *incx < 0 ? ix >= (*n-1)**incx+1 : ix <= (*n-1)**incx+1; ix += *incx) {
 	    if (X(ix) != 0.f) {
 		absxi = (r__1 = X(ix), dabs(r__1));

--- a/CBLAS/srot.c
+++ b/CBLAS/srot.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i;
@@ -50,7 +49,6 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	stemp = *c * SX(ix) + *s * SY(iy);
 	SY(iy) = *c * SY(iy) - *s * SX(ix);
@@ -64,7 +62,6 @@
 /*       code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	stemp = *c * SX(i) + *s * SY(i);
 	SY(i) = *c * SY(i) - *s * SX(i);

--- a/CBLAS/srot.c
+++ b/CBLAS/srot.c
@@ -15,9 +15,9 @@
     integer i__1;
 
     /* Local variables */
-    static integer i;
-    static real stemp;
-    static integer ix, iy;
+    integer i;
+    real stemp;
+    integer ix, iy;
 
 
 /*     applies a plane rotation.   

--- a/CBLAS/sscal.c
+++ b/CBLAS/sscal.c
@@ -11,7 +11,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2;
+ 
 
     /* Local variables */
     integer i, m, nincx, mp1;
@@ -40,8 +40,6 @@
 /*        code for increment not equal to 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
 	SX(i) = *sa * SX(i);
 /* L10: */
@@ -58,7 +56,6 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__2 = m;
     for (i = 1; i <= m; ++i) {
 	SX(i) = *sa * SX(i);
 /* L30: */
@@ -68,7 +65,6 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__2 = *n;
     for (i = mp1; i <= *n; i += 5) {
 	SX(i) = *sa * SX(i);
 	SX(i + 1) = *sa * SX(i + 1);

--- a/CBLAS/sscal.c
+++ b/CBLAS/sscal.c
@@ -14,7 +14,7 @@
     integer i__1, i__2;
 
     /* Local variables */
-    static integer i, m, nincx, mp1;
+    integer i, m, nincx, mp1;
 
 
 /*     scales a vector by a constant.   

--- a/CBLAS/sswap.c
+++ b/CBLAS/sswap.c
@@ -5,7 +5,6 @@
 	integer *incy)
 {
     /* System generated locals */
-    integer i__1;
 
     /* Local variables */
     integer i__, m, ix, iy, mp1;
@@ -52,8 +51,7 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
+    for (i__ = 1; i__ <= *n; ++i__) {
 	stemp = sx[ix];
 	sx[ix] = sy[iy];
 	sy[iy] = stemp;
@@ -73,8 +71,7 @@ L20:
     if (m == 0) {
 	goto L40;
     }
-    i__1 = m;
-    for (i__ = 1; i__ <= i__1; ++i__) {
+    for (i__ = 1; i__ <= m; ++i__) {
 	stemp = sx[i__];
 	sx[i__] = sy[i__];
 	sy[i__] = stemp;
@@ -85,8 +82,7 @@ L20:
     }
 L40:
     mp1 = m + 1;
-    i__1 = *n;
-    for (i__ = mp1; i__ <= i__1; i__ += 3) {
+    for (i__ = mp1; i__ <= *n; i__ += 3) {
 	stemp = sx[i__];
 	sx[i__] = sy[i__];
 	sy[i__] = stemp;

--- a/CBLAS/ssymv.c
+++ b/CBLAS/ssymv.c
@@ -13,7 +13,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -171,13 +170,11 @@
     if (*beta != 1.f) {
 	if (*incy == 1) {
 	    if (*beta == 0.f) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(i) = 0.f;
 /* L10: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(i) = *beta * Y(i);
 /* L20: */
@@ -186,14 +183,12 @@
 	} else {
 	    iy = ky;
 	    if (*beta == 0.f) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(iy) = 0.f;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
 		    Y(iy) = *beta * Y(iy);
 		    iy += *incy;
@@ -210,11 +205,9 @@
 /*        Form  y  when A is stored in upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(j);
 		temp2 = 0.f;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
 		    Y(i) += temp1 * A(i,j);
 		    temp2 += A(i,j) * X(i);
@@ -226,13 +219,11 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(jx);
 		temp2 = 0.f;
 		ix = kx;
 		iy = ky;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
 		    Y(iy) += temp1 * A(i,j);
 		    temp2 += A(i,j) * X(ix);
@@ -251,12 +242,10 @@
 /*        Form  y  when A is stored in lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(j);
 		temp2 = 0.f;
 		Y(j) += temp1 * A(j,j);
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
 		    Y(i) += temp1 * A(i,j);
 		    temp2 += A(i,j) * X(i);
@@ -268,14 +257,12 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp1 = *alpha * X(jx);
 		temp2 = 0.f;
 		Y(jy) += temp1 * A(j,j);
 		ix = jx;
 		iy = jy;
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
 		    ix += *incx;
 		    iy += *incy;

--- a/CBLAS/ssymv.c
+++ b/CBLAS/ssymv.c
@@ -16,10 +16,10 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static real temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    real temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/ssyr2.c
+++ b/CBLAS/ssyr2.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -174,12 +173,10 @@
 /*        Form  A  when A is stored in the upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(j) != 0.f || Y(j) != 0.f) {
 		    temp1 = *alpha * Y(j);
 		    temp2 = *alpha * X(j);
-		    i__2 = j;
 		    for (i = 1; i <= j; ++i) {
 			A(i,j) = A(i,j) + X(i) * temp1 
 				+ Y(i) * temp2;
@@ -189,14 +186,12 @@
 /* L20: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0.f || Y(jy) != 0.f) {
 		    temp1 = *alpha * Y(jy);
 		    temp2 = *alpha * X(jx);
 		    ix = kx;
 		    iy = ky;
-		    i__2 = j;
 		    for (i = 1; i <= j; ++i) {
 			A(i,j) = A(i,j) + X(ix) * temp1 
 				+ Y(iy) * temp2;
@@ -215,12 +210,10 @@
 /*        Form  A  when A is stored in the lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(j) != 0.f || Y(j) != 0.f) {
 		    temp1 = *alpha * Y(j);
 		    temp2 = *alpha * X(j);
-		    i__2 = *n;
 		    for (i = j; i <= *n; ++i) {
 			A(i,j) = A(i,j) + X(i) * temp1 
 				+ Y(i) * temp2;
@@ -230,14 +223,12 @@
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		if (X(jx) != 0.f || Y(jy) != 0.f) {
 		    temp1 = *alpha * Y(jy);
 		    temp2 = *alpha * X(jx);
 		    ix = jx;
 		    iy = jy;
-		    i__2 = *n;
 		    for (i = j; i <= *n; ++i) {
 			A(i,j) = A(i,j) + X(ix) * temp1 
 				+ Y(iy) * temp2;

--- a/CBLAS/ssyr2.c
+++ b/CBLAS/ssyr2.c
@@ -15,10 +15,10 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static real temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    real temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
     extern int input_error(char *, int *);
 
 /*  Purpose   

--- a/CBLAS/strsv.c
+++ b/CBLAS/strsv.c
@@ -12,7 +12,6 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
     integer info;
@@ -211,14 +210,12 @@
 	    }
 	} else {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    if (X(j) != 0.f) {
 			if (nounit) {
 			    X(j) /= A(j,j);
 			}
 			temp = X(j);
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
 			    X(i) -= temp * A(i,j);
 /* L50: */
@@ -228,7 +225,6 @@
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    if (X(jx) != 0.f) {
 			if (nounit) {
@@ -236,7 +232,6 @@
 			}
 			temp = X(jx);
 			ix = jx;
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
 			    ix += *incx;
 			    X(ix) -= temp * A(i,j);
@@ -254,10 +249,8 @@
 
 	if (strncmp(uplo, "U", 1)==0) {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    temp = X(j);
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
 			temp -= A(i,j) * X(i);
 /* L90: */
@@ -270,11 +263,9 @@
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    temp = X(jx);
 		    ix = kx;
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
 			temp -= A(i,j) * X(ix);
 			ix += *incx;
@@ -292,7 +283,6 @@
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
 		    temp = X(j);
-		    i__1 = j + 1;
 		    for (i = *n; i >= j+1; --i) {
 			temp -= A(i,j) * X(i);
 /* L130: */
@@ -309,7 +299,6 @@
 		for (j = *n; j >= 1; --j) {
 		    temp = X(jx);
 		    ix = kx;
-		    i__1 = j + 1;
 		    for (i = *n; i >= j+1; --i) {
 			temp -= A(i,j) * X(ix);
 			ix -= *incx;

--- a/CBLAS/strsv.c
+++ b/CBLAS/strsv.c
@@ -15,11 +15,11 @@
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer info;
-    static real temp;
-    static integer i, j;
-    static integer ix, jx, kx;
-    static logical nounit;
+    integer info;
+    real temp;
+    integer i, j;
+    integer ix, jx, kx;
+    logical nounit;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/zaxpy.c
+++ b/CBLAS/zaxpy.c
@@ -16,9 +16,9 @@
     doublecomplex z__1, z__2;
 
     /* Local variables */
-    static integer i;
+    integer i;
     extern doublereal dcabs1_(doublecomplex *);
-    static integer ix, iy;
+    integer ix, iy;
 
 
 /*     constant times a vector plus a vector.   

--- a/CBLAS/zaxpy.c
+++ b/CBLAS/zaxpy.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
+
     doublecomplex z__1, z__2;
 
     /* Local variables */
@@ -53,11 +53,7 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = iy;
-	i__3 = iy;
-	i__4 = ix;
 	z__2.r = za->r * ZX(ix).r - za->i * ZX(ix).i, z__2.i = za->r * ZX(
 		ix).i + za->i * ZX(ix).r;
 	z__1.r = ZY(iy).r + z__2.r, z__1.i = ZY(iy).i + z__2.i;
@@ -71,11 +67,7 @@
 /*        code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = i;
-	i__3 = i;
-	i__4 = i;
 	z__2.r = za->r * ZX(i).r - za->i * ZX(i).i, z__2.i = za->r * ZX(
 		i).i + za->i * ZX(i).r;
 	z__1.r = ZY(i).r + z__2.r, z__1.i = ZY(i).i + z__2.i;

--- a/CBLAS/zcopy.c
+++ b/CBLAS/zcopy.c
@@ -15,7 +15,7 @@
     integer i__1, i__2, i__3;
 
     /* Local variables */
-    static integer i, ix, iy;
+    integer i, ix, iy;
 
 
 /*     copies a vector, x, to a vector, y.   

--- a/CBLAS/zcopy.c
+++ b/CBLAS/zcopy.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3;
+
 
     /* Local variables */
     integer i, ix, iy;
@@ -48,10 +48,7 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = iy;
-	i__3 = ix;
 	ZY(iy).r = ZX(ix).r, ZY(iy).i = ZX(ix).i;
 	ix += *incx;
 	iy += *incy;
@@ -62,10 +59,7 @@
 /*        code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = i;
-	i__3 = i;
 	ZY(i).r = ZX(i).r, ZY(i).i = ZX(i).i;
 /* L30: */
     }

--- a/CBLAS/zdotc.c
+++ b/CBLAS/zdotc.c
@@ -9,7 +9,7 @@
 	doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2;
+ 
     doublecomplex z__1, z__2, z__3;
 
     /* Builtin functions */
@@ -51,10 +51,8 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	d_cnjg(&z__3, &zx[ix]);
-	i__2 = iy;
 	z__2.r = z__3.r * zy[iy].r - z__3.i * zy[iy].i, z__2.i = z__3.r * 
 		zy[iy].i + z__3.i * zy[iy].r;
 	z__1.r = ztemp.r + z__2.r, z__1.i = ztemp.i + z__2.i;
@@ -69,10 +67,8 @@
 /*        code for both increments equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
 	d_cnjg(&z__3, &zx[i]);
-	i__2 = i;
 	z__2.r = z__3.r * zy[i].r - z__3.i * zy[i].i, z__2.i = z__3.r * 
 		zy[i].i + z__3.i * zy[i].r;
 	z__1.r = ztemp.r + z__2.r, z__1.i = ztemp.i + z__2.i;

--- a/CBLAS/zdotc.c
+++ b/CBLAS/zdotc.c
@@ -16,9 +16,9 @@
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer i;
-    static doublecomplex ztemp;
-    static integer ix, iy;
+    integer i;
+    doublecomplex ztemp;
+    integer ix, iy;
 
 
 /*     forms the dot product of a vector.   

--- a/CBLAS/zgemv.c
+++ b/CBLAS/zgemv.c
@@ -14,7 +14,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     doublecomplex z__1, z__2, z__3;
 
     /* Builtin functions */
@@ -192,17 +192,12 @@
     if (beta->r != 1. || beta->i != 0.) {
 	if (*incy == 1) {
 	    if (beta->r == 0. && beta->i == 0.) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = i;
 		    Y(i).r = 0., Y(i).i = 0.;
 /* L10: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = i;
-		    i__3 = i;
 		    z__1.r = beta->r * Y(i).r - beta->i * Y(i).i, 
 			    z__1.i = beta->r * Y(i).i + beta->i * Y(i)
 			    .r;
@@ -213,18 +208,13 @@
 	} else {
 	    iy = ky;
 	    if (beta->r == 0. && beta->i == 0.) {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = iy;
 		    Y(iy).r = 0., Y(iy).i = 0.;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = leny;
 		for (i = 1; i <= leny; ++i) {
-		    i__2 = iy;
-		    i__3 = iy;
 		    z__1.r = beta->r * Y(iy).r - beta->i * Y(iy).i, 
 			    z__1.i = beta->r * Y(iy).i + beta->i * Y(iy)
 			    .r;
@@ -244,20 +234,13 @@
 
 	jx = kx;
 	if (*incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		if (X(jx).r != 0. || X(jx).i != 0.) {
-		    i__2 = jx;
 		    z__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    z__1.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
 		    temp.r = z__1.r, temp.i = z__1.i;
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = i;
-			i__4 = i;
-			i__5 = i + j * a_dim1;
 			z__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				z__2.i = temp.r * A(i,j).i + temp.i * A(i,j)
 				.r;
@@ -271,21 +254,14 @@
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		if (X(jx).r != 0. || X(jx).i != 0.) {
-		    i__2 = jx;
 		    z__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    z__1.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
 		    temp.r = z__1.r, temp.i = z__1.i;
 		    iy = ky;
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = iy;
-			i__4 = iy;
-			i__5 = i + j * a_dim1;
 			z__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				z__2.i = temp.r * A(i,j).i + temp.i * A(i,j)
 				.r;
@@ -307,14 +283,10 @@
 
 	jy = ky;
 	if (*incx == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp.r = 0., temp.i = 0.;
 		if (noconj) {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i;
 			z__2.r = A(i,j).r * X(i).r - A(i,j).i * X(i)
 				.i, z__2.i = A(i,j).r * X(i).i + A(i,j)
 				.i * X(i).r;
@@ -323,10 +295,8 @@
 /* L90: */
 		    }
 		} else {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			d_cnjg(&z__3, &A(i,j));
-			i__3 = i;
 			z__2.r = z__3.r * X(i).r - z__3.i * X(i).i, 
 				z__2.i = z__3.r * X(i).i + z__3.i * X(i)
 				.r;
@@ -335,8 +305,6 @@
 /* L100: */
 		    }
 		}
-		i__2 = jy;
-		i__3 = jy;
 		z__2.r = alpha->r * temp.r - alpha->i * temp.i, z__2.i = 
 			alpha->r * temp.i + alpha->i * temp.r;
 		z__1.r = Y(jy).r + z__2.r, z__1.i = Y(jy).i + z__2.i;
@@ -345,15 +313,11 @@
 /* L110: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
 		temp.r = 0., temp.i = 0.;
 		ix = kx;
 		if (noconj) {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = ix;
 			z__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(ix)
 				.i, z__2.i = A(i,j).r * X(ix).i + A(i,j)
 				.i * X(ix).r;
@@ -363,10 +327,8 @@
 /* L120: */
 		    }
 		} else {
-		    i__2 = *m;
 		    for (i = 1; i <= *m; ++i) {
 			d_cnjg(&z__3, &A(i,j));
-			i__3 = ix;
 			z__2.r = z__3.r * X(ix).r - z__3.i * X(ix).i, 
 				z__2.i = z__3.r * X(ix).i + z__3.i * X(ix)
 				.r;
@@ -376,8 +338,6 @@
 /* L130: */
 		    }
 		}
-		i__2 = jy;
-		i__3 = jy;
 		z__2.r = alpha->r * temp.r - alpha->i * temp.i, z__2.i = 
 			alpha->r * temp.i + alpha->i * temp.r;
 		z__1.r = Y(jy).r + z__2.r, z__1.i = Y(jy).i + z__2.i;

--- a/CBLAS/zgemv.c
+++ b/CBLAS/zgemv.c
@@ -21,11 +21,11 @@
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer info;
-    static doublecomplex temp;
-    static integer lenx, leny, i, j;
-    static integer ix, iy, jx, jy, kx, ky;
-    static logical noconj;
+    integer info;
+    doublecomplex temp;
+    integer lenx, leny, i, j;
+    integer ix, iy, jx, jy, kx, ky;
+    logical noconj;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/zgerc.c
+++ b/CBLAS/zgerc.c
@@ -20,9 +20,9 @@
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer info;
-    static doublecomplex temp;
-    static integer i, j, ix, jy, kx;
+    integer info;
+    doublecomplex temp;
+    integer i, j, ix, jy, kx;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/zgerc.c
+++ b/CBLAS/zgerc.c
@@ -13,7 +13,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     doublecomplex z__1, z__2;
 
     /* Builtin functions */
@@ -143,19 +143,13 @@
 	jy = 1 - (*n - 1) * *incy;
     }
     if (*incx == 1) {
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
-	    i__2 = jy;
 	    if (Y(jy).r != 0. || Y(jy).i != 0.) {
 		d_cnjg(&z__2, &Y(jy));
 		z__1.r = alpha->r * z__2.r - alpha->i * z__2.i, z__1.i = 
 			alpha->r * z__2.i + alpha->i * z__2.r;
 		temp.r = z__1.r, temp.i = z__1.i;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
-		    i__3 = i + j * a_dim1;
-		    i__4 = i + j * a_dim1;
-		    i__5 = i;
 		    z__2.r = X(i).r * temp.r - X(i).i * temp.i, z__2.i =
 			     X(i).r * temp.i + X(i).i * temp.r;
 		    z__1.r = A(i,j).r + z__2.r, z__1.i = A(i,j).i + z__2.i;
@@ -172,20 +166,14 @@
 	} else {
 	    kx = 1 - (*m - 1) * *incx;
 	}
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
-	    i__2 = jy;
 	    if (Y(jy).r != 0. || Y(jy).i != 0.) {
 		d_cnjg(&z__2, &Y(jy));
 		z__1.r = alpha->r * z__2.r - alpha->i * z__2.i, z__1.i = 
 			alpha->r * z__2.i + alpha->i * z__2.r;
 		temp.r = z__1.r, temp.i = z__1.i;
 		ix = kx;
-		i__2 = *m;
 		for (i = 1; i <= *m; ++i) {
-		    i__3 = i + j * a_dim1;
-		    i__4 = i + j * a_dim1;
-		    i__5 = ix;
 		    z__2.r = X(ix).r * temp.r - X(ix).i * temp.i, z__2.i =
 			     X(ix).r * temp.i + X(ix).i * temp.r;
 		    z__1.r = A(i,j).r + z__2.r, z__1.i = A(i,j).i + z__2.i;

--- a/CBLAS/zhemv.c
+++ b/CBLAS/zhemv.c
@@ -13,7 +13,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4;
 
@@ -177,17 +177,12 @@
     if (beta->r != 1. || beta->i != 0.) {
 	if (*incy == 1) {
 	    if (beta->r == 0. && beta->i == 0.) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
 		    Y(i).r = 0., Y(i).i = 0.;
 /* L10: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
-		    i__3 = i;
 		    z__1.r = beta->r * Y(i).r - beta->i * Y(i).i, 
 			    z__1.i = beta->r * Y(i).i + beta->i * Y(i)
 			    .r;
@@ -198,18 +193,13 @@
 	} else {
 	    iy = ky;
 	    if (beta->r == 0. && beta->i == 0.) {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
 		    Y(iy).r = 0., Y(iy).i = 0.;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = *n;
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
-		    i__3 = iy;
 		    z__1.r = beta->r * Y(iy).r - beta->i * Y(iy).i, 
 			    z__1.i = beta->r * Y(iy).i + beta->i * Y(iy)
 			    .r;
@@ -228,34 +218,24 @@
 /*        Form  y  when A is stored in upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
 		z__1.r = alpha->r * X(j).r - alpha->i * X(j).i, z__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(i).r + z__2.r, z__1.i = Y(i).i + z__2.i;
 		    Y(i).r = z__1.r, Y(i).i = z__1.i;
 		    d_cnjg(&z__3, &A(i,j));
-		    i__3 = i;
 		    z__2.r = z__3.r * X(i).r - z__3.i * X(i).i, z__2.i =
 			     z__3.r * X(i).i + z__3.i * X(i).r;
 		    z__1.r = temp2.r + z__2.r, z__1.i = temp2.i + z__2.i;
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 /* L50: */
 		}
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		z__3.r = d__1 * temp1.r, z__3.i = d__1 * temp1.i;
 		z__2.r = Y(j).r + z__3.r, z__2.i = Y(j).i + z__3.i;
@@ -268,27 +248,20 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		z__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, z__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
 		ix = kx;
 		iy = ky;
-		i__2 = j - 1;
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(iy).r + z__2.r, z__1.i = Y(iy).i + z__2.i;
 		    Y(iy).r = z__1.r, Y(iy).i = z__1.i;
 		    d_cnjg(&z__3, &A(i,j));
-		    i__3 = ix;
 		    z__2.r = z__3.r * X(ix).r - z__3.i * X(ix).i, z__2.i =
 			     z__3.r * X(ix).i + z__3.i * X(ix).r;
 		    z__1.r = temp2.r + z__2.r, z__1.i = temp2.i + z__2.i;
@@ -297,9 +270,6 @@
 		    iy += *incy;
 /* L70: */
 		}
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		z__3.r = d__1 * temp1.r, z__3.i = d__1 * temp1.i;
 		z__2.r = Y(jy).r + z__3.r, z__2.i = Y(jy).i + z__3.i;
@@ -317,40 +287,28 @@
 /*        Form  y  when A is stored in lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
 		z__1.r = alpha->r * X(j).r - alpha->i * X(j).i, z__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		z__2.r = d__1 * temp1.r, z__2.i = d__1 * temp1.i;
 		z__1.r = Y(j).r + z__2.r, z__1.i = Y(j).i + z__2.i;
 		Y(j).r = z__1.r, Y(j).i = z__1.i;
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(i).r + z__2.r, z__1.i = Y(i).i + z__2.i;
 		    Y(i).r = z__1.r, Y(i).i = z__1.i;
 		    d_cnjg(&z__3, &A(i,j));
-		    i__3 = i;
 		    z__2.r = z__3.r * X(i).r - z__3.i * X(i).i, z__2.i =
 			     z__3.r * X(i).i + z__3.i * X(i).r;
 		    z__1.r = temp2.r + z__2.r, z__1.i = temp2.i + z__2.i;
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 /* L90: */
 		}
-		i__2 = j;
-		i__3 = j;
 		z__2.r = alpha->r * temp2.r - alpha->i * temp2.i, z__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		z__1.r = Y(j).r + z__2.r, z__1.i = Y(j).i + z__2.i;
@@ -360,44 +318,32 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		z__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, z__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
 		d__1 = A(j,j).r;
 		z__2.r = d__1 * temp1.r, z__2.i = d__1 * temp1.i;
 		z__1.r = Y(jy).r + z__2.r, z__1.i = Y(jy).i + z__2.i;
 		Y(jy).r = z__1.r, Y(jy).i = z__1.i;
 		ix = jx;
 		iy = jy;
-		i__2 = *n;
 		for (i = j + 1; i <= *n; ++i) {
 		    ix += *incx;
 		    iy += *incy;
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(iy).r + z__2.r, z__1.i = Y(iy).i + z__2.i;
 		    Y(iy).r = z__1.r, Y(iy).i = z__1.i;
 		    d_cnjg(&z__3, &A(i,j));
-		    i__3 = ix;
 		    z__2.r = z__3.r * X(ix).r - z__3.i * X(ix).i, z__2.i =
 			     z__3.r * X(ix).i + z__3.i * X(ix).r;
 		    z__1.r = temp2.r + z__2.r, z__1.i = temp2.i + z__2.i;
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 /* L110: */
 		}
-		i__2 = jy;
-		i__3 = jy;
 		z__2.r = alpha->r * temp2.r - alpha->i * temp2.i, z__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		z__1.r = Y(jy).r + z__2.r, z__1.i = Y(jy).i + z__2.i;

--- a/CBLAS/zhemv.c
+++ b/CBLAS/zhemv.c
@@ -21,10 +21,10 @@
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer info;
-    static doublecomplex temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    doublecomplex temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/zher2.c
+++ b/CBLAS/zher2.c
@@ -13,7 +13,7 @@
 
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4;
 
@@ -185,33 +185,24 @@
 /*        Form  A  when A is stored in the upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
-		i__3 = j;
 		if (X(j).r != 0. || X(j).i != 0. || (Y(j).r != 0. || 
 			Y(j).i != 0.)) {
 		    d_cnjg(&z__2, &Y(j));
 		    z__1.r = alpha->r * z__2.r - alpha->i * z__2.i, z__1.i = 
 			    alpha->r * z__2.i + alpha->i * z__2.r;
 		    temp1.r = z__1.r, temp1.i = z__1.i;
-		    i__2 = j;
 		    z__2.r = alpha->r * X(j).r - alpha->i * X(j).i, 
 			    z__2.i = alpha->r * X(j).i + alpha->i * X(j)
 			    .r;
 		    d_cnjg(&z__1, &z__2);
 		    temp2.r = z__1.r, temp2.i = z__1.i;
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = i;
 			z__3.r = X(i).r * temp1.r - X(i).i * temp1.i, 
 				z__3.i = X(i).r * temp1.i + X(i).i * 
 				temp1.r;
 			z__2.r = A(i,j).r + z__3.r, z__2.i = A(i,j).i + 
 				z__3.i;
-			i__6 = i;
 			z__4.r = Y(i).r * temp2.r - Y(i).i * temp2.i, 
 				z__4.i = Y(i).r * temp2.i + Y(i).i * 
 				temp2.r;
@@ -219,13 +210,9 @@
 			A(i,j).r = z__1.r, A(i,j).i = z__1.i;
 /* L10: */
 		    }
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = j;
 		    z__2.r = X(j).r * temp1.r - X(j).i * temp1.i, 
 			    z__2.i = X(j).r * temp1.i + X(j).i * 
 			    temp1.r;
-		    i__5 = j;
 		    z__3.r = Y(j).r * temp2.r - Y(j).i * temp2.i, 
 			    z__3.i = Y(j).r * temp2.i + Y(j).i * 
 			    temp2.r;
@@ -233,25 +220,19 @@
 		    d__1 = A(j,j).r + z__1.r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		}
 /* L20: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
-		i__3 = jy;
 		if (X(jx).r != 0. || X(jx).i != 0. || (Y(jy).r != 0. || 
 			Y(jy).i != 0.)) {
 		    d_cnjg(&z__2, &Y(jy));
 		    z__1.r = alpha->r * z__2.r - alpha->i * z__2.i, z__1.i = 
 			    alpha->r * z__2.i + alpha->i * z__2.r;
 		    temp1.r = z__1.r, temp1.i = z__1.i;
-		    i__2 = jx;
 		    z__2.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    z__2.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
@@ -259,17 +240,12 @@
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 		    ix = kx;
 		    iy = ky;
-		    i__2 = j - 1;
 		    for (i = 1; i <= j-1; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = ix;
 			z__3.r = X(ix).r * temp1.r - X(ix).i * temp1.i, 
 				z__3.i = X(ix).r * temp1.i + X(ix).i * 
 				temp1.r;
 			z__2.r = A(i,j).r + z__3.r, z__2.i = A(i,j).i + 
 				z__3.i;
-			i__6 = iy;
 			z__4.r = Y(iy).r * temp2.r - Y(iy).i * temp2.i, 
 				z__4.i = Y(iy).r * temp2.i + Y(iy).i * 
 				temp2.r;
@@ -279,13 +255,9 @@
 			iy += *incy;
 /* L30: */
 		    }
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = jx;
 		    z__2.r = X(jx).r * temp1.r - X(jx).i * temp1.i, 
 			    z__2.i = X(jx).r * temp1.i + X(jx).i * 
 			    temp1.r;
-		    i__5 = jy;
 		    z__3.r = Y(jy).r * temp2.r - Y(jy).i * temp2.i, 
 			    z__3.i = Y(jy).r * temp2.i + Y(jy).i * 
 			    temp2.r;
@@ -293,8 +265,6 @@
 		    d__1 = A(j,j).r + z__1.r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		}
@@ -308,46 +278,33 @@
 /*        Form  A  when A is stored in the lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
-		i__3 = j;
 		if (X(j).r != 0. || X(j).i != 0. || (Y(j).r != 0. || 
 			Y(j).i != 0.)) {
 		    d_cnjg(&z__2, &Y(j));
 		    z__1.r = alpha->r * z__2.r - alpha->i * z__2.i, z__1.i = 
 			    alpha->r * z__2.i + alpha->i * z__2.r;
 		    temp1.r = z__1.r, temp1.i = z__1.i;
-		    i__2 = j;
 		    z__2.r = alpha->r * X(j).r - alpha->i * X(j).i, 
 			    z__2.i = alpha->r * X(j).i + alpha->i * X(j)
 			    .r;
 		    d_cnjg(&z__1, &z__2);
 		    temp2.r = z__1.r, temp2.i = z__1.i;
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = j;
 		    z__2.r = X(j).r * temp1.r - X(j).i * temp1.i, 
 			    z__2.i = X(j).r * temp1.i + X(j).i * 
 			    temp1.r;
-		    i__5 = j;
 		    z__3.r = Y(j).r * temp2.r - Y(j).i * temp2.i, 
 			    z__3.i = Y(j).r * temp2.i + Y(j).i * 
 			    temp2.r;
 		    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
 		    d__1 = A(j,j).r + z__1.r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
-		    i__2 = *n;
 		    for (i = j + 1; i <= *n; ++i) {
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = i;
 			z__3.r = X(i).r * temp1.r - X(i).i * temp1.i, 
 				z__3.i = X(i).r * temp1.i + X(i).i * 
 				temp1.r;
 			z__2.r = A(i,j).r + z__3.r, z__2.i = A(i,j).i + 
 				z__3.i;
-			i__6 = i;
 			z__4.r = Y(i).r * temp2.r - Y(i).i * temp2.i, 
 				z__4.i = Y(i).r * temp2.i + Y(i).i * 
 				temp2.r;
@@ -356,37 +313,27 @@
 /* L50: */
 		    }
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		}
 /* L60: */
 	    }
 	} else {
-	    i__1 = *n;
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
-		i__3 = jy;
 		if (X(jx).r != 0. || X(jx).i != 0. || (Y(jy).r != 0. || 
 			Y(jy).i != 0.)) {
 		    d_cnjg(&z__2, &Y(jy));
 		    z__1.r = alpha->r * z__2.r - alpha->i * z__2.i, z__1.i = 
 			    alpha->r * z__2.i + alpha->i * z__2.r;
 		    temp1.r = z__1.r, temp1.i = z__1.i;
-		    i__2 = jx;
 		    z__2.r = alpha->r * X(jx).r - alpha->i * X(jx).i, 
 			    z__2.i = alpha->r * X(jx).i + alpha->i * X(jx)
 			    .r;
 		    d_cnjg(&z__1, &z__2);
 		    temp2.r = z__1.r, temp2.i = z__1.i;
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
-		    i__4 = jx;
 		    z__2.r = X(jx).r * temp1.r - X(jx).i * temp1.i, 
 			    z__2.i = X(jx).r * temp1.i + X(jx).i * 
 			    temp1.r;
-		    i__5 = jy;
 		    z__3.r = Y(jy).r * temp2.r - Y(jy).i * temp2.i, 
 			    z__3.i = Y(jy).r * temp2.i + Y(jy).i * 
 			    temp2.r;
@@ -395,19 +342,14 @@
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		    ix = jx;
 		    iy = jy;
-		    i__2 = *n;
 		    for (i = j + 1; i <= *n; ++i) {
 			ix += *incx;
 			iy += *incy;
-			i__3 = i + j * a_dim1;
-			i__4 = i + j * a_dim1;
-			i__5 = ix;
 			z__3.r = X(ix).r * temp1.r - X(ix).i * temp1.i, 
 				z__3.i = X(ix).r * temp1.i + X(ix).i * 
 				temp1.r;
 			z__2.r = A(i,j).r + z__3.r, z__2.i = A(i,j).i + 
 				z__3.i;
-			i__6 = iy;
 			z__4.r = Y(iy).r * temp2.r - Y(iy).i * temp2.i, 
 				z__4.i = Y(iy).r * temp2.i + Y(iy).i * 
 				temp2.r;
@@ -416,8 +358,6 @@
 /* L70: */
 		    }
 		} else {
-		    i__2 = j + j * a_dim1;
-		    i__3 = j + j * a_dim1;
 		    d__1 = A(j,j).r;
 		    A(j,j).r = d__1, A(j,j).i = 0.;
 		}

--- a/CBLAS/zher2.c
+++ b/CBLAS/zher2.c
@@ -21,10 +21,10 @@
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer info;
-    static doublecomplex temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    integer info;
+    doublecomplex temp1, temp2;
+    integer i, j;
+    integer ix, iy, jx, jy, kx, ky;
 
     extern int input_error(char *, int *);
 

--- a/CBLAS/zscal.c
+++ b/CBLAS/zscal.c
@@ -12,7 +12,7 @@
 
 
     /* System generated locals */
-    integer i__1, i__2, i__3;
+
     doublecomplex z__1;
 
     /* Local variables */
@@ -41,10 +41,7 @@
 /*        code for increment not equal to 1 */
 
     ix = 1;
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = ix;
-	i__3 = ix;
 	z__1.r = za->r * ZX(ix).r - za->i * ZX(ix).i, z__1.i = za->r * ZX(
 		ix).i + za->i * ZX(ix).r;
 	ZX(ix).r = z__1.r, ZX(ix).i = z__1.i;
@@ -56,10 +53,7 @@
 /*        code for increment equal to 1 */
 
 L20:
-    i__1 = *n;
     for (i = 1; i <= *n; ++i) {
-	i__2 = i;
-	i__3 = i;
 	z__1.r = za->r * ZX(i).r - za->i * ZX(i).i, z__1.i = za->r * ZX(
 		i).i + za->i * ZX(i).r;
 	ZX(i).r = z__1.r, ZX(i).i = z__1.i;

--- a/CBLAS/zscal.c
+++ b/CBLAS/zscal.c
@@ -16,7 +16,7 @@
     doublecomplex z__1;
 
     /* Local variables */
-    static integer i, ix;
+    integer i, ix;
 
 
 /*     scales a vector by a constant.   

--- a/CBLAS/zswap.c
+++ b/CBLAS/zswap.c
@@ -5,7 +5,7 @@
 	doublecomplex *zy, integer *incy)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3;
+    
 
     /* Local variables */
     integer i__, ix, iy;
@@ -49,15 +49,10 @@
     if (*incy < 0) {
 	iy = (-(*n) + 1) * *incy + 1;
     }
-    i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
-	i__2 = ix;
-	ztemp.r = zx[i__2].r, ztemp.i = zx[i__2].i;
-	i__2 = ix;
-	i__3 = iy;
-	zx[i__2].r = zy[i__3].r, zx[i__2].i = zy[i__3].i;
-	i__2 = iy;
-	zy[i__2].r = ztemp.r, zy[i__2].i = ztemp.i;
+    for (i__ = 1; i__ <= *n; ++i__) {
+	ztemp.r = zx[ix].r, ztemp.i = zx[ix].i;
+	zx[ix].r = zy[iy].r, zx[ix].i = zy[iy].i;
+	zy[iy].r = ztemp.r, zy[iy].i = ztemp.i;
 	ix += *incx;
 	iy += *incy;
 /* L10: */
@@ -66,15 +61,10 @@
 
 /*       code for both increments equal to 1 */
 L20:
-    i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
-	i__2 = i__;
-	ztemp.r = zx[i__2].r, ztemp.i = zx[i__2].i;
-	i__2 = i__;
-	i__3 = i__;
-	zx[i__2].r = zy[i__3].r, zx[i__2].i = zy[i__3].i;
-	i__2 = i__;
-	zy[i__2].r = ztemp.r, zy[i__2].i = ztemp.i;
+    for (i__ = 1; i__ <= *n; ++i__) {
+	ztemp.r = zx[i__].r, ztemp.i = zx[i__].i;
+	zx[i__].r = zy[i__].r, zx[i__].i = zy[i__].i;
+	zy[i__].r = ztemp.r, zy[i__].i = ztemp.i;
 /* L30: */
     }
     return 0;

--- a/CBLAS/ztrsv.c
+++ b/CBLAS/ztrsv.c
@@ -11,7 +11,7 @@
 {
 
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     doublecomplex z__1, z__2, z__3;
 
     /* Builtin functions */
@@ -186,19 +186,13 @@
 	if (strncmp(uplo, "U", 1)==0) {
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
-		    i__1 = j;
 		    if (X(j).r != 0. || X(j).i != 0.) {
 			if (nounit) {
-			    i__1 = j;
 			    z_div(&z__1, &X(j), &A(j,j));
 			    X(j).r = z__1.r, X(j).i = z__1.i;
 			}
-			i__1 = j;
 			temp.r = X(j).r, temp.i = X(j).i;
 			for (i = j - 1; i >= 1; --i) {
-			    i__1 = i;
-			    i__2 = i;
-			    i__3 = i + j * a_dim1;
 			    z__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    z__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    z__1.r = X(i).r - z__2.r, z__1.i = X(i).i - 
@@ -212,21 +206,15 @@
 	    } else {
 		jx = kx + (*n - 1) * *incx;
 		for (j = *n; j >= 1; --j) {
-		    i__1 = jx;
 		    if (X(jx).r != 0. || X(jx).i != 0.) {
 			if (nounit) {
-			    i__1 = jx;
 			    z_div(&z__1, &X(jx), &A(j,j));
 			    X(jx).r = z__1.r, X(jx).i = z__1.i;
 			}
-			i__1 = jx;
 			temp.r = X(jx).r, temp.i = X(jx).i;
 			ix = jx;
 			for (i = j - 1; i >= 1; --i) {
 			    ix -= *incx;
-			    i__1 = ix;
-			    i__2 = ix;
-			    i__3 = i + j * a_dim1;
 			    z__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    z__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    z__1.r = X(ix).r - z__2.r, z__1.i = X(ix).i - 
@@ -241,22 +229,14 @@
 	    }
 	} else {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
-		    i__2 = j;
 		    if (X(j).r != 0. || X(j).i != 0.) {
 			if (nounit) {
-			    i__2 = j;
 			    z_div(&z__1, &X(j), &A(j,j));
 			    X(j).r = z__1.r, X(j).i = z__1.i;
 			}
-			i__2 = j;
 			temp.r = X(j).r, temp.i = X(j).i;
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
-			    i__3 = i;
-			    i__4 = i;
-			    i__5 = i + j * a_dim1;
 			    z__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    z__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    z__1.r = X(i).r - z__2.r, z__1.i = X(i).i - 
@@ -269,24 +249,16 @@
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
-		    i__2 = jx;
 		    if (X(jx).r != 0. || X(jx).i != 0.) {
 			if (nounit) {
-			    i__2 = jx;
 			    z_div(&z__1, &X(jx), &A(j,j));
 			    X(jx).r = z__1.r, X(jx).i = z__1.i;
 			}
-			i__2 = jx;
 			temp.r = X(jx).r, temp.i = X(jx).i;
 			ix = jx;
-			i__2 = *n;
 			for (i = j + 1; i <= *n; ++i) {
 			    ix += *incx;
-			    i__3 = ix;
-			    i__4 = ix;
-			    i__5 = i + j * a_dim1;
 			    z__2.r = temp.r * A(i,j).r - temp.i * A(i,j).i, 
 				    z__2.i = temp.r * A(i,j).i + temp.i * A(i,j).r;
 			    z__1.r = X(ix).r - z__2.r, z__1.i = X(ix).i - 
@@ -306,15 +278,10 @@
 
 	if (strncmp(uplo, "U", 1)==0) {
 	    if (*incx == 1) {
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
-		    i__2 = j;
 		    temp.r = X(j).r, temp.i = X(j).i;
 		    if (noconj) {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
-			    i__3 = i + j * a_dim1;
-			    i__4 = i;
 			    z__2.r = A(i,j).r * X(i).r - A(i,j).i * X(
 				    i).i, z__2.i = A(i,j).r * X(i).i + 
 				    A(i,j).i * X(i).r;
@@ -328,10 +295,8 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    } else {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
 			    d_cnjg(&z__3, &A(i,j));
-			    i__3 = i;
 			    z__2.r = z__3.r * X(i).r - z__3.i * X(i).i, 
 				    z__2.i = z__3.r * X(i).i + z__3.i * X(
 				    i).r;
@@ -346,22 +311,16 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    }
-		    i__2 = j;
 		    X(j).r = temp.r, X(j).i = temp.i;
 /* L110: */
 		}
 	    } else {
 		jx = kx;
-		i__1 = *n;
 		for (j = 1; j <= *n; ++j) {
 		    ix = kx;
-		    i__2 = jx;
 		    temp.r = X(jx).r, temp.i = X(jx).i;
 		    if (noconj) {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
-			    i__3 = i + j * a_dim1;
-			    i__4 = ix;
 			    z__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(
 				    ix).i, z__2.i = A(i,j).r * X(ix).i + 
 				    A(i,j).i * X(ix).r;
@@ -376,10 +335,8 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    } else {
-			i__2 = j - 1;
 			for (i = 1; i <= j-1; ++i) {
 			    d_cnjg(&z__3, &A(i,j));
-			    i__3 = ix;
 			    z__2.r = z__3.r * X(ix).r - z__3.i * X(ix).i, 
 				    z__2.i = z__3.r * X(ix).i + z__3.i * X(
 				    ix).r;
@@ -395,7 +352,6 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    }
-		    i__2 = jx;
 		    X(jx).r = temp.r, X(jx).i = temp.i;
 		    jx += *incx;
 /* L140: */
@@ -404,13 +360,9 @@
 	} else {
 	    if (*incx == 1) {
 		for (j = *n; j >= 1; --j) {
-		    i__1 = j;
 		    temp.r = X(j).r, temp.i = X(j).i;
 		    if (noconj) {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
-			    i__2 = i + j * a_dim1;
-			    i__3 = i;
 			    z__2.r = A(i,j).r * X(i).r - A(i,j).i * X(
 				    i).i, z__2.i = A(i,j).r * X(i).i + 
 				    A(i,j).i * X(i).r;
@@ -424,10 +376,8 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    } else {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
 			    d_cnjg(&z__3, &A(i,j));
-			    i__2 = i;
 			    z__2.r = z__3.r * X(i).r - z__3.i * X(i).i, 
 				    z__2.i = z__3.r * X(i).i + z__3.i * X(
 				    i).r;
@@ -442,7 +392,6 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    }
-		    i__1 = j;
 		    X(j).r = temp.r, X(j).i = temp.i;
 /* L170: */
 		}
@@ -451,13 +400,9 @@
 		jx = kx;
 		for (j = *n; j >= 1; --j) {
 		    ix = kx;
-		    i__1 = jx;
 		    temp.r = X(jx).r, temp.i = X(jx).i;
 		    if (noconj) {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
-			    i__2 = i + j * a_dim1;
-			    i__3 = ix;
 			    z__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(
 				    ix).i, z__2.i = A(i,j).r * X(ix).i + 
 				    A(i,j).i * X(ix).r;
@@ -472,10 +417,8 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    } else {
-			i__1 = j + 1;
 			for (i = *n; i >= j+1; --i) {
 			    d_cnjg(&z__3, &A(i,j));
-			    i__2 = ix;
 			    z__2.r = z__3.r * X(ix).r - z__3.i * X(ix).i, 
 				    z__2.i = z__3.r * X(ix).i + z__3.i * X(
 				    ix).r;
@@ -491,7 +434,6 @@
 			    temp.r = z__1.r, temp.i = z__1.i;
 			}
 		    }
-		    i__1 = jx;
 		    X(jx).r = temp.r, X(jx).i = temp.i;
 		    jx -= *incx;
 /* L200: */

--- a/CBLAS/ztrsv.c
+++ b/CBLAS/ztrsv.c
@@ -19,11 +19,11 @@
 	    doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer info;
-    static doublecomplex temp;
-    static integer i, j;
-    static integer ix, jx, kx;
-    static logical noconj, nounit;
+    integer info;
+    doublecomplex temp;
+    integer i, j;
+    integer ix, jx, kx;
+    logical noconj, nounit;
 
     extern int input_error(char *, int *);
 

--- a/EXAMPLE/clinsolx.c
+++ b/EXAMPLE/clinsolx.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     complex         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/clinsolx1.c
+++ b/EXAMPLE/clinsolx1.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     complex         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/clinsolx2.c
+++ b/EXAMPLE/clinsolx2.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     complex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/clinsolx3.c
+++ b/EXAMPLE/clinsolx3.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     complex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx.c
+++ b/EXAMPLE/dlinsolx.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     double         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx1.c
+++ b/EXAMPLE/dlinsolx1.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     double         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx2.c
+++ b/EXAMPLE/dlinsolx2.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     double         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx3.c
+++ b/EXAMPLE/dlinsolx3.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     double         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/slinsolx.c
+++ b/EXAMPLE/slinsolx.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     float         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/slinsolx1.c
+++ b/EXAMPLE/slinsolx1.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     float         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/slinsolx2.c
+++ b/EXAMPLE/slinsolx2.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     float         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/slinsolx3.c
+++ b/EXAMPLE/slinsolx3.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     float         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx.c
+++ b/EXAMPLE/zlinsolx.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     doublecomplex         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx1.c
+++ b/EXAMPLE/zlinsolx1.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, m, n, nnz;
     doublecomplex         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx2.c
+++ b/EXAMPLE/zlinsolx2.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     doublecomplex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx3.c
+++ b/EXAMPLE/zlinsolx3.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, ldx;
     int            i, j, m, n, nnz;
     doublecomplex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/TESTING/MATGEN/claset.c
+++ b/TESTING/MATGEN/claset.c
@@ -57,7 +57,7 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+
     /* Local variables */
     static integer i, j;
 
@@ -65,71 +65,52 @@
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]
 
     if (strncmp(uplo, "U", 1)==0) {
-
 /*        Set the diagonal to BETA and the strictly upper triangular 
   
           part of the array to ALPHA. */
-
-	i__1 = *n;
 	for (j = 2; j <= *n; ++j) {
 /* Computing MIN */
-	    i__3 = j - 1;
-	    i__2 = min(i__3,*m);
 	    for (i = 1; i <= min(j-1,*m); ++i) {
-		i__3 = i + j * a_dim1;
 		A(i,j).r = alpha->r, A(i,j).i = alpha->i;
 /* L10: */
 	    }
 /* L20: */
 	}
-	i__1 = min(*n,*m);
+
 	for (i = 1; i <= min(*n,*m); ++i) {
-	    i__2 = i + i * a_dim1;
 	    A(i,i).r = beta->r, A(i,i).i = beta->i;
 /* L30: */
 	}
-
     } else if (strncmp(uplo, "L", 1)==0) {
-
 /*        Set the diagonal to BETA and the strictly lower triangular 
   
           part of the array to ALPHA. */
-
-	i__1 = min(*m,*n);
 	for (j = 1; j <= min(*m,*n); ++j) {
-	    i__2 = *m;
+
 	    for (i = j + 1; i <= *m; ++i) {
-		i__3 = i + j * a_dim1;
 		A(i,j).r = alpha->r, A(i,j).i = alpha->i;
 /* L40: */
 	    }
 /* L50: */
 	}
-	i__1 = min(*n,*m);
+
 	for (i = 1; i <= min(*n,*m); ++i) {
-	    i__2 = i + i * a_dim1;
 	    A(i,i).r = beta->r, A(i,i).i = beta->i;
 /* L60: */
 	}
-
     } else {
-
 /*        Set the array to BETA on the diagonal and ALPHA on the   
           offdiagonal. */
-
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
-	    i__2 = *m;
+
 	    for (i = 1; i <= *m; ++i) {
-		i__3 = i + j * a_dim1;
 		A(i,j).r = alpha->r, A(i,j).i = alpha->i;
 /* L70: */
 	    }
 /* L80: */
 	}
-	i__1 = min(*m,*n);
+
 	for (i = 1; i <= min(*m,*n); ++i) {
-	    i__2 = i + i * a_dim1;
 	    A(i,i).r = beta->r, A(i,i).i = beta->i;
 /* L90: */
 	}

--- a/TESTING/MATGEN/csymv.c
+++ b/TESTING/MATGEN/csymv.c
@@ -103,7 +103,7 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     complex q__1, q__2, q__3, q__4;
     /* Local variables */
     static integer info;
@@ -163,17 +163,17 @@
     if (beta->r != 1.f || beta->i != 0.f) {
 	if (*incy == 1) {
 	    if (beta->r == 0.f && beta->i == 0.f) {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
+
 		    Y(i).r = 0.f, Y(i).i = 0.f;
 /* L10: */
 		}
 	    } else {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
-		    i__3 = i;
+
+
 		    q__1.r = beta->r * Y(i).r - beta->i * Y(i).i, 
 			    q__1.i = beta->r * Y(i).i + beta->i * Y(i)
 			    .r;
@@ -184,18 +184,18 @@
 	} else {
 	    iy = ky;
 	    if (beta->r == 0.f && beta->i == 0.f) {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
+
 		    Y(iy).r = 0.f, Y(iy).i = 0.f;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
-		    i__3 = iy;
+
+
 		    q__1.r = beta->r * Y(iy).r - beta->i * Y(iy).i, 
 			    q__1.i = beta->r * Y(iy).i + beta->i * Y(iy)
 			    .r;
@@ -214,25 +214,19 @@
 /*        Form  y  when A is stored in upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
 		q__1.r = alpha->r * X(j).r - alpha->i * X(j).i, q__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
-		i__2 = j - 1;
+
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(i).r + q__2.r, q__1.i = Y(i).i + q__2.i;
 		    Y(i).r = q__1.r, Y(i).i = q__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = i;
 		    q__2.r = A(i,j).r * X(i).r - A(i,j).i * X(i).i, 
 			    q__2.i = A(i,j).r * X(i).i + A(i,j).i * X(
 			    i).r;
@@ -240,9 +234,6 @@
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 /* L50: */
 		}
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
 		q__3.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, q__3.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		q__2.r = Y(j).r + q__3.r, q__2.i = Y(j).i + q__3.i;
@@ -255,27 +246,21 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		q__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, q__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
 		ix = kx;
 		iy = ky;
-		i__2 = j - 1;
+
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(iy).r + q__2.r, q__1.i = Y(iy).i + q__2.i;
 		    Y(iy).r = q__1.r, Y(iy).i = q__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = ix;
 		    q__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(ix).i, 
 			    q__2.i = A(i,j).r * X(ix).i + A(i,j).i * X(
 			    ix).r;
@@ -285,9 +270,6 @@
 		    iy += *incy;
 /* L70: */
 		}
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
 		q__3.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, q__3.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		q__2.r = Y(jy).r + q__3.r, q__2.i = Y(jy).i + q__3.i;
@@ -305,32 +287,23 @@
 /*        Form  y  when A is stored in lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
 		q__1.r = alpha->r * X(j).r - alpha->i * X(j).i, q__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
 		q__2.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, q__2.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		q__1.r = Y(j).r + q__2.r, q__1.i = Y(j).i + q__2.i;
 		Y(j).r = q__1.r, Y(j).i = q__1.i;
-		i__2 = *n;
+
 		for (i = j + 1; i <= *n; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(i).r + q__2.r, q__1.i = Y(i).i + q__2.i;
 		    Y(i).r = q__1.r, Y(i).i = q__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = i;
 		    q__2.r = A(i,j).r * X(i).r - A(i,j).i * X(i).i, 
 			    q__2.i = A(i,j).r * X(i).i + A(i,j).i * X(
 			    i).r;
@@ -338,8 +311,6 @@
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 /* L90: */
 		}
-		i__2 = j;
-		i__3 = j;
 		q__2.r = alpha->r * temp2.r - alpha->i * temp2.i, q__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		q__1.r = Y(j).r + q__2.r, q__1.i = Y(j).i + q__2.i;
@@ -349,36 +320,27 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
 		q__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, q__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = q__1.r, temp1.i = q__1.i;
 		temp2.r = 0.f, temp2.i = 0.f;
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
 		q__2.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, q__2.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		q__1.r = Y(jy).r + q__2.r, q__1.i = Y(jy).i + q__2.i;
 		Y(jy).r = q__1.r, Y(jy).i = q__1.i;
 		ix = jx;
 		iy = jy;
-		i__2 = *n;
+
 		for (i = j + 1; i <= *n; ++i) {
 		    ix += *incx;
 		    iy += *incy;
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
 		    q__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    q__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    q__1.r = Y(iy).r + q__2.r, q__1.i = Y(iy).i + q__2.i;
 		    Y(iy).r = q__1.r, Y(iy).i = q__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = ix;
 		    q__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(ix).i, 
 			    q__2.i = A(i,j).r * X(ix).i + A(i,j).i * X(
 			    ix).r;
@@ -386,8 +348,6 @@
 		    temp2.r = q__1.r, temp2.i = q__1.i;
 /* L110: */
 		}
-		i__2 = jy;
-		i__3 = jy;
 		q__2.r = alpha->r * temp2.r - alpha->i * temp2.i, q__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		q__1.r = Y(jy).r + q__2.r, q__1.i = Y(jy).i + q__2.i;

--- a/TESTING/MATGEN/zlaset.c
+++ b/TESTING/MATGEN/zlaset.c
@@ -58,7 +58,7 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+
     /* Local variables */
     static integer i, j;
 
@@ -66,71 +66,52 @@
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]
 
     if (strncmp(uplo, "U", 1)==0) {
-
 /*        Set the diagonal to BETA and the strictly upper triangular 
   
           part of the array to ALPHA. */
-
-	i__1 = *n;
 	for (j = 2; j <= *n; ++j) {
 /* Computing MIN */
-	    i__3 = j - 1;
-	    i__2 = min(i__3,*m);
 	    for (i = 1; i <= min(j-1,*m); ++i) {
-		i__3 = i + j * a_dim1;
 		A(i,j).r = alpha->r, A(i,j).i = alpha->i;
 /* L10: */
 	    }
 /* L20: */
 	}
-	i__1 = min(*n,*m);
+
 	for (i = 1; i <= min(*n,*m); ++i) {
-	    i__2 = i + i * a_dim1;
 	    A(i,i).r = beta->r, A(i,i).i = beta->i;
 /* L30: */
 	}
-
     } else if (strncmp(uplo, "L", 1)==0) {
-
 /*        Set the diagonal to BETA and the strictly lower triangular 
   
           part of the array to ALPHA. */
-
-	i__1 = min(*m,*n);
 	for (j = 1; j <= min(*m,*n); ++j) {
-	    i__2 = *m;
+
 	    for (i = j + 1; i <= *m; ++i) {
-		i__3 = i + j * a_dim1;
 		A(i,j).r = alpha->r, A(i,j).i = alpha->i;
 /* L40: */
 	    }
 /* L50: */
 	}
-	i__1 = min(*n,*m);
+
 	for (i = 1; i <= min(*n,*m); ++i) {
-	    i__2 = i + i * a_dim1;
 	    A(i,i).r = beta->r, A(i,i).i = beta->i;
 /* L60: */
 	}
-
     } else {
-
 /*        Set the array to BETA on the diagonal and ALPHA on the   
           offdiagonal. */
-
-	i__1 = *n;
 	for (j = 1; j <= *n; ++j) {
-	    i__2 = *m;
+
 	    for (i = 1; i <= *m; ++i) {
-		i__3 = i + j * a_dim1;
 		A(i,j).r = alpha->r, A(i,j).i = alpha->i;
 /* L70: */
 	    }
 /* L80: */
 	}
-	i__1 = min(*m,*n);
+
 	for (i = 1; i <= min(*m,*n); ++i) {
-	    i__2 = i + i * a_dim1;
 	    A(i,i).r = beta->r, A(i,i).i = beta->i;
 /* L90: */
 	}

--- a/TESTING/MATGEN/zsymv.c
+++ b/TESTING/MATGEN/zsymv.c
@@ -103,7 +103,7 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5;
+
     doublecomplex z__1, z__2, z__3, z__4;
     /* Local variables */
     static integer info;
@@ -163,17 +163,17 @@
     if (beta->r != 1. || beta->i != 0.) {
 	if (*incy == 1) {
 	    if (beta->r == 0. && beta->i == 0.) {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
+
 		    Y(i).r = 0., Y(i).i = 0.;
 /* L10: */
 		}
 	    } else {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = i;
-		    i__3 = i;
+
+
 		    z__1.r = beta->r * Y(i).r - beta->i * Y(i).i, 
 			    z__1.i = beta->r * Y(i).i + beta->i * Y(i)
 			    .r;
@@ -184,18 +184,18 @@
 	} else {
 	    iy = ky;
 	    if (beta->r == 0. && beta->i == 0.) {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
+
 		    Y(iy).r = 0., Y(iy).i = 0.;
 		    iy += *incy;
 /* L30: */
 		}
 	    } else {
-		i__1 = *n;
+
 		for (i = 1; i <= *n; ++i) {
-		    i__2 = iy;
-		    i__3 = iy;
+
+
 		    z__1.r = beta->r * Y(iy).r - beta->i * Y(iy).i, 
 			    z__1.i = beta->r * Y(iy).i + beta->i * Y(iy)
 			    .r;
@@ -214,25 +214,25 @@
 /*        Form  y  when A is stored in upper triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
+
 		z__1.r = alpha->r * X(j).r - alpha->i * X(j).i, z__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
-		i__2 = j - 1;
+
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
+
+
+
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(i).r + z__2.r, z__1.i = Y(i).i + z__2.i;
 		    Y(i).r = z__1.r, Y(i).i = z__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = i;
+
+
 		    z__2.r = A(i,j).r * X(i).r - A(i,j).i * X(i).i, 
 			    z__2.i = A(i,j).r * X(i).i + A(i,j).i * X(
 			    i).r;
@@ -240,9 +240,9 @@
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 /* L50: */
 		}
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
+
+
+
 		z__3.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, z__3.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		z__2.r = Y(j).r + z__3.r, z__2.i = Y(j).i + z__3.i;
@@ -255,27 +255,27 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
+
 		z__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, z__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
 		ix = kx;
 		iy = ky;
-		i__2 = j - 1;
+
 		for (i = 1; i <= j-1; ++i) {
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
+
+
+
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(iy).r + z__2.r, z__1.i = Y(iy).i + z__2.i;
 		    Y(iy).r = z__1.r, Y(iy).i = z__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = ix;
+
+
 		    z__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(ix).i, 
 			    z__2.i = A(i,j).r * X(ix).i + A(i,j).i * X(
 			    ix).r;
@@ -285,9 +285,9 @@
 		    iy += *incy;
 /* L70: */
 		}
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
+
+
+
 		z__3.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, z__3.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		z__2.r = Y(jy).r + z__3.r, z__2.i = Y(jy).i + z__3.i;
@@ -305,32 +305,32 @@
 /*        Form  y  when A is stored in lower triangle. */
 
 	if (*incx == 1 && *incy == 1) {
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = j;
+
 		z__1.r = alpha->r * X(j).r - alpha->i * X(j).i, z__1.i =
 			 alpha->r * X(j).i + alpha->i * X(j).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
-		i__2 = j;
-		i__3 = j;
-		i__4 = j + j * a_dim1;
+
+
+
 		z__2.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, z__2.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		z__1.r = Y(j).r + z__2.r, z__1.i = Y(j).i + z__2.i;
 		Y(j).r = z__1.r, Y(j).i = z__1.i;
-		i__2 = *n;
+
 		for (i = j + 1; i <= *n; ++i) {
-		    i__3 = i;
-		    i__4 = i;
-		    i__5 = i + j * a_dim1;
+
+
+
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(i).r + z__2.r, z__1.i = Y(i).i + z__2.i;
 		    Y(i).r = z__1.r, Y(i).i = z__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = i;
+
+
 		    z__2.r = A(i,j).r * X(i).r - A(i,j).i * X(i).i, 
 			    z__2.i = A(i,j).r * X(i).i + A(i,j).i * X(
 			    i).r;
@@ -338,8 +338,8 @@
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 /* L90: */
 		}
-		i__2 = j;
-		i__3 = j;
+
+
 		z__2.r = alpha->r * temp2.r - alpha->i * temp2.i, z__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		z__1.r = Y(j).r + z__2.r, z__1.i = Y(j).i + z__2.i;
@@ -349,36 +349,36 @@
 	} else {
 	    jx = kx;
 	    jy = ky;
-	    i__1 = *n;
+
 	    for (j = 1; j <= *n; ++j) {
-		i__2 = jx;
+
 		z__1.r = alpha->r * X(jx).r - alpha->i * X(jx).i, z__1.i =
 			 alpha->r * X(jx).i + alpha->i * X(jx).r;
 		temp1.r = z__1.r, temp1.i = z__1.i;
 		temp2.r = 0., temp2.i = 0.;
-		i__2 = jy;
-		i__3 = jy;
-		i__4 = j + j * a_dim1;
+
+
+
 		z__2.r = temp1.r * A(j,j).r - temp1.i * A(j,j).i, z__2.i = 
 			temp1.r * A(j,j).i + temp1.i * A(j,j).r;
 		z__1.r = Y(jy).r + z__2.r, z__1.i = Y(jy).i + z__2.i;
 		Y(jy).r = z__1.r, Y(jy).i = z__1.i;
 		ix = jx;
 		iy = jy;
-		i__2 = *n;
+
 		for (i = j + 1; i <= *n; ++i) {
 		    ix += *incx;
 		    iy += *incy;
-		    i__3 = iy;
-		    i__4 = iy;
-		    i__5 = i + j * a_dim1;
+
+
+
 		    z__2.r = temp1.r * A(i,j).r - temp1.i * A(i,j).i, 
 			    z__2.i = temp1.r * A(i,j).i + temp1.i * A(i,j)
 			    .r;
 		    z__1.r = Y(iy).r + z__2.r, z__1.i = Y(iy).i + z__2.i;
 		    Y(iy).r = z__1.r, Y(iy).i = z__1.i;
-		    i__3 = i + j * a_dim1;
-		    i__4 = ix;
+
+
 		    z__2.r = A(i,j).r * X(ix).r - A(i,j).i * X(ix).i, 
 			    z__2.i = A(i,j).r * X(ix).i + A(i,j).i * X(
 			    ix).r;
@@ -386,8 +386,8 @@
 		    temp2.r = z__1.r, temp2.i = z__1.i;
 /* L110: */
 		}
-		i__2 = jy;
-		i__3 = jy;
+
+
 		z__2.r = alpha->r * temp2.r - alpha->i * temp2.i, z__2.i = 
 			alpha->r * temp2.i + alpha->i * temp2.r;
 		z__1.r = Y(jy).r + z__2.r, z__1.i = Y(jy).i + z__2.i;

--- a/TESTING/cdrive.c
+++ b/TESTING/cdrive.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     float         *ferr, *berr;
     float         *rwork;
     complex	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, panel_size, relax;
     int            m, n, nnz;
     complex         *xact;
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     int            zerot, izero, ioff;
     double         u;
     float         anorm, cndnum;
-    complex         *Afull;
+    complex         *Afull = NULL;
     float         result[NTESTS];
     superlu_options_t options;
     fact_t         fact;

--- a/TESTING/ddrive.c
+++ b/TESTING/ddrive.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     double         *ferr, *berr;
     double         *rwork;
     double	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, panel_size, relax;
     int            m, n, nnz;
     double         *xact;
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     int            zerot, izero, ioff;
     double         u;
     double         anorm, cndnum;
-    double         *Afull;
+    double         *Afull = NULL;
     double         result[NTESTS];
     superlu_options_t options;
     fact_t         fact;

--- a/TESTING/sdrive.c
+++ b/TESTING/sdrive.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     float         *ferr, *berr;
     float         *rwork;
     float	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, panel_size, relax;
     int            m, n, nnz;
     float         *xact;
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     int            zerot, izero, ioff;
     double         u;
     float         anorm, cndnum;
-    float         *Afull;
+    float         *Afull = NULL;
     float         result[NTESTS];
     superlu_options_t options;
     fact_t         fact;

--- a/TESTING/zdrive.c
+++ b/TESTING/zdrive.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     double         *ferr, *berr;
     double         *rwork;
     doublecomplex	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            info, lwork, nrhs, panel_size, relax;
     int            m, n, nnz;
     doublecomplex         *xact;
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     int            zerot, izero, ioff;
     double         u;
     double         anorm, cndnum;
-    doublecomplex         *Afull;
+    doublecomplex         *Afull = NULL;
     double         result[NTESTS];
     superlu_options_t options;
     fact_t         fact;


### PR DESCRIPTION
### Main changes to CBLAS code
* Remove `static` keyword from local variables: f2c often declares local variables as `static` which introduces a global scope, which is not necessary here and might have undesirable side effects.
* Remove system generated locals: f2c uses local variables like `i__1`, `i__2` and so on. Most of them weren't used anyway, so the declarations were removed.

### Other changes

* Some pointers in the examples and test drivers have been initialized to `NULL`. Not initializing them prevented compilation with Microsoft Visual Studio C compiler.
* f2c local variables were removed from some MATGEN files.

---

All tests complete without error on Windows 10, compiled with Microsoft (R) C/C++ Optimizing Compiler Version 19.28.29335 (x64).