### PR TITLE
CMake: Enable Doxygen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 ######################################################################
 
 # Required version
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
 
 # Project Version	
 project(SuperLU C)
@@ -24,6 +24,7 @@ set(PROJECT_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BugFix})
 set(USE_XSDK_DEFAULTS TRUE)
 include(CTest)
 include(GNUInstallDirs)
+include(FeatureSummary)
 
 ######################################################################
 
@@ -76,7 +77,7 @@ endif()
 option(enable_internal_blaslib  "Build the CBLAS library" ${enable_blaslib_DEFAULT})
 option(enable_matlabmex "Build the Matlab mex library" OFF)
 option(enable_tests     "Build tests" ON)
-option(enable_doc       "Build doxygen documentation" OFF)
+option(enable_doc       "Add target 'doc' to build Doxygen documentation" OFF)
 option(enable_single    "Enable single precision library" ON)
 option(enable_double    "Enable double precision library" ON)
 option(enable_complex   "Enable complex precision library" ON)
@@ -215,8 +216,7 @@ if (XSDK_ENABLE_Fortran)
 endif()
 
 if(enable_doc)
-  message(FATAL_ERROR "Documentation build requested but not implemented.")
-  #implement doxygen
+  add_subdirectory(DOC)
 endif()
 
 # Generate various configure files with proper definitions

--- a/DOC/CMakeLists.txt
+++ b/DOC/CMakeLists.txt
@@ -6,6 +6,11 @@ set_package_properties("Doxygen" PROPERTIES
   URL "www.doxygen.org"
   PURPOSE "Generate HTML documentation from C sources")
 
+# set Doxygen options
+set(DOXYGEN_WARN_LOGFILE "doxygen.log")
+
 doxygen_add_docs(doc
+                 "${PROJECT_SOURCE_DIR}/EXAMPLE"
+                 "${PROJECT_SOURCE_DIR}/FORTRAN"
                  "${PROJECT_SOURCE_DIR}/SRC"
                  COMMENT "Generate HTML documentation with Doxygen")

--- a/DOC/CMakeLists.txt
+++ b/DOC/CMakeLists.txt
@@ -1,0 +1,11 @@
+# build HTML documentation using Doxygen
+
+find_package(Doxygen)
+set_package_properties("Doxygen" PROPERTIES
+  DESCRIPTION "Documentation generator"
+  URL "www.doxygen.org"
+  PURPOSE "Generate HTML documentation from C sources")
+
+doxygen_add_docs(doc
+                 "${PROJECT_SOURCE_DIR}/SRC"
+                 COMMENT "Generate HTML documentation with Doxygen")

