### PR TITLE
Fix cmake build with `-Denable_internal_blaslib=YES`.

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -84,7 +84,6 @@ if (enable_complex16)
 endif()
 
 add_library(blas ${sources})
-target_link_options(blas PRIVATE "-lm" "-Wl,--no-undefined" "-Wl,--no-allow-shlib-undefined")
 
 include(GNUInstallDirs)
 install(TARGETS blas

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -83,7 +83,7 @@ if (enable_complex16)
     )
 endif()
 
-add_library(blas ${sources})
+add_library(blas STATIC ${sources})
 
 include(GNUInstallDirs)
 install(TARGETS blas

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -3,10 +3,10 @@ set(headers
     slu_Cnames.h
 )
 
-# set(sources input_error.c)
-set(sources "")
+set(sources ../SRC/input_error.c)
+# set(sources "")
 
-#if (enable_single)
+if (enable_single)
     list(APPEND sources
       isamax.c
       sasum.c
@@ -23,9 +23,9 @@ set(sources "")
       sger.c
       ssyr2.c
     )
-#endif()
+endif()
 
-#if (enable_double)
+if (enable_double)
     list(APPEND sources
       idamax.c
       dasum.c
@@ -42,10 +42,11 @@ set(sources "")
       dger.c
       dsyr2.c
     )
-#endif()
+endif()
 
-#if (enable_complex)
+if (enable_complex)
     list(APPEND sources
+      ../SRC/scomplex.c
       icamax.c
       scasum.c
       caxpy.c
@@ -60,10 +61,11 @@ set(sources "")
       cgerc.c
       cher2.c
     )
-#endif()
+endif()
 
-#if (enable_complex16)
+if (enable_complex16)
     list(APPEND sources
+      ../SRC/dcomplex.c
       izamax.c
       dzasum.c
       zaxpy.c
@@ -79,9 +81,10 @@ set(sources "")
       zgerc.c
       zher2.c
     )
-#endif()
+endif()
 
 add_library(blas ${sources})
+target_link_options(blas PRIVATE "-lm" "-Wl,--no-undefined" "-Wl,--no-allow-shlib-undefined")
 
 include(GNUInstallDirs)
 install(TARGETS blas

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -233,7 +233,7 @@ if(enable_complex16)
   )
 endif()
 
-add_library(superlu ${sources})
+add_library(superlu STATIC ${sources})
 target_link_libraries(superlu PUBLIC ${BLAS_LIB})
 if (NOT WIN32)
   target_link_libraries(superlu PUBLIC m)


### PR DESCRIPTION
MSCV errors on unresolved shared library symbols. This can be seen with gcc by adding `target_link_options(blas PRIVATE "-lm" "-Wl,--no-undefined" "-Wl,--no-allow-shlib-undefined")` after `add_library(blas ${sources})`.

You may use that or copy these files inside CBLAS directory.

related https://github.com/xiaoyeli/superlu/issues/71.