### PR TITLE
Draft: build and run examples with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ option(enable_single    "Enable single precision library" ON)
 option(enable_double    "Enable double precision library" ON)
 option(enable_complex   "Enable complex precision library" ON)
 option(enable_complex16 "Enable complex16 precision library" ON)
-# option(enable_examples  "Build examples" ON)
+option(enable_examples  "Build examples" ON)
 
 #-- BLAS
 option(TPL_ENABLE_INTERNAL_BLASLIB  "Build the CBLAS library" ${enable_blaslib_DEFAULT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,11 +219,12 @@ if(enable_doc)
   add_subdirectory(DOC)
 endif()
 
+######################################################################
+#
 # Generate various configure files with proper definitions
+#
+######################################################################
 
-# file(WRITE "make.defs" "# can be exposed to users"
-#  ${CMAKE_C_COMPILER}  )
-# configure_file(${CMAKE_SOURCE_DIR}/make.inc.in ${CMAKE_SOURCE_DIR}/make.inc)
 configure_file(${SuperLU_SOURCE_DIR}/make.inc.in ${SuperLU_SOURCE_DIR}/make.inc)
  
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/superlu.pc.in ${CMAKE_CURRENT_BINARY_DIR}/superlu.pc @ONLY)

--- a/EXAMPLE/CMakeLists.txt
+++ b/EXAMPLE/CMakeLists.txt
@@ -1,0 +1,8 @@
+include_directories(${SuperLU_SOURCE_DIR}/SRC)
+
+add_executable(slinsol
+               EXCLUDE_FROM_ALL
+               slinsol.c)
+target_link_libraries(slinsol superlu)
+add_test(NAME slinsol
+         COMMAND slinsol "${CMAKE_CURRENT_SOURCE_DIR}/g20.rua")

--- a/EXAMPLE/README
+++ b/EXAMPLE/README
@@ -35,7 +35,7 @@ To run the small 5x5 sample program in Section 1 of the Users' Guide, type:
     	% superlu
 
 To run the real version examples, type:
-        % dlinsol < g20.rua      (or, % slinsol < g20.rua)
+        % dlinsol < g20.rua      (or, % slinsol g20.rua)
         % dlinsolx  < g20.rua     (or, % slinsolx < g20.rua)
         % dlinsolx1 < g20.rua    (or, % slinsolx1 < g20.rua)
         % dlinsolx2 < g20.rua    (or, % slinsolx2 < g20.rua)

--- a/EXAMPLE/slinsol.c
+++ b/EXAMPLE/slinsol.c
@@ -1,4 +1,4 @@
-/*! \file
+/*
 Copyright (c) 2003, The Regents of the University of California, through
 Lawrence Berkeley National Laboratory (subject to receipt of any required 
 approvals from U.S. Dept. of Energy) 
@@ -15,6 +15,10 @@ at the top-level directory.
  * and Lawrence Berkeley National Lab.
  * October 15, 2003
  *
+ */
+
+/*! \file
+ * Example: use simple driver DGSSV to solve a linear system one time
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/EXAMPLE/slinsol.c
+++ b/EXAMPLE/slinsol.c
@@ -16,11 +16,27 @@ at the top-level directory.
  * October 15, 2003
  *
  */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include "slu_sdefs.h"
 
 int main(int argc, char *argv[])
 {
+    // ensure right number of arguments are passed
+    if (argc != 2) {
+        printf("slinsol requires one additional argument, the path to the matrix file %i\n", argc);
+        return EXIT_FAILURE;
+    }
+
+    // print out help
+    if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
+        printf("use simple driver DGSSV to solve a linear system one time\n");
+        printf("requires one additional argument, the path to the matrix file\n");
+        return EXIT_SUCCESS;
+    }
+
     SuperMatrix A;
     NCformat *Astore;
     float   *a;
@@ -38,7 +54,7 @@ int main(int argc, char *argv[])
     mem_usage_t   mem_usage;
     superlu_options_t options;
     SuperLUStat_t stat;
-    FILE      *fp = stdin;
+    FILE    *fp = fopen(argv[1], "r");
     
 #if ( DEBUGlevel>=1 )
     CHECK_MALLOC("Enter main()");

--- a/EXAMPLE/slinsol.c
+++ b/EXAMPLE/slinsol.c
@@ -129,9 +129,10 @@ int main(int argc, char *argv[])
 	}
     }
 
-    if ( options.PrintStat ) StatPrint(&stat);
-    StatFree(&stat);
+    if (options.PrintStat)
+        StatPrint(&stat);
 
+    StatFree(&stat);
     SUPERLU_FREE (rhs);
     SUPERLU_FREE (xact);
     SUPERLU_FREE (perm_r);
@@ -144,5 +145,6 @@ int main(int argc, char *argv[])
 #if ( DEBUGlevel>=1 )
     CHECK_MALLOC("Exit main()");
 #endif
-}
 
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
I created a first draft for building and running examples with CMake. It currently covers only one example, `slinsol`. I needed to adapt the way the matrices are passed to examples, the path is no longer passed by stdin, but as the first argument of the command, i.e., `slinsol ../../EXAMPLE/g20.rua` instead of `slinsol < ../../EXAMPLE/g20.rua`, mind the **<**.

@xiaoyeli Is this the right way to go? If yes, I will adapt the other examples in a similar way and extend this merge request.