### PR TITLE
[doxygen] Include modules.txt and mainpage.txt in DoxyConfig

### DIFF
--- a/DoxyConfig
+++ b/DoxyConfig
@@ -513,7 +513,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories 
 # with spaces.
 
-INPUT                  = SRC/ EXAMPLE/ FORTRAN/
+INPUT                  = SRC/ EXAMPLE/ FORTRAN/ DOC/mainpage.txt DOC/modules.txt
 
 # This tag can be used to specify the character encoding of the source files 
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ testing:
 	( cd TESTING ; $(MAKE) )
 
 doc:
-	doxygen Doxyfile
+	doxygen DoxyConfig
 
 cleanlib:
 	( cd SRC; $(MAKE) clean )


### PR DESCRIPTION
This added the missing files when building the Doxygen documentation with Make. When using CMake, the DoxyConfig is generated on the fly and it already contains these two files.

@xiaoyeli This should fix you Doxygen problems.

Over the time, we have to unify the way we build documentation or drop support for plain Makefiles and support only CMake.