--- a/EXAMPLE/sp_ienv.c
+++ b/EXAMPLE/sp_ienv.c
@@ -8,7 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file sp_ienv.c
+/*! @file EXAMPLE/sp_ienv.c
  * \brief Chooses machine-dependent parameters for the local environment.
  *
  * <pre>

--- a/FORTRAN/c_fortran_cgssv.c
+++ b/FORTRAN/c_fortran_cgssv.c
@@ -22,16 +22,7 @@ typedef struct {
     int *perm_r;
 } factors_t;
 
-void
-c_fortran_cgssv_(int *iopt, int *n, int_t *nnz, int *nrhs, 
-                 complex *values, int_t *rowind, int_t *colptr,
-                 complex *b, int *ldb,
-		 fptr *f_factors, /* a handle containing the address
-				     pointing to the factored matrices */
-		 int_t *info)
-
-{
-/* 
+/*!
  * This routine can be called from Fortran.
  *
  * iopt (input) int
@@ -44,9 +35,15 @@ c_fortran_cgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
  *      If iopt == 1, it is an output and contains the pointer pointing to
  *                    the structure of the factored matrices.
  *      Otherwise, it it an input.
- *
  */
- 
+void
+c_fortran_cgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
+                 complex *values, int_t *rowind, int_t *colptr,
+                 complex *b, int *ldb,
+                 fptr *f_factors, /* a handle containing the address
+                                     pointing to the factored matrices */
+                 int_t *info)
+{
     SuperMatrix A, AC, B;
     SuperMatrix *L, *U;
     int *perm_r; /* row permutations from partial pivoting */

--- a/FORTRAN/c_fortran_dgssv.c
+++ b/FORTRAN/c_fortran_dgssv.c
@@ -22,16 +22,7 @@ typedef struct {
     int *perm_r;
 } factors_t;
 
-void
-c_fortran_dgssv_(int *iopt, int *n, int_t *nnz, int *nrhs, 
-                 double *values, int_t *rowind, int_t *colptr,
-                 double *b, int *ldb,
-		 fptr *f_factors, /* a handle containing the address
-				     pointing to the factored matrices */
-		 int_t *info)
-
-{
-/* 
+/*!
  * This routine can be called from Fortran.
  *
  * iopt (input) int
@@ -44,9 +35,15 @@ c_fortran_dgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
  *      If iopt == 1, it is an output and contains the pointer pointing to
  *                    the structure of the factored matrices.
  *      Otherwise, it it an input.
- *
  */
- 
+void
+c_fortran_dgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
+                 double *values, int_t *rowind, int_t *colptr,
+                 double *b, int *ldb,
+                 fptr *f_factors, /* a handle containing the address
+                                     pointing to the factored matrices */
+                 int_t *info)
+{
     SuperMatrix A, AC, B;
     SuperMatrix *L, *U;
     int *perm_r; /* row permutations from partial pivoting */

--- a/FORTRAN/c_fortran_sgssv.c
+++ b/FORTRAN/c_fortran_sgssv.c
@@ -22,16 +22,7 @@ typedef struct {
     int *perm_r;
 } factors_t;
 
-void
-c_fortran_sgssv_(int *iopt, int *n, int_t *nnz, int *nrhs, 
-                 float *values, int_t *rowind, int_t *colptr,
-                 float *b, int *ldb,
-		 fptr *f_factors, /* a handle containing the address
-				     pointing to the factored matrices */
-		 int_t *info)
-
-{
-/* 
+/*!
  * This routine can be called from Fortran.
  *
  * iopt (input) int
@@ -44,9 +35,15 @@ c_fortran_sgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
  *      If iopt == 1, it is an output and contains the pointer pointing to
  *                    the structure of the factored matrices.
  *      Otherwise, it it an input.
- *
  */
- 
+void
+c_fortran_sgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
+                 float *values, int_t *rowind, int_t *colptr,
+                 float *b, int *ldb,
+                 fptr *f_factors, /* a handle containing the address
+                                     pointing to the factored matrices */
+                 int_t *info)
+{
     SuperMatrix A, AC, B;
     SuperMatrix *L, *U;
     int *perm_r; /* row permutations from partial pivoting */

--- a/FORTRAN/c_fortran_zgssv.c
+++ b/FORTRAN/c_fortran_zgssv.c
@@ -22,16 +22,7 @@ typedef struct {
     int *perm_r;
 } factors_t;
 
-void
-c_fortran_zgssv_(int *iopt, int *n, int_t *nnz, int *nrhs, 
-                 doublecomplex *values, int_t *rowind, int_t *colptr,
-                 doublecomplex *b, int *ldb,
-		 fptr *f_factors, /* a handle containing the address
-				     pointing to the factored matrices */
-		 int_t *info)
-
-{
-/* 
+/*!
  * This routine can be called from Fortran.
  *
  * iopt (input) int
@@ -44,9 +35,15 @@ c_fortran_zgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
  *      If iopt == 1, it is an output and contains the pointer pointing to
  *                    the structure of the factored matrices.
  *      Otherwise, it it an input.
- *
  */
- 
+void
+c_fortran_zgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
+                 doublecomplex *values, int_t *rowind, int_t *colptr,
+                 doublecomplex *b, int *ldb,
+                 fptr *f_factors, /* a handle containing the address
+                                     pointing to the factored matrices */
+                 int_t *info)
+{
     SuperMatrix A, AC, B;
     SuperMatrix *L, *U;
     int *perm_r; /* row permutations from partial pivoting */

--- a/SRC/ccolumn_bmod.c
+++ b/SRC/ccolumn_bmod.c
@@ -43,7 +43,7 @@ at the top-level directory.
  * ========
  * Performs numeric block updates (sup-col) in topological order.
  * It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- * Special processing on the supernodal portion of L\U[*,j]
+ * Special processing on the supernodal portion of L\\U[*,j]
  * Return value:   0 - successful return
  *               > 0 - number of bytes allocated when run out of space
  * </pre>

--- a/SRC/cgsisx.c
+++ b/SRC/cgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\U data structures.
+ *	     The amount of space used in bytes for L\\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)

--- a/SRC/cgsisx.c
+++ b/SRC/cgsisx.c
@@ -21,7 +21,8 @@ at the top-level directory.
  */
 #include "slu_cdefs.h"
 
-/*! \brief
+/*!
+ * Computes approximate solutions using the ILU factorization from cgsitrf()
  *
  * <pre>
  * Purpose

--- a/SRC/cgssvx.c
+++ b/SRC/cgssvx.c
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\U data structures.
+ *           The amount of space used in bytes for L\\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)

--- a/SRC/cgssvx.c
+++ b/SRC/cgssvx.c
@@ -21,7 +21,9 @@ at the top-level directory.
  */
 #include "slu_cdefs.h"
 
-/*! \brief
+/*!
+ * Solves the system of linear equations using
+ * the LU factorization from cgstrf()
  *
  * <pre>
  * Purpose

--- a/SRC/cmemory.c
+++ b/SRC/cmemory.c
@@ -103,7 +103,7 @@ void cuser_free(int bytes, int which_end, GlobalLU_t *Glu)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -141,7 +141,7 @@ int cQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>

--- a/SRC/cmemory.c
+++ b/SRC/cmemory.c
@@ -98,15 +98,14 @@ void cuser_free(int bytes, int which_end, GlobalLU_t *Glu)
 
 
 
-/*! \brief 
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int cQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {
@@ -136,15 +135,14 @@ int cQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 } /* cQuerySpace */
 
 
-/*! \brief
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int ilu_cQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {

--- a/SRC/cmyblas2.c
+++ b/SRC/cmyblas2.c
@@ -18,6 +18,7 @@ at the top-level directory.
  * and Lawrence Berkeley National Lab.
  * November 15, 1997
  * </pre>
+ * <pre>
  * Purpose:
  *     Level 2 BLAS operations: solves and matvec, written in C.
  * Note:

--- a/SRC/cpanel_bmod.c
+++ b/SRC/cpanel_bmod.c
@@ -46,7 +46,7 @@ at the top-level directory.
  *
  *    Performs numeric block updates (sup-panel) in topological order.
  *    It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- *    Special processing on the supernodal portion of L\U[*,j]
+ *    Special processing on the supernodal portion of L\\U[*,j]
  *
  *    Before entering this routine, the original nonzeros in the panel 
  *    were already copied into the spa[m,w].

--- a/SRC/creadrb.c
+++ b/SRC/creadrb.c
@@ -17,6 +17,7 @@ at the top-level directory.
  * Lawrence Berkeley National Laboratory.
  * June 30, 2009
  * </pre>
+ * <pre>
  *
  * Purpose
  * =======

--- a/SRC/dcolumn_bmod.c
+++ b/SRC/dcolumn_bmod.c
@@ -43,7 +43,7 @@ at the top-level directory.
  * ========
  * Performs numeric block updates (sup-col) in topological order.
  * It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- * Special processing on the supernodal portion of L\U[*,j]
+ * Special processing on the supernodal portion of L\\U[*,j]
  * Return value:   0 - successful return
  *               > 0 - number of bytes allocated when run out of space
  * </pre>

--- a/SRC/dgsisx.c
+++ b/SRC/dgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\U data structures.
+ *	     The amount of space used in bytes for L\\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)

--- a/SRC/dgssvx.c
+++ b/SRC/dgssvx.c
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\U data structures.
+ *           The amount of space used in bytes for L\\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)

--- a/SRC/dmemory.c
+++ b/SRC/dmemory.c
@@ -47,7 +47,7 @@ extern void    user_bcopy      (char *, char *, int);
 
 
 /*! \brief Setup the memory model to be used for factorization.
- *  
+ *
  *    lwork = 0: use system malloc;
  *    lwork > 0: use user-supplied work[] space.
  */
@@ -103,7 +103,7 @@ void duser_free(int bytes, int which_end, GlobalLU_t *Glu)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -141,7 +141,7 @@ int dQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -333,8 +333,11 @@ dLUMemInit(fact_t fact, void *work, int_t lwork, int m, int n, int_t annz,
     
 } /* dLUMemInit */
 
-/*! \brief Allocate known working storage. Returns 0 if success, otherwise
-   returns the number of bytes allocated so far when failure occurred. */
+/*! \brief Allocate known working storage.
+ *
+ * Returns 0 if success, otherwise
+ * returns the number of bytes allocated so far when failure occurred.
+ */
 int
 dLUWorkInit(int m, int n, int panel_size, int **iworkptr, 
             double **dworkptr, GlobalLU_t *Glu)

--- a/SRC/dmemory.c
+++ b/SRC/dmemory.c
@@ -98,15 +98,14 @@ void duser_free(int bytes, int which_end, GlobalLU_t *Glu)
 
 
 
-/*! \brief 
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int dQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {
@@ -136,15 +135,14 @@ int dQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 } /* dQuerySpace */
 
 
-/*! \brief
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int ilu_dQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {

--- a/SRC/dmyblas2.c
+++ b/SRC/dmyblas2.c
@@ -18,6 +18,7 @@ at the top-level directory.
  * and Lawrence Berkeley National Lab.
  * November 15, 1997
  * </pre>
+ * <pre>
  * Purpose:
  *     Level 2 BLAS operations: solves and matvec, written in C.
  * Note:

--- a/SRC/dpanel_bmod.c
+++ b/SRC/dpanel_bmod.c
@@ -46,7 +46,7 @@ at the top-level directory.
  *
  *    Performs numeric block updates (sup-panel) in topological order.
  *    It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- *    Special processing on the supernodal portion of L\U[*,j]
+ *    Special processing on the supernodal portion of L\\U[*,j]
  *
  *    Before entering this routine, the original nonzeros in the panel 
  *    were already copied into the spa[m,w].

--- a/SRC/dreadrb.c
+++ b/SRC/dreadrb.c
@@ -17,6 +17,7 @@ at the top-level directory.
  * Lawrence Berkeley National Laboratory.
  * June 30, 2009
  * </pre>
+ * <pre>
  *
  * Purpose
  * =======

--- a/SRC/mark_relax.c
+++ b/SRC/mark_relax.c
@@ -15,7 +15,7 @@ at the top-level directory.
  * -- SuperLU routine (version 4.0) --
  * Lawrence Berkeley National Laboratory
  * June 1, 2009
- * <\pre>
+ * </pre>
  */
 #include "slu_ddefs.h"
 

--- a/SRC/scolumn_bmod.c
+++ b/SRC/scolumn_bmod.c
@@ -43,7 +43,7 @@ at the top-level directory.
  * ========
  * Performs numeric block updates (sup-col) in topological order.
  * It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- * Special processing on the supernodal portion of L\U[*,j]
+ * Special processing on the supernodal portion of L\\U[*,j]
  * Return value:   0 - successful return
  *               > 0 - number of bytes allocated when run out of space
  * </pre>
@@ -263,7 +263,7 @@ scolumn_bmod (
     } /* for each segment... */
 
     /*
-     *	Process the supernodal portion of L\U[*,j]
+     *	Process the supernodal portion of L\\U[*,j]
      */
     nextlu = xlusup[jcol];
     fsupc = xsup[jsupno];

--- a/SRC/sgsisx.c
+++ b/SRC/sgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\U data structures.
+ *	     The amount of space used in bytes for L\\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)

--- a/SRC/sgssvx.c
+++ b/SRC/sgssvx.c
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\U data structures.
+ *           The amount of space used in bytes for L\\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)

--- a/SRC/slu_sdefs.h
+++ b/SRC/slu_sdefs.h
@@ -20,7 +20,7 @@ at the top-level directory.
  * 
  * Global data structures used in LU factorization -
  * 
- *   nsuper: #supernodes = nsuper + 1, numbered [0, nsuper].
+ *   nsuper: \#supernodes = nsuper + 1, numbered [0, nsuper].
  *   (xsup,supno): supno[i] is the supernode no to which i belongs;
  *	xsup(s) points to the beginning of the s-th supernode.
  *	e.g.   supno 0 1 2 2 3 3 3 4 4 4 4 4   (n=12)

--- a/SRC/slu_zdefs.h
+++ b/SRC/slu_zdefs.h
@@ -20,7 +20,7 @@ at the top-level directory.
  * 
  * Global data structures used in LU factorization -
  * 
- *   nsuper: #supernodes = nsuper + 1, numbered [0, nsuper].
+ *   nsuper: \#supernodes = nsuper + 1, numbered [0, nsuper].
  *   (xsup,supno): supno[i] is the supernode no to which i belongs;
  *	xsup(s) points to the beginning of the s-th supernode.
  *	e.g.   supno 0 1 2 2 3 3 3 4 4 4 4 4   (n=12)

--- a/SRC/smemory.c
+++ b/SRC/smemory.c
@@ -47,7 +47,7 @@ extern void    user_bcopy      (char *, char *, int);
 
 
 /*! \brief Setup the memory model to be used for factorization.
- *  
+ *
  *    lwork = 0: use system malloc;
  *    lwork > 0: use user-supplied work[] space.
  */
@@ -103,7 +103,7 @@ void suser_free(int bytes, int which_end, GlobalLU_t *Glu)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -141,7 +141,7 @@ int sQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -333,8 +333,12 @@ sLUMemInit(fact_t fact, void *work, int_t lwork, int m, int n, int_t annz,
     
 } /* sLUMemInit */
 
-/*! \brief Allocate known working storage. Returns 0 if success, otherwise
-   returns the number of bytes allocated so far when failure occurred. */
+/*! \brief Allocate known working storage.
+ *
+ * Returns 0 if success, otherwise returns the number of bytes allocated 
+ * so far when failure occurred. 
+ */
+
 int
 sLUWorkInit(int m, int n, int panel_size, int **iworkptr, 
             float **dworkptr, GlobalLU_t *Glu)

--- a/SRC/smemory.c
+++ b/SRC/smemory.c
@@ -98,15 +98,14 @@ void suser_free(int bytes, int which_end, GlobalLU_t *Glu)
 
 
 
-/*! \brief 
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int sQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {
@@ -136,15 +135,14 @@ int sQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 } /* sQuerySpace */
 
 
-/*! \brief
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int ilu_sQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {

--- a/SRC/smyblas2.c
+++ b/SRC/smyblas2.c
@@ -18,6 +18,7 @@ at the top-level directory.
  * and Lawrence Berkeley National Lab.
  * November 15, 1997
  * </pre>
+ * <pre>
  * Purpose:
  *     Level 2 BLAS operations: solves and matvec, written in C.
  * Note:

--- a/SRC/sp_ienv.c
+++ b/SRC/sp_ienv.c
@@ -8,7 +8,7 @@ All rights reserved.
 The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
-/*! @file sp_ienv.c
+/*! @file SRC/sp_ienv.c
  * \brief Chooses machine-dependent parameters for the local environment.
  *
  * <pre>

--- a/SRC/spanel_bmod.c
+++ b/SRC/spanel_bmod.c
@@ -46,7 +46,7 @@ at the top-level directory.
  *
  *    Performs numeric block updates (sup-panel) in topological order.
  *    It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- *    Special processing on the supernodal portion of L\U[*,j]
+ *    Special processing on the supernodal portion of L\\U[*,j]
  *
  *    Before entering this routine, the original nonzeros in the panel 
  *    were already copied into the spa[m,w].

--- a/SRC/sreadrb.c
+++ b/SRC/sreadrb.c
@@ -17,6 +17,7 @@ at the top-level directory.
  * Lawrence Berkeley National Laboratory.
  * June 30, 2009
  * </pre>
+ * <pre>
  *
  * Purpose
  * =======

--- a/SRC/zcolumn_bmod.c
+++ b/SRC/zcolumn_bmod.c
@@ -43,7 +43,7 @@ at the top-level directory.
  * ========
  * Performs numeric block updates (sup-col) in topological order.
  * It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- * Special processing on the supernodal portion of L\U[*,j]
+ * Special processing on the supernodal portion of L\\U[*,j]
  * Return value:   0 - successful return
  *               > 0 - number of bytes allocated when run out of space
  * </pre>

--- a/SRC/zgsisx.c
+++ b/SRC/zgsisx.c
@@ -373,7 +373,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *	   Record the memory usage statistics, consisting of following fields:
  *	   - for_lu (float)
- *	     The amount of space used in bytes for L\U data structures.
+ *	     The amount of space used in bytes for L\\U data structures.
  *	   - total_needed (float)
  *	     The amount of space needed in bytes to perform factorization.
  *	   - expansions (int)

--- a/SRC/zgssvx.c
+++ b/SRC/zgssvx.c
@@ -324,7 +324,7 @@ at the top-level directory.
  * mem_usage (output) mem_usage_t*
  *         Record the memory usage statistics, consisting of following fields:
  *         - for_lu (float)
- *           The amount of space used in bytes for L\U data structures.
+ *           The amount of space used in bytes for L\\U data structures.
  *         - total_needed (float)
  *           The amount of space needed in bytes to perform factorization.
  *         - expansions (int)

--- a/SRC/zmemory.c
+++ b/SRC/zmemory.c
@@ -47,7 +47,7 @@ extern void    user_bcopy      (char *, char *, int);
 
 
 /*! \brief Setup the memory model to be used for factorization.
- *  
+ *
  *    lwork = 0: use system malloc;
  *    lwork > 0: use user-supplied work[] space.
  */
@@ -103,7 +103,7 @@ void zuser_free(int bytes, int which_end, GlobalLU_t *Glu)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -141,7 +141,7 @@ int zQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
  * <pre>
  * mem_usage consists of the following fields:
  *    - for_lu (float)
- *      The amount of space used in bytes for the L\U data structures.
+ *      The amount of space used in bytes for the L\\U data structures.
  *    - total_needed (float)
  *      The amount of space needed in bytes to perform factorization.
  * </pre>
@@ -333,8 +333,12 @@ zLUMemInit(fact_t fact, void *work, int_t lwork, int m, int n, int_t annz,
     
 } /* zLUMemInit */
 
-/*! \brief Allocate known working storage. Returns 0 if success, otherwise
-   returns the number of bytes allocated so far when failure occurred. */
+/*! \brief Allocate known working storage.
+ *
+ * Returns 0 if success, otherwise returns the number of bytes 
+ * allocated so far when failure occurred. 
+*/
+
 int
 zLUWorkInit(int m, int n, int panel_size, int **iworkptr, 
             doublecomplex **dworkptr, GlobalLU_t *Glu)

--- a/SRC/zmemory.c
+++ b/SRC/zmemory.c
@@ -98,15 +98,14 @@ void zuser_free(int bytes, int which_end, GlobalLU_t *Glu)
 
 
 
-/*! \brief 
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int zQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {
@@ -136,15 +135,14 @@ int zQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 } /* zQuerySpace */
 
 
-/*! \brief
+/*!
+ * Calculate memory usage
  *
- * <pre>
- * mem_usage consists of the following fields:
- *    - for_lu (float)
+ * \param mem_usage consists of the following fields:
+ *    - <tt>for_lu (float)</tt>
  *      The amount of space used in bytes for the L\\U data structures.
- *    - total_needed (float)
+ *    - <tt>total_needed (float)</tt>
  *      The amount of space needed in bytes to perform factorization.
- * </pre>
  */
 int ilu_zQuerySpace(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage)
 {

--- a/SRC/zmyblas2.c
+++ b/SRC/zmyblas2.c
@@ -18,6 +18,7 @@ at the top-level directory.
  * and Lawrence Berkeley National Lab.
  * November 15, 1997
  * </pre>
+ * <pre>
  * Purpose:
  *     Level 2 BLAS operations: solves and matvec, written in C.
  * Note:

--- a/SRC/zpanel_bmod.c
+++ b/SRC/zpanel_bmod.c
@@ -46,7 +46,7 @@ at the top-level directory.
  *
  *    Performs numeric block updates (sup-panel) in topological order.
  *    It features: col-col, 2cols-col, 3cols-col, and sup-col updates.
- *    Special processing on the supernodal portion of L\U[*,j]
+ *    Special processing on the supernodal portion of L\\U[*,j]
  *
  *    Before entering this routine, the original nonzeros in the panel 
  *    were already copied into the spa[m,w].

--- a/SRC/zreadrb.c
+++ b/SRC/zreadrb.c
@@ -17,6 +17,7 @@ at the top-level directory.
  * Lawrence Berkeley National Laboratory.
  * June 30, 2009
  * </pre>
+ * <pre>
  *
  * Purpose
  * =======


### PR DESCRIPTION
Initial support for Doxygen when building SuperLU with CMake.

I extracted all relevant fixes from #25. With CMake 3.9 calling Doxygen became much easier, so I wrote my own code. Not all Doxygen fixes are still required with Doxygen 1.9.

@xiaoyeli