### PR TITLE
BUG: fix memory error caused from overflowing signed 32-bit int input to doubleCalloc

### DIFF
--- a/SRC/dgstrs.c
+++ b/SRC/dgstrs.c
@@ -136,9 +136,9 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     }
 
     n = L->nrow;
-    work = doubleCalloc(n * nrhs);
+    work = doubleCalloc((size_t)n * (size_t)nrhs);
     if ( !work ) ABORT("Malloc fails for local work[].");
-    soln = doubleMalloc(n);
+    soln = doubleMalloc((size_t)n);
     if ( !soln ) ABORT("Malloc fails for local soln[].");
 
     Bmat = Bstore->nzval;
@@ -151,7 +151,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     if ( trans == NOTRANS ) {
 	/* Permute right hand sides to form Pr*B */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[perm_r[k]] = rhs_work[k];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}
@@ -169,7 +169,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 	    
 	    if ( nsupc == 1 ) {
 		for (j = 0; j < nrhs; j++) {
-		    rhs_work = &Bmat[j*ldb];
+		    rhs_work = &Bmat[(size_t)j * (size_t)ldb];
 	    	    luptr = L_NZ_START(fsupc);
 		    for (iptr=istart+1; iptr < L_SUB_START(fsupc+1); iptr++){
 			irow = L_SUB(iptr);
@@ -199,8 +199,8 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 			&beta, &work[0], &n );
 #endif
 		for (j = 0; j < nrhs; j++) {
-		    rhs_work = &Bmat[j*ldb];
-		    work_col = &work[j*n];
+		    rhs_work = &Bmat[(size_t)j * (size_t)ldb];
+		    work_col = &work[(size_t)j * (size_t)n];
 		    iptr = istart + nsupc;
 		    for (i = 0; i < nrow; i++) {
 			irow = L_SUB(iptr);
@@ -211,7 +211,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 		}
 #else		
 		for (j = 0; j < nrhs; j++) {
-		    rhs_work = &Bmat[j*ldb];
+		    rhs_work = &Bmat[(size_t)j * (size_t)ldb];
 		    dlsolve (nsupr, nsupc, &Lval[luptr], &rhs_work[fsupc]);
 		    dmatvec (nsupr, nrow, nsupc, &Lval[luptr+nsupc],
 			    &rhs_work[fsupc], &work[0] );
@@ -265,12 +265,12 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 #endif
 #else		
 		for (j = 0; j < nrhs; j++)
-		    dusolve ( nsupr, nsupc, &Lval[luptr], &Bmat[fsupc+j*ldb] );
+		    dusolve ( nsupr, nsupc, &Lval[luptr], &Bmat[(size_t)fsupc + (size_t)j * (size_t)ldb] );
 #endif		
 	    }
 
 	    for (j = 0; j < nrhs; ++j) {
-		rhs_work = &Bmat[j*ldb];
+		rhs_work = &Bmat[(size_t)j * (size_t)ldb];
 		for (jcol = fsupc; jcol < fsupc + nsupc; jcol++) {
 		    solve_ops += 2*(U_NZ_START(jcol+1) - U_NZ_START(jcol));
 		    for (i = U_NZ_START(jcol); i < U_NZ_START(jcol+1); i++ ){
@@ -289,7 +289,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 
 	/* Compute the final solution X := Pc*X. */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[k] = rhs_work[perm_c[k]];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}
@@ -299,7 +299,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     } else { /* Solve A'*X=B or CONJ(A)*X=B */
 	/* Permute right hand sides to form Pc'*B. */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[perm_c[k]] = rhs_work[k];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}
@@ -308,15 +308,15 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
 	for (k = 0; k < nrhs; ++k) {
 	    
 	    /* Multiply by inv(U'). */
-	    sp_dtrsv("U", "T", "N", L, U, &Bmat[k*ldb], stat, info);
+	    sp_dtrsv("U", "T", "N", L, U, &Bmat[(size_t)k * (size_t)ldb], stat, info);
 	    
 	    /* Multiply by inv(L'). */
-	    sp_dtrsv("L", "T", "U", L, U, &Bmat[k*ldb], stat, info);
+	    sp_dtrsv("L", "T", "U", L, U, &Bmat[(size_t)k * (size_t)ldb], stat, info);
 	    
 	}
 	/* Compute the final solution X := Pr'*X (=inv(Pr)*X) */
 	for (i = 0; i < nrhs; i++) {
-	    rhs_work = &Bmat[i*ldb];
+	    rhs_work = &Bmat[(size_t)i * (size_t)ldb];
 	    for (k = 0; k < n; k++) soln[k] = rhs_work[perm_r[k]];
 	    for (k = 0; k < n; k++) rhs_work[k] = soln[k];
 	}

--- a/SRC/dmemory.c
+++ b/SRC/dmemory.c
@@ -673,22 +673,22 @@ dallocateA(int n, int nnz, double **a, int **asub, int **xa)
 }
 
 
-double *doubleMalloc(int n)
+double *doubleMalloc(size_t n)
 {
     double *buf;
-    buf = (double *) SUPERLU_MALLOC((size_t)n * sizeof(double)); 
+    buf = (double *) SUPERLU_MALLOC(n * (size_t) sizeof(double)); 
     if ( !buf ) {
 	ABORT("SUPERLU_MALLOC failed for buf in doubleMalloc()\n");
     }
     return (buf);
 }
 
-double *doubleCalloc(int n)
+double *doubleCalloc(size_t n)
 {
     double *buf;
-    register int i;
+    register size_t i;
     double zero = 0.0;
-    buf = (double *) SUPERLU_MALLOC((size_t)n * sizeof(double));
+    buf = (double *) SUPERLU_MALLOC(n * (size_t) sizeof(double));
     if ( !buf ) {
 	ABORT("SUPERLU_MALLOC failed for buf in doubleCalloc()\n");
     }

--- a/SRC/slu_ddefs.h
+++ b/SRC/slu_ddefs.h
@@ -237,8 +237,8 @@ extern void    dSetRWork (int, int, double *, double **, double **);
 extern void    dLUWorkFree (int *, double *, GlobalLU_t *);
 extern int     dLUMemXpand (int, int, MemType, int *, GlobalLU_t *);
 
-extern double  *doubleMalloc(int);
-extern double  *doubleCalloc(int);
+extern double  *doubleMalloc(size_t);
+extern double  *doubleCalloc(size_t);
 extern int     dmemory_usage(const int, const int, const int, const int);
 extern int     dQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern int     ilu_dQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);


### PR DESCRIPTION
BUG: For big linear systems **AX = B** such as when the right hand side B is of size 46679 x 46680 containing doubles, `dgssv` gets stuck in a runtime memory error that looks like below:
```
SUPERLU_MALLOC failed for buf in doubleCalloc()
 at line 693 in file superlu/SRC/dmemory.c
```
**dgssv** in turn calls **dgstrs**, with this last one calling `doubleCalloc(n * nrhs)` where `int n = L->nrow` and `int nrhs = B->ncol`. Finally, **doubleCalloc** makes a call to the **SUPERLU_MALLOC** macro
```
buf = (double*) SUPERLU_MALLOC((size_t)n * sizeof(double));
if( !buf ) {
	ABORT("SUPERLU_MALLOC failed for buf in doubleCalloc()\n");
}
```
with the macro being defined as the `void* superlu_python_module_malloc(size_t size)` function that sets some member `mem_ptr = malloc(size);` and returns _nullptr_ if malloc returns _nullptr_ (meaning that the system wasn’t able to return a valid pointer to usable contiguous memory because it couldn’t allocate it), so **buf** in **doubleCalloc** is a null pointer and **doubleCalloc** aborts with the failure message explained above -- all this due to `(L->nrow * B->ncol)` exceeding the maximum value of a _signed 32-bit int_.

Fixes #57 