### PR TITLE
Fix many clang warnings

### DIFF
--- a/SRC/cgscon.c
+++ b/SRC/cgscon.c
@@ -87,7 +87,7 @@ cgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
 
 
     /* Local variables */
-    int    kase, kase1, onenrm, i;
+    int    kase, kase1, onenrm;
     float ainvnm;
     complex *work;
     int    isave[3];

--- a/SRC/cgsitrf.c
+++ b/SRC/cgsitrf.c
@@ -251,7 +251,6 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     int       nnzLj, nnzUj;
     double    tol_L = drop_tol, tol_U = drop_tol;
     complex zero = {0.0, 0.0};
-    float one = 1.0;
 
     /* Executable */	   
     iinfo    = 0;

--- a/SRC/cgssv.c
+++ b/SRC/cgssv.c
@@ -186,8 +186,14 @@ cgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 			       Astore->nzval, Astore->colind, Astore->rowptr,
 			       SLU_NC, A->Dtype, A->Mtype);
 	trans = TRANS;
-    } else {
-        if ( A->Stype == SLU_NC ) AA = A;
+    } else if ( A->Stype == SLU_NC ) {
+        AA = A;
+    }
+    /* A is of unsupported matrix format. */
+    else {
+        AA = NULL;
+        *info = 1;
+        input_error("cgssv", &i);
     }
 
     t = SuperLU_timer_();

--- a/SRC/clacon2.c
+++ b/SRC/clacon2.c
@@ -179,7 +179,7 @@ L70:
     *est = scsum1_slu(n, v, &c__1);
 
 
-L90:
+/* L90: */
     /*     TEST FOR CYCLING. */
     if (*est <= estold) goto L120;
 

--- a/SRC/dgscon.c
+++ b/SRC/dgscon.c
@@ -87,7 +87,7 @@ dgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
 
 
     /* Local variables */
-    int    kase, kase1, onenrm, i;
+    int    kase, kase1, onenrm;
     double ainvnm;
     double *work;
     int    *iwork;

--- a/SRC/dgssv.c
+++ b/SRC/dgssv.c
@@ -186,8 +186,14 @@ dgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 			       Astore->nzval, Astore->colind, Astore->rowptr,
 			       SLU_NC, A->Dtype, A->Mtype);
 	trans = TRANS;
-    } else {
-        if ( A->Stype == SLU_NC ) AA = A;
+    } else if ( A->Stype == SLU_NC ) {
+        AA = A;
+    }
+    /* A is of unsupported matrix format. */
+    else {
+        AA = NULL;
+        *info = 1;
+        input_error("dgssv", &i);
     }
 
     t = SuperLU_timer_();

--- a/SRC/dmach.c
+++ b/SRC/dmach.c
@@ -8,6 +8,8 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
+#include "slu_ddefs.h"
+
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -87,6 +89,10 @@ double dmach(char *cmach)
 	rmach = DBL_MAX_EXP;
     } else if (strncmp(cmach, "O", 1)==0) {
 	rmach = DBL_MAX;
+    } else {
+        int argument = 0;
+        input_error("dmach", &argument);
+        rmach = 0;
     }
 
     return rmach;

