### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test library
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        compiler:
+          - clang
+          - gcc
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo apt-get install csh clang
+
+      - name: Build
+        run: |
+          cp MAKE_INC/make.linux make.inc
+          # We use ~ instead of / as a separator in sed, since $(pwd)
+          # also includes /
+          sed -i  "s~^SuperLUroot\s*=.*~SuperLUroot = $(pwd)~g" make.inc
+          sed -i  "s/^CC\s*=.*/CC = ${CC_CI}/g" make.inc
+          mkdir lib
+          make install lib
+        env:
+          CC_CI: ${{ matrix.compiler }}
+                
+      - name: Test
+        run: |
+          make testing

--- a/SRC/dGetDiagU.c
+++ b/SRC/dGetDiagU.c
@@ -29,7 +29,7 @@
  * data structures.
  * </pre> 
 */
-#include <slu_ddefs.h>
+#include "slu_ddefs.h"
 
 void dGetDiagU(SuperMatrix *L, double *diagU)
 {


### PR DESCRIPTION
It would be really useful to have CI for this library.  

This adds CI using GitHub Actions as discussed in https://github.com/xiaoyeli/superlu/pull/18#issuecomment-751284386

The library is built with gcc and clang then tests are run. Note that there are currently segfaults in tests, not sure if it's normal.  

I also had to apply a small fix for including `slu_ddefs.h` as otherwise I was getting,
```
 gcc -O3 -g -DAdd_ -DUSE_VENDOR_BLAS -c dGetDiagU.c 
dGetDiagU.c:32:10: fatal error: slu_ddefs.h: No such file or directory
   32 | #include <slu_ddefs.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:115: dGetDiagU.o] Error 1
```

closes https://github.com/xiaoyeli/superlu/pull/18

**Note:** CI is triggered on my fork https://github.com/rth/superlu/tree/add-ci so I'm not sure why it's not showing in this PR. Maybe it needs to have `.github/workflows/test.yml` in master first, to enable GH Actions.