### PR TITLE
Append `CBLAS` files to `suplerlu` when not found.

### DIFF
--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(headers 
-    f2c.h
-    slu_Cnames.h
+    ${PROJECT_SOURCE_DIR}/CBLAS/f2c.h
+    ${PROJECT_SOURCE_DIR}/CBLAS/slu_Cnames.h
 )
 
 # set(sources input_error.c)
@@ -8,77 +8,77 @@ set(sources "")
 
 if (enable_single)
     list(APPEND sources
-      isamax.c
-      sasum.c
-      saxpy.c
-      scopy.c
-      sdot.c
-      snrm2.c
-      srot.c 
-      sscal.c 
-      sswap.c
-      sgemv.c
-      ssymv.c
-      strsv.c
-      sger.c
-      ssyr2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/isamax.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/sasum.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/saxpy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/scopy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/sdot.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/snrm2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/srot.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/sscal.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/sswap.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/sgemv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/ssymv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/strsv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/sger.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/ssyr2.c
     )
 endif()
 
 if (enable_double)
     list(APPEND sources
-      idamax.c
-      dasum.c
-      daxpy.c
-      dcopy.c
-      ddot.c
-      dnrm2.c
-      drot.c
-      dscal.c
-      dswap.c
-      dgemv.c
-      dsymv.c
-      dtrsv.c
-      dger.c
-      dsyr2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/idamax.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dasum.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/daxpy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dcopy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/ddot.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dnrm2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/drot.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dscal.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dswap.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dgemv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dsymv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dtrsv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dger.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dsyr2.c
     )
 endif()
 
 if (enable_complex)
     list(APPEND sources
-      icamax.c
-      scasum.c
-      caxpy.c
-      ccopy.c
-      scnrm2.c
-      cscal.c
-      cswap.c
-      cdotc.c
-      cgemv.c
-      chemv.c
-      ctrsv.c
-      cgerc.c
-      cher2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/icamax.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/scasum.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/caxpy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/ccopy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/scnrm2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/cscal.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/cswap.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/cdotc.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/cgemv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/chemv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/ctrsv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/cgerc.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/cher2.c
     )
 endif()
 
 if (enable_complex16)
     list(APPEND sources
-      izamax.c
-      dzasum.c
-      zaxpy.c
-      zcopy.c
-      dznrm2.c
-      zscal.c
-      dcabs1.c
-      zswap.c
-      zdotc.c
-      zgemv.c
-      zhemv.c
-      ztrsv.c
-      zgerc.c
-      zher2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/izamax.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dzasum.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zaxpy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zcopy.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dznrm2.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zscal.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/dcabs1.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zswap.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zdotc.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zgemv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zhemv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/ztrsv.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zgerc.c
+      ${PROJECT_SOURCE_DIR}/CBLAS/zher2.c
     )
 endif()
 
-set(cblas_sources ${sources})
+set(CBLAS_SOURCES ${sources} CACHE INTERNAL "")

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -82,3 +82,4 @@ if (enable_complex16)
 endif()
 
 set(CBLAS_SOURCES ${sources} CACHE INTERNAL "")
+set(CBLAS_HEADERS ${headers} CACHE INTERNAL "")

--- a/CBLAS/CMakeLists.txt
+++ b/CBLAS/CMakeLists.txt
@@ -6,7 +6,7 @@ set(headers
 # set(sources input_error.c)
 set(sources "")
 
-#if (enable_single)
+if (enable_single)
     list(APPEND sources
       isamax.c
       sasum.c
@@ -23,9 +23,9 @@ set(sources "")
       sger.c
       ssyr2.c
     )
-#endif()
+endif()
 
-#if (enable_double)
+if (enable_double)
     list(APPEND sources
       idamax.c
       dasum.c
@@ -42,9 +42,9 @@ set(sources "")
       dger.c
       dsyr2.c
     )
-#endif()
+endif()
 
-#if (enable_complex)
+if (enable_complex)
     list(APPEND sources
       icamax.c
       scasum.c
@@ -60,9 +60,9 @@ set(sources "")
       cgerc.c
       cher2.c
     )
-#endif()
+endif()
 
-#if (enable_complex16)
+if (enable_complex16)
     list(APPEND sources
       izamax.c
       dzasum.c
@@ -79,21 +79,6 @@ set(sources "")
       zgerc.c
       zher2.c
     )
-#endif()
+endif()
 
-add_library(blas ${sources})
-
-include(GNUInstallDirs)
-install(TARGETS blas
-  EXPORT blasTargets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-)
-
-install(EXPORT blasTargets
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/superlu"
-  )
-export(EXPORT blasTargets
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/blasTargets.cmake"
-  )
+set(cblas_sources ${sources})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,12 +122,6 @@ if(BLAS_FOUND)
 else()
   message("-- Did not find or specify BLAS so configure to build internal CBLAS ...")
   add_subdirectory(CBLAS)
-  set(BLAS_LIB blas)
-  if (BUILD_SHARED_LIBS)  # export to be referenced by downstream makefile
-      set(BLAS_LIB_EXPORT ${CMAKE_INSTALL_PREFIX}/CBLAS/libblas.so)
-  else()
-      set(BLAS_LIB_EXPORT ${CMAKE_INSTALL_PREFIX}/CBLAS/libblas.a)
-  endif()
 endif()
 
 ######################################################################

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -234,7 +234,7 @@ if(enable_complex16)
 endif()
 
 if(NOT BLAS_FOUND)
-  list(APPEND sources ${CBLAS_sources})
+  list(APPEND sources ${CBLAS_SOURCES})
 endif()
 
 add_library(superlu ${sources})

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -235,6 +235,7 @@ endif()
 
 if(NOT BLAS_FOUND)
   list(APPEND sources ${CBLAS_SOURCES})
+  list(APPEND headers ${CBLAS_HEADERS})
 endif()
 
 add_library(superlu ${sources})

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -233,6 +233,10 @@ if(enable_complex16)
   )
 endif()
 
+if(NOT BLAS_FOUND)
+  list(APPEND sources ${CBLAS_sources})
+endif()
+
 add_library(superlu ${sources})
 target_link_libraries(superlu PUBLIC ${BLAS_LIB})
 if (NOT WIN32)


### PR DESCRIPTION
This PR avoid building a separate `CBLAS` library when `CBLAS` is not found.

related https://github.com/xiaoyeli/superlu/issues/71.