--- a/SRC/heap_relax_snode.c
+++ b/SRC/heap_relax_snode.c
@@ -56,7 +56,9 @@ heap_relax_snode (
     register int i, j, k, l, parent;
     register int snode_start;	/* beginning of a snode */
     int *et_save, *post, *inv_post, *iwork;
+#if ( PRNTlevel>=1 )
     int nsuper_et = 0, nsuper_et_post = 0;
+#endif
 
     /* The etree may not be postordered, but is heap ordered. */
 
@@ -94,7 +96,9 @@ heap_relax_snode (
 	    parent = et[j];
 	}
 	/* Found a supernode in postordered etree; j is the last column. */
+#if ( PRNTlevel>=1 )
 	++nsuper_et_post;
+#endif
 	k = n;
 	for (i = snode_start; i <= j; ++i)
 	    k = SUPERLU_MIN(k, inv_post[i]);
@@ -102,13 +106,17 @@ heap_relax_snode (
 	if ( (l - k) == (j - snode_start) ) {
 	    /* It's also a supernode in the original etree */
 	    relax_end[k] = l;		/* Last column is recorded */
+#if ( PRNTlevel>=1 )
 	    ++nsuper_et;
+#endif
 	} else {
 	    for (i = snode_start; i <= j; ++i) {
 	        l = inv_post[i];
 	        if ( descendants[i] == 0 ) {
 		    relax_end[l] = l;
+#if ( PRNTlevel>=1 )
 		    ++nsuper_et;
+#endif
 		}
 	    }
 	}

--- a/SRC/ilu_heap_relax_snode.c
+++ b/SRC/ilu_heap_relax_snode.c
@@ -51,7 +51,9 @@ ilu_heap_relax_snode (
     register int i, j, k, l, f, parent;
     register int snode_start;	/* beginning of a snode */
     int *et_save, *post, *inv_post, *iwork;
+#if ( PRNTlevel>=1 )
     int nsuper_et = 0, nsuper_et_post = 0;
+#endif
 
     /* The etree may not be postordered, but is heap ordered. */
 
@@ -90,7 +92,9 @@ ilu_heap_relax_snode (
 	    parent = et[j];
 	}
 	/* Found a supernode in postordered etree; j is the last column. */
+#if ( PRNTlevel>=1 )
 	++nsuper_et_post;
+#endif
 	k = n;
 	for (i = snode_start; i <= j; ++i)
 	    k = SUPERLU_MIN(k, inv_post[i]);
@@ -99,14 +103,18 @@ ilu_heap_relax_snode (
 	    /* It's also a supernode in the original etree */
 	    relax_end[k] = l;		/* Last column is recorded */
 	    relax_fsupc[f++] = k;
+#if ( PRNTlevel>=1 )
 	    ++nsuper_et;
+#endif
 	} else {
 	    for (i = snode_start; i <= j; ++i) {
 		l = inv_post[i];
 		if ( descendants[i] == 0 ) {
 		    relax_end[l] = l;
 		    relax_fsupc[f++] = l;
+#if ( PRNTlevel>=1 )
 		    ++nsuper_et;
+#endif
 		}
 	    }
 	}

--- a/SRC/input_error.c
+++ b/SRC/input_error.c
@@ -42,9 +42,8 @@ at the top-level directory.
  *
  * </pre>
  */
-int input_error(char *srname, int *info)
+void input_error(char *srname, int *info)
 {
     printf("** On entry to %6s, parameter number %2d had an illegal value\n",
 		srname, *info);
-    return 0;
 }

--- a/SRC/mc64ad.c
+++ b/SRC/mc64ad.c
@@ -1090,7 +1090,6 @@ L1000:
 {
     /* System generated locals */
     int_t i__1;
-    int_t c__1 = 1;
 
     /* Local variables */
     double di;

--- a/SRC/scsum1.c
+++ b/SRC/scsum1.c
@@ -53,7 +53,6 @@ at the top-level directory.
 double scsum1_slu(int *n, complex *cx, int *incx)
 {
     /* System generated locals */
-    int i__1;
     float ret_val;
     /* Builtin functions */
     double c_abs(complex *);
@@ -77,7 +76,6 @@ double scsum1_slu(int *n, complex *cx, int *incx)
 /*     CODE FOR INCREMENT NOT EQUAL TO 1 */
 
     nincx = *n * *incx;
-    i__1 = nincx;
     for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
 
 /*        NEXT LINE MODIFIED. */

--- a/SRC/sgscon.c
+++ b/SRC/sgscon.c
@@ -87,7 +87,7 @@ sgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
 
 
     /* Local variables */
-    int    kase, kase1, onenrm, i;
+    int    kase, kase1, onenrm;
     float ainvnm;
     float *work;
     int    *iwork;

--- a/SRC/sgssv.c
+++ b/SRC/sgssv.c
@@ -186,8 +186,14 @@ sgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 			       Astore->nzval, Astore->colind, Astore->rowptr,
 			       SLU_NC, A->Dtype, A->Mtype);
 	trans = TRANS;
-    } else {
-        if ( A->Stype == SLU_NC ) AA = A;
+    } else if ( A->Stype == SLU_NC ) {
+        AA = A;
+    }
+    /* A is of unsupported matrix format. */
+    else {
+        AA = NULL;
+        *info = 1;
+        input_error("sgssv", &i);
     }
 
     t = SuperLU_timer_();

--- a/SRC/smach.c
+++ b/SRC/smach.c
@@ -8,6 +8,8 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
+#include "slu_sdefs.h"
+
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
@@ -87,6 +89,10 @@ float smach(char *cmach)
 	rmach = FLT_MAX_EXP;
     } else if (strncmp(cmach, "O", 1)==0) {
 	rmach = FLT_MAX;
+    } else {
+        int argument = 0;
+        input_error("smach", &argument);
+        rmach = 0;
     }
 
     return rmach;

--- a/SRC/util.c
+++ b/SRC/util.c
@@ -184,7 +184,10 @@ void
 countnz(const int n, int_t *xprune, int_t *nnzL, int_t *nnzU, GlobalLU_t *Glu)
 {
     int          nsuper, fsupc, i, j;
-    int_t        nnzL0, jlen, irep;
+    int_t        jlen;
+#if ( DEBUGlevel>=1 )
+    int_t        irep = 0, nnzL0 = 0;
+#endif
     int          *xsup;
     int_t        *xlsub;
 
@@ -192,7 +195,6 @@ countnz(const int n, int_t *xprune, int_t *nnzL, int_t *nnzU, GlobalLU_t *Glu)
     xlsub  = Glu->xlsub;
     *nnzL  = 0;
     *nnzU  = (Glu->xusub)[n];
-    nnzL0  = 0;
     nsuper = (Glu->supno)[n];
 
     if ( n <= 0 ) return;
@@ -209,11 +211,13 @@ countnz(const int n, int_t *xprune, int_t *nnzL, int_t *nnzU, GlobalLU_t *Glu)
 	    *nnzU += j - fsupc + 1;
 	    jlen--;
 	}
-	irep = xsup[i+1] - 1;
-	nnzL0 += xprune[irep] - xlsub[irep];
+#if ( DEBUGlevel>=1 )
+        irep = xsup[i+1] - 1;
+        nnzL0 += xprune[irep] - xlsub[irep];
+#endif
     }
 
-#if ( DEBUGlevel>=1 )    
+#if ( DEBUGlevel>=1 )
     printf("\tNo of nonzeros in symm-reduced L = %lld\n", (long long) nnzL0); fflush(stdout);
 #endif
 }

--- a/SRC/zgscon.c
+++ b/SRC/zgscon.c
@@ -87,7 +87,7 @@ zgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
 
 
     /* Local variables */
-    int    kase, kase1, onenrm, i;
+    int    kase, kase1, onenrm;
     double ainvnm;
     doublecomplex *work;
     int    isave[3];

--- a/SRC/zgsitrf.c
+++ b/SRC/zgsitrf.c
@@ -251,7 +251,6 @@ zgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     int       nnzLj, nnzUj;
     double    tol_L = drop_tol, tol_U = drop_tol;
     doublecomplex zero = {0.0, 0.0};
-    double one = 1.0;
 
     /* Executable */	   
     iinfo    = 0;

--- a/SRC/zgssv.c
+++ b/SRC/zgssv.c
@@ -186,8 +186,14 @@ zgssv(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 			       Astore->nzval, Astore->colind, Astore->rowptr,
 			       SLU_NC, A->Dtype, A->Mtype);
 	trans = TRANS;
-    } else {
-        if ( A->Stype == SLU_NC ) AA = A;
+    } else if ( A->Stype == SLU_NC ) {
+        AA = A;
+    }
+    /* A is of unsupported matrix format. */
+    else {
+        AA = NULL;
+        *info = 1;
+        input_error("zgssv", &i);
     }
 
     t = SuperLU_timer_();

--- a/SRC/zlacon2.c
+++ b/SRC/zlacon2.c
@@ -179,7 +179,7 @@ L70:
     *est = dzsum1_slu(n, v, &c__1);
 
 
-L90:
+/* L90: */
     /*     TEST FOR CYCLING. */
     if (*est <= estold) goto L120;
 

--- a/TESTING/MATGEN/clacgv.c
+++ b/TESTING/MATGEN/clacgv.c
@@ -35,7 +35,6 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer i__2;
     complex q__1;
     /* Builtin functions */
     void r_cnjg(complex *, complex *);
@@ -48,7 +47,6 @@
 
     if (*incx == 1) {
 	for (i = 1; i <= *n; ++i) {
-	    i__2 = i;
 	    r_cnjg(&q__1, &X(i));
 	    X(i).r = q__1.r, X(i).i = q__1.i;
 /* L10: */
@@ -59,7 +57,6 @@
 	    ioff = 1 - (*n - 1) * *incx;
 	}
 	for (i = 1; i <= *n; ++i) {
-	    i__2 = ioff;
 	    r_cnjg(&q__1, &X(ioff));
 	    X(ioff).r = q__1.r, X(ioff).i = q__1.i;
 	    ioff += *incx;

--- a/TESTING/MATGEN/clarnd.c
+++ b/TESTING/MATGEN/clarnd.c
@@ -75,44 +75,38 @@
     t1 = dlaran_sluslu(&iseed[1]);
     t2 = dlaran_sluslu(&iseed[1]);
 
-    if (*idist == 1) {
-
 /*        real and imaginary parts each uniform (0,1) */
-
+    if (*idist == 1) {
 	q__1.r = t1, q__1.i = t2;
 	 ret_val->r = q__1.r,  ret_val->i = q__1.i;
-    } else if (*idist == 2) {
 
 /*        real and imaginary parts each uniform (-1,1) */
-
+    } else if (*idist == 2) {
 	d__1 = t1 * 2.f - 1.f;
 	d__2 = t2 * 2.f - 1.f;
 	q__1.r = d__1, q__1.i = d__2;
 	 ret_val->r = q__1.r,  ret_val->i = q__1.i;
-    } else if (*idist == 3) {
 
 /*        real and imaginary parts each normal (0,1) */
-
+    } else if (*idist == 3) {
 	d__1 = sqrt(log(t1) * -2.f);
 	d__2 = t2 * 6.2831853071795864769252867663f;
 	q__3.r = 0.f, q__3.i = d__2;
 	c_exp(&q__2, &q__3);
 	q__1.r = d__1 * q__2.r, q__1.i = d__1 * q__2.i;
 	 ret_val->r = q__1.r,  ret_val->i = q__1.i;
-    } else if (*idist == 4) {
 
 /*        uniform distribution on the unit disc abs(z) <= 1 */
-
+    } else if (*idist == 4) {
 	d__1 = sqrt(t1);
 	d__2 = t2 * 6.2831853071795864769252867663f;
 	q__3.r = 0.f, q__3.i = d__2;
 	c_exp(&q__2, &q__3);
 	q__1.r = d__1 * q__2.r, q__1.i = d__1 * q__2.i;
 	 ret_val->r = q__1.r,  ret_val->i = q__1.i;
-    } else if (*idist == 5) {
 
 /*        uniform distribution on the unit circle abs(z) = 1 */
-
+    } else if (*idist == 5) {
 	d__1 = t2 * 6.2831853071795864769252867663f;
 	q__2.r = 0.f, q__2.i = d__1;
 	c_exp(&q__1, &q__2);

--- a/TESTING/MATGEN/clarnd.c
+++ b/TESTING/MATGEN/clarnd.c
@@ -18,6 +18,7 @@
     /* Local variables */
     static real t1, t2;
     extern doublereal dlaran_sluslu(integer *);
+    extern int input_error(char *, int *);
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -116,6 +117,13 @@
 	q__2.r = 0.f, q__2.i = d__1;
 	c_exp(&q__1, &q__2);
 	 ret_val->r = q__1.r,  ret_val->i = q__1.i;
+    }
+
+/*        invalid input, *idist must be 1, 2, 3, 4, or 5  */
+    else {
+        int argument = 0;
+        input_error("clarnd", &argument);
+        ret_val = 0;
     }
 
 /*     End of CLARND */

--- a/TESTING/MATGEN/clarnd.c
+++ b/TESTING/MATGEN/clarnd.c
@@ -117,7 +117,6 @@
 	c_exp(&q__1, &q__2);
 	 ret_val->r = q__1.r,  ret_val->i = q__1.i;
     }
-    return ;
 
 /*     End of CLARND */
 

--- a/TESTING/MATGEN/dlarnd.c
+++ b/TESTING/MATGEN/dlarnd.c
@@ -69,20 +69,16 @@ doublereal dlarnd_slu(integer *idist, integer *iseed)
     /* Function Body */
     t1 = dlaran_slu(&iseed[1]);
 
-    if (*idist == 1) {
-
 /*        uniform (0,1) */
-
+    if (*idist == 1) {
 	ret_val = t1;
-    } else if (*idist == 2) {
 
 /*        uniform (-1,1) */
-
+    } else if (*idist == 2) {
 	ret_val = t1 * 2. - 1.;
-    } else if (*idist == 3) {
 
 /*        normal (0,1) */
-
+    } else if (*idist == 3) {
 	t2 = dlaran_slu(&iseed[1]);
 	ret_val = sqrt(log(t1) * -2.) * cos(t2 * 
 		6.2831853071795864769252867663);

--- a/TESTING/MATGEN/dlarnd.c
+++ b/TESTING/MATGEN/dlarnd.c
@@ -16,6 +16,7 @@ doublereal dlarnd_slu(integer *idist, integer *iseed)
     /* Local variables */
     static doublereal t1, t2;
     extern doublereal dlaran_slu(integer *);
+    extern int input_error(char *, int *);
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -86,6 +87,14 @@ doublereal dlarnd_slu(integer *idist, integer *iseed)
 	ret_val = sqrt(log(t1) * -2.) * cos(t2 * 
 		6.2831853071795864769252867663);
     }
+
+/*        invalid input, *idist must be 1, 2, or 3  */
+    else {
+        int argument = 0;
+        input_error("dlarnd", &argument);
+        ret_val = 0;
+    }
+
     return ret_val;
 
 /*     End of DLARND */

--- a/TESTING/MATGEN/slarnd.c
+++ b/TESTING/MATGEN/slarnd.c
@@ -16,6 +16,7 @@ doublereal slarnd_slu(integer *idist, integer *iseed)
     /* Local variables */
     static real t1, t2;
     extern doublereal dlaran_sluslu(integer *);
+    extern int input_error(char *, int *);
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -86,6 +87,14 @@ doublereal slarnd_slu(integer *idist, integer *iseed)
 	ret_val = sqrt(log(t1) * -2.f) * cos(t2 * 
 		6.2831853071795864769252867663f);
     }
+
+/*        invalid input, *idist must be 1, 2, or 3  */
+    else {
+        int argument = 0;
+        input_error("slarnd", &argument);
+        ret_val = 0;
+    }
+
     return ret_val;
 
 /*     End of SLARND */

--- a/TESTING/MATGEN/slarnd.c
+++ b/TESTING/MATGEN/slarnd.c
@@ -69,19 +69,17 @@ doublereal slarnd_slu(integer *idist, integer *iseed)
     /* Function Body */
     t1 = dlaran_sluslu(&iseed[1]);
 
-    if (*idist == 1) {
 
 /*        uniform (0,1) */
-
+    if (*idist == 1) {
 	ret_val = t1;
-    } else if (*idist == 2) {
 
 /*        uniform (-1,1) */
-
+    } else if (*idist == 2) {
 	ret_val = t1 * 2.f - 1.f;
-    } else if (*idist == 3) {
 
 /*        normal (0,1) */
+    } else if (*idist == 3) {
 
 	t2 = dlaran_sluslu(&iseed[1]);
 	ret_val = sqrt(log(t1) * -2.f) * cos(t2 * 

--- a/TESTING/MATGEN/zlacgv.c
+++ b/TESTING/MATGEN/zlacgv.c
@@ -35,7 +35,6 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer i__2;
     doublecomplex z__1;
     /* Builtin functions */
     void d_cnjg(doublecomplex *, doublecomplex *);
@@ -48,7 +47,6 @@
 
     if (*incx == 1) {
 	for (i = 1; i <= *n; ++i) {
-	    i__2 = i;
 	    d_cnjg(&z__1, &X(i));
 	    X(i).r = z__1.r, X(i).i = z__1.i;
 /* L10: */
@@ -59,7 +57,6 @@
 	    ioff = 1 - (*n - 1) * *incx;
 	}
 	for (i = 1; i <= *n; ++i) {
-	    i__2 = ioff;
 	    d_cnjg(&z__1, &X(ioff));
 	    X(ioff).r = z__1.r, X(ioff).i = z__1.i;
 	    ioff += *incx;

--- a/TESTING/MATGEN/zlarnd.c
+++ b/TESTING/MATGEN/zlarnd.c
@@ -76,44 +76,38 @@
     t1 = dlaran_slu(&iseed[1]);
     t2 = dlaran_slu(&iseed[1]);
 
-    if (*idist == 1) {
-
 /*        real and imaginary parts each uniform (0,1) */
-
+    if (*idist == 1) {
 	z__1.r = t1, z__1.i = t2;
 	 ret_val->r = z__1.r,  ret_val->i = z__1.i;
-    } else if (*idist == 2) {
 
 /*        real and imaginary parts each uniform (-1,1) */
-
+    } else if (*idist == 2) {
 	d__1 = t1 * 2. - 1.;
 	d__2 = t2 * 2. - 1.;
 	z__1.r = d__1, z__1.i = d__2;
 	 ret_val->r = z__1.r,  ret_val->i = z__1.i;
-    } else if (*idist == 3) {
 
 /*        real and imaginary parts each normal (0,1) */
-
+    } else if (*idist == 3) {
 	d__1 = sqrt(log(t1) * -2.);
 	d__2 = t2 * 6.2831853071795864769252867663;
 	z__3.r = 0., z__3.i = d__2;
 	z_exp(&z__2, &z__3);
 	z__1.r = d__1 * z__2.r, z__1.i = d__1 * z__2.i;
 	 ret_val->r = z__1.r,  ret_val->i = z__1.i;
-    } else if (*idist == 4) {
 
 /*        uniform distribution on the unit disc abs(z) <= 1 */
-
+    } else if (*idist == 4) {
 	d__1 = sqrt(t1);
 	d__2 = t2 * 6.2831853071795864769252867663;
 	z__3.r = 0., z__3.i = d__2;
 	z_exp(&z__2, &z__3);
 	z__1.r = d__1 * z__2.r, z__1.i = d__1 * z__2.i;
 	 ret_val->r = z__1.r,  ret_val->i = z__1.i;
-    } else if (*idist == 5) {
 
 /*        uniform distribution on the unit circle abs(z) = 1 */
-
+    } else if (*idist == 5) {
 	d__1 = t2 * 6.2831853071795864769252867663;
 	z__2.r = 0., z__2.i = d__1;
 	z_exp(&z__1, &z__2);

--- a/TESTING/MATGEN/zlarnd.c
+++ b/TESTING/MATGEN/zlarnd.c
@@ -118,7 +118,6 @@
 	z_exp(&z__1, &z__2);
 	 ret_val->r = z__1.r,  ret_val->i = z__1.i;
     }
-    return ;
 
 /*     End of ZLARND */
 

--- a/TESTING/MATGEN/zlarnd.c
+++ b/TESTING/MATGEN/zlarnd.c
@@ -19,6 +19,7 @@
     /* Local variables */
     static doublereal t1, t2;
     extern doublereal dlaran_slu(integer *);
+    extern int input_error(char *, int *);
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -117,6 +118,13 @@
 	z__2.r = 0., z__2.i = d__1;
 	z_exp(&z__1, &z__2);
 	 ret_val->r = z__1.r,  ret_val->i = z__1.i;
+    }
+
+/*        invalid input, *idist must be 1, 2, 3, 4, or 5  */
+    else {
+        int argument = 0;
+        input_error("zlarnd", &argument);
+        ret_val = 0;
     }
 
 /*     End of ZLARND */


### PR DESCRIPTION
Fix most of the warnings emitted by Clang with `-Wall -Wpedantic -std=c11".