### PR TITLE
testing/matgen: reduce use of f2c.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,14 @@ include(FeatureSummary)
 #
 ######################################################################
 
+# set C standard to C99 without GNU extensions, if not specified by the user
+if ("${CMAKE_C_STANDARD}" STREQUAL "")
+  set(CMAKE_C_STANDARD 99)
+endif()
+if ("${CMAKE_C_EXTENSIONS}" STREQUAL "")
+  set(CMAKE_C_EXTENSIONS FALSE)
+endif()
+
 #---- set RPATH handling
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH FALSE)

--- a/TESTING/MATGEN/cdotc.c
+++ b/TESTING/MATGEN/cdotc.c
@@ -5,20 +5,20 @@
 
 #include "f2c.h"
 
-/* Complex */ void cdotc_(complex * ret_val, integer *n, complex *cx, integer
-	*incx, complex *cy, integer *incy)
+/* Complex */ void cdotc_(complex * ret_val, int *n, complex *cx, int
+	*incx, complex *cy, int *incy)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     complex q__1, q__2, q__3;
 
     /* Builtin functions */
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer i;
+    static int i;
     static complex ctemp;
-    static integer ix, iy;
+    static int ix, iy;
 
 
 /*     forms the dot product of two vectors, conjugating the first   

--- a/TESTING/MATGEN/cdotc.c
+++ b/TESTING/MATGEN/cdotc.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Complex */ VOID cdotc_(complex * ret_val, integer *n, complex *cx, integer 
+/* Complex */ void cdotc_(complex * ret_val, integer *n, complex *cx, integer
 	*incx, complex *cy, integer *incy)
 {
     /* System generated locals */

--- a/TESTING/MATGEN/clacgv.c
+++ b/TESTING/MATGEN/clacgv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int clacgv_slu(integer *n, complex *x, integer *incx)
+/* Subroutine */ int clacgv_slu(int *n, complex *x, int *incx)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -39,7 +39,7 @@
     /* Builtin functions */
     void r_cnjg(complex *, complex *);
     /* Local variables */
-    static integer ioff, i;
+    static int ioff, i;
 
 
 #define X(I) x[(I)-1]

--- a/TESTING/MATGEN/clagge.c
+++ b/TESTING/MATGEN/clagge.c
@@ -9,15 +9,15 @@
 
 static complex c_b1 = {0.f,0.f};
 static complex c_b2 = {1.f,0.f};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int clagge_slu(integer *m, integer *n, integer *kl, integer *ku,
-	 real *d, complex *a, integer *lda, integer *iseed, complex *work, 
-	integer *info)
+/* Subroutine */ int clagge_slu(int *m, int *n, int *kl, int *ku,
+	 real *d, complex *a, int *lda, int *iseed, complex *work,
+	int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
     complex q__1;
 
@@ -26,17 +26,17 @@ static integer c__1 = 1;
     void c_div(complex *, complex *, complex *);
 
     /* Local variables */
-    static integer i, j;
-    extern /* Subroutine */ int cgerc_(integer *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, integer *),
-	     cscal_(integer *, complex *, complex *, integer *), cgemv_(char *
-	    , integer *, integer *, complex *, complex *, integer *, complex *
-	    , integer *, complex *, complex *, integer *);
-    extern real scnrm2_(integer *, complex *, integer *);
+    static int i, j;
+    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, int *),
+	     cscal_(int *, complex *, complex *, int *), cgemv_(char *
+	    , int *, int *, complex *, complex *, int *, complex *
+	    , int *, complex *, complex *, int *);
+    extern real scnrm2_(int *, complex *, int *);
     static complex wa, wb;
-    extern /* Subroutine */ int clacgv_slu(integer *, complex *, integer *);
+    extern /* Subroutine */ int clacgv_slu(int *, complex *, int *);
     static real wn;
-    extern /* Subroutine */ int clarnv_slu(integer *, integer *, integer *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
     extern int input_error(char *, int *);
     static complex tau;
 

--- a/TESTING/MATGEN/claghe.c
+++ b/TESTING/MATGEN/claghe.c
@@ -9,14 +9,14 @@
 
 static complex c_b1 = {0.f,0.f};
 static complex c_b2 = {1.f,0.f};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int claghe_slu(integer *n, integer *k, real *d, complex *a, 
-	integer *lda, integer *iseed, complex *work, integer *info)
+/* Subroutine */ int claghe_slu(int *n, int *k, real *d, complex *a,
+	int *lda, int *iseed, complex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
     complex q__1, q__2, q__3, q__4;
 
@@ -25,26 +25,26 @@ static integer c__1 = 1;
     void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
 
     /* Local variables */
-    extern /* Subroutine */ int cher2_(char *, integer *, complex *, complex *
-	    , integer *, complex *, integer *, complex *, integer *);
-    static integer i, j;
-    extern /* Subroutine */ int cgerc_(integer *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, integer *);
+    extern /* Subroutine */ int cher2_(char *, int *, complex *, complex *
+	    , int *, complex *, int *, complex *, int *);
+    static int i, j;
+    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, int *);
     static complex alpha;
-    extern /* Subroutine */ int cscal_(integer *, complex *, complex *, 
-	    integer *);
-    extern /* Complex */ void cdotc_(complex *, integer *, complex *, integer
-	    *, complex *, integer *);
-    extern /* Subroutine */ int cgemv_(char *, integer *, integer *, complex *
-	    , complex *, integer *, complex *, integer *, complex *, complex *
-	    , integer *), chemv_(char *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, complex *, 
-	    integer *), caxpy_(integer *, complex *, complex *, 
-	    integer *, complex *, integer *);
-    extern real scnrm2_(integer *, complex *, integer *);
+    extern /* Subroutine */ int cscal_(int *, complex *, complex *,
+	    int *);
+    extern /* Complex */ void cdotc_(complex *, int *, complex *, int
+	    *, complex *, int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
+	    , complex *, int *, complex *, int *, complex *, complex *
+	    , int *), chemv_(char *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, complex *,
+	    int *), caxpy_(int *, complex *, complex *,
+	    int *, complex *, int *);
+    extern real scnrm2_(int *, complex *, int *);
     static complex wa, wb;
     static real wn;
-    extern /* Subroutine */ int clarnv_slu(integer *, integer *, integer *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
     extern int input_error(char *, int *);
     static complex tau;
 

--- a/TESTING/MATGEN/claghe.c
+++ b/TESTING/MATGEN/claghe.c
@@ -33,7 +33,7 @@ static integer c__1 = 1;
     static complex alpha;
     extern /* Subroutine */ int cscal_(integer *, complex *, complex *, 
 	    integer *);
-    extern /* Complex */ VOID cdotc_(complex *, integer *, complex *, integer 
+    extern /* Complex */ void cdotc_(complex *, integer *, complex *, integer
 	    *, complex *, integer *);
     extern /* Subroutine */ int cgemv_(char *, integer *, integer *, complex *
 	    , complex *, integer *, complex *, integer *, complex *, complex *

--- a/TESTING/MATGEN/clagsy.c
+++ b/TESTING/MATGEN/clagsy.c
@@ -32,7 +32,7 @@ static integer c__1 = 1;
     static complex alpha;
     extern /* Subroutine */ int cscal_(integer *, complex *, complex *, 
 	    integer *);
-    extern /* Complex */ VOID cdotc_(complex *, integer *, complex *, integer 
+    extern /* Complex */ void cdotc_(complex *, integer *, complex *, integer
 	    *, complex *, integer *);
     extern /* Subroutine */ int cgemv_(char *, integer *, integer *, complex *
 	    , complex *, integer *, complex *, integer *, complex *, complex *

--- a/TESTING/MATGEN/clagsy.c
+++ b/TESTING/MATGEN/clagsy.c
@@ -9,14 +9,14 @@
 
 static complex c_b1 = {0.f,0.f};
 static complex c_b2 = {1.f,0.f};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int clagsy_slu(integer *n, integer *k, real *d, complex *a, 
-	integer *lda, integer *iseed, complex *work, integer *info)
+/* Subroutine */ int clagsy_slu(int *n, int *k, real *d, complex *a,
+	int *lda, int *iseed, complex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6, i__7, i__8, 
+    int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6, i__7, i__8,
 	    i__9;
     doublereal d__1;
     complex q__1, q__2, q__3, q__4;
@@ -26,26 +26,26 @@ static integer c__1 = 1;
     void c_div(complex *, complex *, complex *);
 
     /* Local variables */
-    static integer i, j;
-    extern /* Subroutine */ int cgerc_(integer *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, integer *);
+    static int i, j;
+    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, int *);
     static complex alpha;
-    extern /* Subroutine */ int cscal_(integer *, complex *, complex *, 
-	    integer *);
-    extern /* Complex */ void cdotc_(complex *, integer *, complex *, integer
-	    *, complex *, integer *);
-    extern /* Subroutine */ int cgemv_(char *, integer *, integer *, complex *
-	    , complex *, integer *, complex *, integer *, complex *, complex *
-	    , integer *), caxpy_(integer *, complex *, complex *, 
-	    integer *, complex *, integer *), csymv_sluslu(char *, integer *, 
-	    complex *, complex *, integer *, complex *, integer *, complex *, 
-	    complex *, integer *);
-    extern real scnrm2_(integer *, complex *, integer *);
-    static integer ii, jj;
+    extern /* Subroutine */ int cscal_(int *, complex *, complex *,
+	    int *);
+    extern /* Complex */ void cdotc_(complex *, int *, complex *, int
+	    *, complex *, int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
+	    , complex *, int *, complex *, int *, complex *, complex *
+	    , int *), caxpy_(int *, complex *, complex *,
+	    int *, complex *, int *), csymv_sluslu(char *, int *,
+	    complex *, complex *, int *, complex *, int *, complex *,
+	    complex *, int *);
+    extern real scnrm2_(int *, complex *, int *);
+    static int ii, jj;
     static complex wa, wb;
-    extern /* Subroutine */ int clacgv_slu(integer *, complex *, integer *);
+    extern /* Subroutine */ int clacgv_slu(int *, complex *, int *);
     static real wn;
-    extern /* Subroutine */ int clarnv_slu(integer *, integer *, integer *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
     extern int input_error(char *, int *);
     static complex tau;
 

--- a/TESTING/MATGEN/clarge.c
+++ b/TESTING/MATGEN/clarge.c
@@ -9,14 +9,14 @@
 
 static complex c_b1 = {0.f,0.f};
 static complex c_b2 = {1.f,0.f};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int clarge_slu(integer *n, complex *a, integer *lda, integer *
-	iseed, complex *work, integer *info)
+/* Subroutine */ int clarge_slu(int *n, complex *a, int *lda, int *
+	iseed, complex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1;
+    int a_dim1, a_offset, i__1;
     doublereal d__1;
     complex q__1;
 
@@ -25,16 +25,16 @@ static integer c__1 = 1;
     void c_div(complex *, complex *, complex *);
 
     /* Local variables */
-    static integer i;
-    extern /* Subroutine */ int cgerc_(integer *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, integer *),
-	     cscal_(integer *, complex *, complex *, integer *), cgemv_(char *
-	    , integer *, integer *, complex *, complex *, integer *, complex *
-	    , integer *, complex *, complex *, integer *);
-    extern real scnrm2_(integer *, complex *, integer *);
+    static int i;
+    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, int *),
+	     cscal_(int *, complex *, complex *, int *), cgemv_(char *
+	    , int *, int *, complex *, complex *, int *, complex *
+	    , int *, complex *, complex *, int *);
+    extern real scnrm2_(int *, complex *, int *);
     static complex wa, wb;
     static real wn;
-    extern /* Subroutine */ int clarnv_slu(integer *, integer *, integer *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
     extern int input_error(char *, int *);
     static complex tau;
 

--- a/TESTING/MATGEN/clarnd.c
+++ b/TESTING/MATGEN/clarnd.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Complex */ void clarnd_slu(complex * ret_val, integer *idist, integer *iseed)
+/* Complex */ void clarnd_slu(complex * ret_val, int *idist, int *iseed)
 {
     /* System generated locals */
     doublereal d__1, d__2;
@@ -17,7 +17,7 @@
 
     /* Local variables */
     static real t1, t2;
-    extern doublereal dlaran_sluslu(integer *);
+    extern doublereal dlaran_sluslu(int *);
     extern int input_error(char *, int *);
 
 

--- a/TESTING/MATGEN/clarnd.c
+++ b/TESTING/MATGEN/clarnd.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Complex */ VOID clarnd_slu(complex * ret_val, integer *idist, integer *iseed)
+/* Complex */ void clarnd_slu(complex * ret_val, integer *idist, integer *iseed)
 {
     /* System generated locals */
     doublereal d__1, d__2;

--- a/TESTING/MATGEN/clarnv.c
+++ b/TESTING/MATGEN/clarnv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int clarnv_slu(integer *idist, integer *iseed, integer *n, 
+/* Subroutine */ int clarnv_slu(int *idist, int *iseed, int *n,
 	complex *x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -56,17 +56,17 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer i__2, i__3;
+    int i__2, i__3;
     doublereal d__1, d__2;
     complex q__1, q__2, q__3;
     /* Builtin functions */
     double log(doublereal), sqrt(doublereal);
     void c_exp(complex *, complex *);
     /* Local variables */
-    static integer i;
+    static int i;
     static real u[128];
-    static integer il, iv;
-    extern /* Subroutine */ int slaruv_slu(integer *, integer *, real *);
+    static int il, iv;
+    extern /* Subroutine */ int slaruv_slu(int *, int *, real *);
 
 
 #define X(I) x[(I)-1]

--- a/TESTING/MATGEN/claror.c
+++ b/TESTING/MATGEN/claror.c
@@ -39,7 +39,7 @@ static integer c__1 = 1;
     static real xnorm;
     extern real scnrm2_(integer *, complex *, integer *);
     extern /* Subroutine */ int clacgv_slu(integer *, complex *, integer *);
-    extern /* Complex */ VOID clarnd_slu(complex *, integer *, integer *);
+    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
     extern /* Subroutine */ int claset_slu(char *, integer *, integer *, complex 
 	    *, complex *, complex *, integer *);
     extern int input_error(char *, int *);

--- a/TESTING/MATGEN/claror.c
+++ b/TESTING/MATGEN/claror.c
@@ -11,14 +11,14 @@
 
 static complex c_b1 = {0.f,0.f};
 static complex c_b2 = {1.f,0.f};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int claror_slu(char *side, char *init, integer *m, integer *n, 
-	complex *a, integer *lda, integer *iseed, complex *x, integer *info)
+/* Subroutine */ int claror_slu(char *side, char *init, int *m, int *n,
+	complex *a, int *lda, int *iseed, complex *x, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     complex q__1, q__2;
 
     /* Builtin functions */
@@ -26,23 +26,23 @@ static integer c__1 = 1;
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer kbeg, jcol;
+    static int kbeg, jcol;
     static real xabs;
-    static integer irow, j;
-    extern /* Subroutine */ int cgerc_(integer *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, integer *),
-	     cscal_(integer *, complex *, complex *, integer *);
-    extern /* Subroutine */ int cgemv_(char *, integer *, integer *, complex *
-	    , complex *, integer *, complex *, integer *, complex *, complex *
-	    , integer *);
+    static int irow, j;
+    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, int *),
+	     cscal_(int *, complex *, complex *, int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
+	    , complex *, int *, complex *, int *, complex *, complex *
+	    , int *);
     static complex csign;
-    static integer ixfrm, itype, nxfrm;
+    static int ixfrm, itype, nxfrm;
     static real xnorm;
-    extern real scnrm2_(integer *, complex *, integer *);
-    extern /* Subroutine */ int clacgv_slu(integer *, complex *, integer *);
-    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
-    extern /* Subroutine */ int claset_slu(char *, integer *, integer *, complex 
-	    *, complex *, complex *, integer *);
+    extern real scnrm2_(int *, complex *, int *);
+    extern /* Subroutine */ int clacgv_slu(int *, complex *, int *);
+    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    extern /* Subroutine */ int claset_slu(char *, int *, int *, complex
+	    *, complex *, complex *, int *);
     extern int input_error(char *, int *);
     static real factor;
     static complex xnorms;

--- a/TESTING/MATGEN/claror.c
+++ b/TESTING/MATGEN/claror.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <math.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -257,7 +258,7 @@ static integer c__1 = 1;
 	q__1.r = -(doublereal)csign.r, q__1.i = -(doublereal)csign.i;
 	x[i__2].r = q__1.r, x[i__2].i = q__1.i;
 	factor = xnorm * (xnorm + xabs);
-	if (dabs(factor) < 1e-20f) {
+	if (fabs(factor) < 1e-20f) {
 	    *info = 1;
 	    i__2 = -(*info);
 	    input_error("CLAROR", &i__2);

--- a/TESTING/MATGEN/clarot.c
+++ b/TESTING/MATGEN/clarot.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include "f2c.h"
 
 /* Table of constant values */
@@ -10,7 +11,8 @@
 static integer c__4 = 4;
 static integer c__8 = 8;
 
-/* Subroutine */ int clarot_slu(logical *lrows, logical *lleft, logical *lright, 
+/* Subroutine */
+int clarot_slu(bool *lrows, bool *lleft, bool *lright,
 	integer *nl, complex *c, complex *s, complex *a, integer *lda, 
 	complex *xleft, complex *xright)
 {

--- a/TESTING/MATGEN/clarot.c
+++ b/TESTING/MATGEN/clarot.c
@@ -8,28 +8,28 @@
 
 /* Table of constant values */
 
-static integer c__4 = 4;
-static integer c__8 = 8;
+static int c__4 = 4;
+static int c__8 = 8;
 
 /* Subroutine */
 int clarot_slu(bool *lrows, bool *lleft, bool *lright,
-	integer *nl, complex *c, complex *s, complex *a, integer *lda, 
+	int *nl, complex *c, complex *s, complex *a, int *lda,
 	complex *xleft, complex *xright)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
+    int i__1, i__2, i__3, i__4;
     complex q__1, q__2, q__3, q__4, q__5, q__6;
 
     /* Builtin functions */
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer iinc, j, inext;
+    static int iinc, j, inext;
     static complex tempx;
-    static integer ix, iy, nt;
+    static int ix, iy, nt;
     static complex xt[2], yt[2];
     extern int input_error(char *, int *);
-    static integer iyt;
+    static int iyt;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clartg.c
+++ b/TESTING/MATGEN/clartg.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "f2c.h"
 
 /* Subroutine */ int clartg_slu(complex *f, complex *g, real *cs, complex *sn, 
@@ -78,8 +79,8 @@
            R = G */
 
     } else {
-	f1 = (r__1 = f->r, dabs(r__1)) + (r__2 = r_imag(f), dabs(r__2));
-	g1 = (r__1 = g->r, dabs(r__1)) + (r__2 = r_imag(g), dabs(r__2));
+	f1 = (r__1 = f->r, fabs(r__1)) + (r__2 = r_imag(f), fabs(r__2));
+	g1 = (r__1 = g->r, fabs(r__1)) + (r__2 = r_imag(g), fabs(r__2));
 	if (f1 >= g1) {
 	    q__1.r = g->r / f1, q__1.i = g->i / f1;
 	    gs.r = q__1.r, gs.i = q__1.i;

--- a/TESTING/MATGEN/claset.c
+++ b/TESTING/MATGEN/claset.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int claset_slu(char *uplo, integer *m, integer *n, complex *
-	alpha, complex *beta, complex *a, integer *lda)
+/* Subroutine */ int claset_slu(char *uplo, int *m, int *n, complex *
+	alpha, complex *beta, complex *a, int *lda)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -59,7 +59,7 @@
     /* System generated locals */
 
     /* Local variables */
-    static integer i, j;
+    static int i, j;
 
 
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]

--- a/TESTING/MATGEN/clatb4.c
+++ b/TESTING/MATGEN/clatb4.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -14,7 +15,7 @@
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bool first = true;
 
     /* System generated locals */
     integer i__1;
@@ -95,7 +96,7 @@
        Set some constants for use in the subroutine. */
 
     if (first) {
-	first = FALSE_;
+	first = false;
 	eps = smach("Precision");
 	badc2 = .1f / eps;
 	badc1 = sqrt(badc2);

--- a/TESTING/MATGEN/clatb4.c
+++ b/TESTING/MATGEN/clatb4.c
@@ -4,6 +4,7 @@
 */
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/clatb4.c
+++ b/TESTING/MATGEN/clatb4.c
@@ -10,8 +10,8 @@
 
 /* Table of constant values */
 
-/* Subroutine */ int clatb4_slu(char *path, integer *imat, integer *m, integer *
-	n, char *type, integer *kl, integer *ku, real *anorm, integer *mode, 
+/* Subroutine */ int clatb4_slu(char *path, int *imat, int *m, int *
+	n, char *type, int *kl, int *ku, real *anorm, int *mode,
 	real *cndnum, char *dist)
 {
     /* Initialized data */
@@ -19,7 +19,7 @@
     static bool first = true;
 
     /* System generated locals */
-    integer i__1;
+    int i__1;
 
     /* Builtin functions */
     double sqrt(doublereal);
@@ -29,7 +29,7 @@
     static char c2[2];
     extern /* Subroutine */ int slabad_slu(real *, real *);
     extern float smach(char *);
-    static integer mat;
+    static int mat;
     static real eps;
 
 

--- a/TESTING/MATGEN/clatm2.c
+++ b/TESTING/MATGEN/clatm2.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Complex */ VOID clatm2_slu(complex * ret_val, integer *m, integer *n, integer 
+/* Complex */ void clatm2_slu(complex * ret_val, integer *m, integer *n, integer
 	*i, integer *j, integer *kl, integer *ku, integer *idist, integer *
 	iseed, complex *d, integer *igrade, complex *dl, complex *dr, integer 
 	*ipvtng, integer *iwork, real *sparse)
@@ -20,7 +20,7 @@
     /* Local variables */
     static integer isub, jsub;
     static complex ctemp;
-    extern /* Complex */ VOID clarnd_slu(complex *, integer *, integer *);
+    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
     extern doublereal dlaran_sluslu(integer *);
 
 

--- a/TESTING/MATGEN/clatm2.c
+++ b/TESTING/MATGEN/clatm2.c
@@ -5,23 +5,23 @@
 
 #include "f2c.h"
 
-/* Complex */ void clatm2_slu(complex * ret_val, integer *m, integer *n, integer
-	*i, integer *j, integer *kl, integer *ku, integer *idist, integer *
-	iseed, complex *d, integer *igrade, complex *dl, complex *dr, integer 
-	*ipvtng, integer *iwork, real *sparse)
+/* Complex */ void clatm2_slu(complex * ret_val, int *m, int *n, int
+	*i, int *j, int *kl, int *ku, int *idist, int *
+	iseed, complex *d, int *igrade, complex *dl, complex *dr, int
+	*ipvtng, int *iwork, real *sparse)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     complex q__1, q__2, q__3;
 
     /* Builtin functions */
     void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer isub, jsub;
+    static int isub, jsub;
     static complex ctemp;
-    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
-    extern doublereal dlaran_sluslu(integer *);
+    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    extern doublereal dlaran_sluslu(int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clatm3.c
+++ b/TESTING/MATGEN/clatm3.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Complex */ VOID clatm3_slu(complex * ret_val, integer *m, integer *n, integer 
+/* Complex */ void clatm3_slu(complex * ret_val, integer *m, integer *n, integer
 	*i, integer *j, integer *isub, integer *jsub, integer *kl, integer *
 	ku, integer *idist, integer *iseed, complex *d, integer *igrade, 
 	complex *dl, complex *dr, integer *ipvtng, integer *iwork, real *
@@ -20,7 +20,7 @@
 
     /* Local variables */
     static complex ctemp;
-    extern /* Complex */ VOID clarnd_slu(complex *, integer *, integer *);
+    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
     extern doublereal dlaran_sluslu(integer *);
 
 

--- a/TESTING/MATGEN/clatm3.c
+++ b/TESTING/MATGEN/clatm3.c
@@ -5,14 +5,14 @@
 
 #include "f2c.h"
 
-/* Complex */ void clatm3_slu(complex * ret_val, integer *m, integer *n, integer
-	*i, integer *j, integer *isub, integer *jsub, integer *kl, integer *
-	ku, integer *idist, integer *iseed, complex *d, integer *igrade, 
-	complex *dl, complex *dr, integer *ipvtng, integer *iwork, real *
+/* Complex */ void clatm3_slu(complex * ret_val, int *m, int *n, int
+	*i, int *j, int *isub, int *jsub, int *kl, int *
+	ku, int *idist, int *iseed, complex *d, int *igrade,
+	complex *dl, complex *dr, int *ipvtng, int *iwork, real *
 	sparse)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     complex q__1, q__2, q__3;
 
     /* Builtin functions */
@@ -20,8 +20,8 @@
 
     /* Local variables */
     static complex ctemp;
-    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
-    extern doublereal dlaran_sluslu(integer *);
+    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    extern doublereal dlaran_sluslu(int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clatme.c
+++ b/TESTING/MATGEN/clatme.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/clatme.c
+++ b/TESTING/MATGEN/clatme.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -428,7 +429,7 @@ static integer c__5 = 5;
 	for (i = 2; i <= i__1; ++i) {
 /* Computing MAX */
 	    r__1 = temp, r__2 = c_abs(&d[i]);
-	    temp = dmax(r__1,r__2);
+	    temp = fmax(r__1,r__2);
 /* L30: */
 	}
 

--- a/TESTING/MATGEN/clatme.c
+++ b/TESTING/MATGEN/clatme.c
@@ -12,18 +12,18 @@
 
 static complex c_b1 = {0.f,0.f};
 static complex c_b2 = {1.f,0.f};
-static integer c__1 = 1;
-static integer c__0 = 0;
-static integer c__5 = 5;
+static int c__1 = 1;
+static int c__0 = 0;
+static int c__5 = 5;
 
-/* Subroutine */ int clatme_slu(integer *n, char *dist, integer *iseed, complex *
-	d, integer *mode, real *cond, complex *dmax__, char *ei, char *rsign, 
-	char *upper, char *sim, real *ds, integer *modes, real *conds, 
-	integer *kl, integer *ku, real *anorm, complex *a, integer *lda, 
-	complex *work, integer *info)
+/* Subroutine */ int clatme_slu(int *n, char *dist, int *iseed, complex *
+	d, int *mode, real *cond, complex *dmax__, char *ei, char *rsign,
+	char *upper, char *sim, real *ds, int *modes, real *conds,
+	int *kl, int *ku, real *anorm, complex *a, int *lda,
+	complex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
+    int a_dim1, a_offset, i__1, i__2;
     real r__1, r__2;
     complex q__1, q__2;
 
@@ -33,45 +33,45 @@ static integer c__5 = 5;
 
     /* Local variables */
     static bool bads;
-    static integer isim;
+    static int isim;
     static real temp;
-    static integer i, j;
-    extern /* Subroutine */ int cgerc_(integer *, integer *, complex *, 
-	    complex *, integer *, complex *, integer *, complex *, integer *);
+    static int i, j;
+    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
+	    complex *, int *, complex *, int *, complex *, int *);
     static complex alpha;
-    extern /* Subroutine */ int cscal_(integer *, complex *, complex *, 
-	    integer *);
-    extern /* Subroutine */ int cgemv_(char *, integer *, integer *, complex *
-	    , complex *, integer *, complex *, integer *, complex *, complex *
-	    , integer *);
-    static integer iinfo;
+    extern /* Subroutine */ int cscal_(int *, complex *, complex *,
+	    int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
+	    , complex *, int *, complex *, int *, complex *, complex *
+	    , int *);
+    static int iinfo;
     static real tempa[1];
-    static integer icols, idist;
-    extern /* Subroutine */ int ccopy_(integer *, complex *, integer *, 
-	    complex *, integer *);
-    static integer irows;
-    extern /* Subroutine */ int clatm1_(integer *, real *, integer *, integer 
-	    *, integer *, complex *, integer *, integer *), slatm1_slu(integer *,
-	     real *, integer *, integer *, integer *, real *, integer *, 
-	    integer *);
-    static integer ic, jc;
-    extern doublereal clange_(char *, integer *, integer *, complex *, 
-	    integer *, real *);
-    static integer ir;
-    extern /* Subroutine */ int clarge_slu(integer *, complex *, integer *, 
-	    integer *, complex *, integer *), clarfg_(integer *, complex *, 
-	    complex *, integer *, complex *), clacgv_slu(integer *, complex *, 
-	    integer *);
-    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
+    static int icols, idist;
+    extern /* Subroutine */ int ccopy_(int *, complex *, int *,
+	    complex *, int *);
+    static int irows;
+    extern /* Subroutine */ int clatm1_(int *, real *, int *, int
+	    *, int *, complex *, int *, int *), slatm1_slu(int *,
+	     real *, int *, int *, int *, real *, int *,
+	    int *);
+    static int ic, jc;
+    extern doublereal clange_(char *, int *, int *, complex *,
+	    int *, real *);
+    static int ir;
+    extern /* Subroutine */ int clarge_slu(int *, complex *, int *,
+	    int *, complex *, int *), clarfg_(int *, complex *,
+	    complex *, int *, complex *), clacgv_slu(int *, complex *,
+	    int *);
+    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
     static real ralpha;
-    extern /* Subroutine */ int csscal_(integer *, real *, complex *, integer 
-	    *), claset_slu(char *, integer *, integer *, complex *, complex *, 
-	    complex *, integer *),
-	     clarnv_slu(integer *, integer *, integer *, complex *);
+    extern /* Subroutine */ int csscal_(int *, real *, complex *, int
+	    *), claset_slu(char *, int *, int *, complex *, complex *,
+	    complex *, int *),
+	     clarnv_slu(int *, int *, int *, complex *);
     extern int input_error(char *, int *);
-    static integer irsign, iupper;
+    static int irsign, iupper;
     static complex xnorms;
-    static integer jcr;
+    static int jcr;
     static complex tau;
 
 

--- a/TESTING/MATGEN/clatme.c
+++ b/TESTING/MATGEN/clatme.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -29,7 +30,7 @@ static integer c__5 = 5;
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static logical bads;
+    static bool bads;
     static integer isim;
     static real temp;
     static integer i, j;
@@ -350,12 +351,12 @@ static integer c__5 = 5;
 
 /*     Check DS, if MODES=0 and ISIM=1 */
 
-    bads = FALSE_;
+    bads = false;
     if (*modes == 0 && isim == 1) {
 	i__1 = *n;
 	for (j = 1; j <= i__1; ++j) {
 	    if (ds[j] == 0.f) {
-		bads = TRUE_;
+		bads = true;
 	    }
 /* L10: */
 	}

--- a/TESTING/MATGEN/clatme.c
+++ b/TESTING/MATGEN/clatme.c
@@ -60,7 +60,7 @@ static integer c__5 = 5;
 	    integer *, complex *, integer *), clarfg_(integer *, complex *, 
 	    complex *, integer *, complex *), clacgv_slu(integer *, complex *, 
 	    integer *);
-    extern /* Complex */ VOID clarnd_slu(complex *, integer *, integer *);
+    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
     static real ralpha;
     extern /* Subroutine */ int csscal_(integer *, real *, complex *, integer 
 	    *), claset_slu(char *, integer *, integer *, complex *, complex *, 

--- a/TESTING/MATGEN/clatms.c
+++ b/TESTING/MATGEN/clatms.c
@@ -2,7 +2,9 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <math.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -532,7 +534,7 @@ static bool c_false = false;
 /*     Choose Top-Down if D is (apparently) increasing,   
        Bottom-Up if D is (apparently) decreasing. */
 
-    if (dabs(d[1]) <= (r__1 = d[mnmin], dabs(r__1))) {
+    if (fabs(d[1]) <= (r__1 = d[mnmin], fabs(r__1))) {
 	topdwn = true;
     } else {
 	topdwn = false;
@@ -542,11 +544,11 @@ static bool c_false = false;
 
 /*        Scale by DMAX */
 
-	temp = dabs(d[1]);
+	temp = fabs(d[1]);
 	i__1 = mnmin;
 	for (i = 2; i <= i__1; ++i) {
 /* Computing MAX */
-	    r__2 = temp, r__3 = (r__1 = d[i], dabs(r__1));
+	    r__2 = temp, r__3 = (r__1 = d[i], fabs(r__1));
 	    temp = dmax(r__2,r__3);
 /* L20: */
 	}

--- a/TESTING/MATGEN/clatms.c
+++ b/TESTING/MATGEN/clatms.c
@@ -549,7 +549,7 @@ static bool c_false = false;
 	for (i = 2; i <= i__1; ++i) {
 /* Computing MAX */
 	    r__2 = temp, r__3 = (r__1 = d[i], fabs(r__1));
-	    temp = dmax(r__2,r__3);
+	    temp = fmax(r__2,r__3);
 /* L20: */
 	}
 

--- a/TESTING/MATGEN/clatms.c
+++ b/TESTING/MATGEN/clatms.c
@@ -11,18 +11,18 @@
 /* Table of constant values */
 
 static complex c_b1 = {0.f,0.f};
-static integer c__1 = 1;
-static integer c__5 = 5;
+static int c__1 = 1;
+static int c__5 = 5;
 static bool c_true = true;
 static bool c_false = false;
 
-/* Subroutine */ int clatms_slu(integer *m, integer *n, char *dist, integer *
-	iseed, char *sym, real *d, integer *mode, real *cond, real *dmax__, 
-	integer *kl, integer *ku, char *pack, complex *a, integer *lda, 
-	complex *work, integer *info)
+/* Subroutine */ int clatms_slu(int *m, int *n, char *dist, int *
+	iseed, char *sym, real *d, int *mode, real *cond, real *dmax__,
+	int *kl, int *ku, char *pack, complex *a, int *lda,
+	complex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     real r__1, r__2, r__3;
     doublereal d__1;
     complex q__1, q__2, q__3;
@@ -33,49 +33,49 @@ static bool c_false = false;
     void r_cnjg(complex *, complex *);
 
     /* Local variables */
-    static integer ilda, icol;
+    static int ilda, icol;
     static real temp;
     static bool csym;
-    static integer irow, isym;
+    static int irow, isym;
     static complex c;
-    static integer i, j, k;
+    static int i, j, k;
     static complex s;
     static real alpha, angle;
-    static integer ipack;
+    static int ipack;
     static real realc;
-    static integer ioffg;
-    static integer iinfo;
-    extern /* Subroutine */ int sscal_(integer *, real *, real *, integer *);
+    static int ioffg;
+    static int iinfo;
+    extern /* Subroutine */ int sscal_(int *, real *, real *, int *);
     static complex ctemp;
-    static integer idist, mnmin, iskew;
+    static int idist, mnmin, iskew;
     static complex extra, dummy;
-    extern /* Subroutine */ int slatm1_slu(integer *, real *, integer *, integer 
-	    *, integer *, real *, integer *, integer *);
-    static integer ic, jc, nc;
-    extern /* Subroutine */ int clagge_slu(integer *, integer *, integer *, 
-	    integer *, real *, complex *, integer *, integer *, complex *, 
-	    integer *), claghe_slu(integer *, integer *, real *, complex *, 
-	    integer *, integer *, complex *, integer *);
-    static integer il;
+    extern /* Subroutine */ int slatm1_slu(int *, real *, int *, int
+	    *, int *, real *, int *, int *);
+    static int ic, jc, nc;
+    extern /* Subroutine */ int clagge_slu(int *, int *, int *,
+	    int *, real *, complex *, int *, int *, complex *,
+	    int *), claghe_slu(int *, int *, real *, complex *,
+	    int *, int *, complex *, int *);
+    static int il;
     static complex ct;
-    static integer iendch, ir, jr, ipackg, mr;
-    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
-    static integer minlda;
+    static int iendch, ir, jr, ipackg, mr;
+    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    static int minlda;
     static complex st;
-    extern /* Subroutine */ int claset_slu(char *, integer *, integer *, complex 
-	    *, complex *, complex *, integer *), clartg_slu(complex *, 
+    extern /* Subroutine */ int claset_slu(char *, int *, int *, complex
+	    *, complex *, complex *, int *), clartg_slu(complex *,
 	    complex *, real *, complex *, complex *), 
-	    clagsy_slu(integer *, integer *, real *, complex *, 
-	    integer *, integer *, complex *, integer *);
+	    clagsy_slu(int *, int *, real *, complex *,
+	    int *, int *, complex *, int *);
     extern int input_error(char *, int *);
-    extern doublereal slarnd_slu(integer *, integer *);
+    extern doublereal slarnd_slu(int *, int *);
     extern /* Subroutine */ int clarot_slu(bool *, bool *, bool *,
-	    integer *, complex *, complex *, complex *, integer *, complex *, 
+	    int *, complex *, complex *, complex *, int *, complex *,
 	    complex *);
     static bool iltemp, givens;
-    static integer ioffst, irsign;
+    static int ioffst, irsign;
     static bool ilextr, topdwn;
-    static integer ir1, ir2, isympk, jch, llb, jkl, jku, uub;
+    static int ir1, ir2, isympk, jch, llb, jkl, jku, uub;
 
 
 /*  -- LAPACK test routine (version 2.0) --   

--- a/TESTING/MATGEN/clatms.c
+++ b/TESTING/MATGEN/clatms.c
@@ -57,7 +57,7 @@ static bool c_false = false;
     static integer il;
     static complex ct;
     static integer iendch, ir, jr, ipackg, mr;
-    extern /* Complex */ VOID clarnd_slu(complex *, integer *, integer *);
+    extern /* Complex */ void clarnd_slu(complex *, integer *, integer *);
     static integer minlda;
     static complex st;
     extern /* Subroutine */ int claset_slu(char *, integer *, integer *, complex 

--- a/TESTING/MATGEN/clatms.c
+++ b/TESTING/MATGEN/clatms.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -10,8 +11,8 @@
 static complex c_b1 = {0.f,0.f};
 static integer c__1 = 1;
 static integer c__5 = 5;
-static logical c_true = TRUE_;
-static logical c_false = FALSE_;
+static bool c_true = true;
+static bool c_false = false;
 
 /* Subroutine */ int clatms_slu(integer *m, integer *n, char *dist, integer *
 	iseed, char *sym, real *d, integer *mode, real *cond, real *dmax__, 
@@ -23,7 +24,7 @@ static logical c_false = FALSE_;
     real r__1, r__2, r__3;
     doublereal d__1;
     complex q__1, q__2, q__3;
-    logical L__1;
+    bool L__1;
 
     /* Builtin functions */
     double cos(doublereal), sin(doublereal);
@@ -32,7 +33,7 @@ static logical c_false = FALSE_;
     /* Local variables */
     static integer ilda, icol;
     static real temp;
-    static logical csym;
+    static bool csym;
     static integer irow, isym;
     static complex c;
     static integer i, j, k;
@@ -66,12 +67,12 @@ static logical c_false = FALSE_;
 	    integer *, integer *, complex *, integer *);
     extern int input_error(char *, int *);
     extern doublereal slarnd_slu(integer *, integer *);
-    extern /* Subroutine */ int clarot_slu(logical *, logical *, logical *, 
+    extern /* Subroutine */ int clarot_slu(bool *, bool *, bool *,
 	    integer *, complex *, complex *, complex *, integer *, complex *, 
 	    complex *);
-    static logical iltemp, givens;
+    static bool iltemp, givens;
     static integer ioffst, irsign;
-    static logical ilextr, topdwn;
+    static bool ilextr, topdwn;
     static integer ir1, ir2, isympk, jch, llb, jkl, jku, uub;
 
 
@@ -383,19 +384,19 @@ static logical c_false = FALSE_;
     if (strncmp(sym, "N", 1)==0) {
 	isym = 1;
 	irsign = 0;
-	csym = FALSE_;
+	csym = false;
     } else if (strncmp(sym, "P", 1)==0) {
 	isym = 2;
 	irsign = 0;
-	csym = FALSE_;
+	csym = false;
     } else if (strncmp(sym, "S", 1)==0) {
 	isym = 2;
 	irsign = 0;
-	csym = TRUE_;
+	csym = true;
     } else if (strncmp(sym, "H", 1)==0) {
 	isym = 2;
 	irsign = 1;
-	csym = FALSE_;
+	csym = false;
     } else {
 	isym = -1;
     }
@@ -456,20 +457,20 @@ static logical c_false = FALSE_;
 /*     Use Givens rotation method if bandwidth small enough,   
        or if LDA is too small to store the matrix unpacked. */
 
-    givens = FALSE_;
+    givens = false;
     if (isym == 1) {
 /* Computing MAX */
 	i__1 = 1, i__2 = mr + nc;
 	if ((real) (llb + uub) < (real) max(i__1,i__2) * .3f) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     } else {
 	if (llb << 1 < *m) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     }
     if (*lda < *m && *lda >= minlda) {
-	givens = TRUE_;
+	givens = true;
     }
 
 /*     Set INFO if an error */
@@ -532,9 +533,9 @@ static logical c_false = FALSE_;
        Bottom-Up if D is (apparently) decreasing. */
 
     if (dabs(d[1]) <= (r__1 = d[mnmin], dabs(r__1))) {
-	topdwn = TRUE_;
+	topdwn = true;
     } else {
-	topdwn = FALSE_;
+	topdwn = false;
     }
 
     if (*mode != 0 && abs(*mode) != 6) {

--- a/TESTING/MATGEN/csymv.c
+++ b/TESTING/MATGEN/csymv.c
@@ -1,9 +1,9 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int csymv_sluslu(char *uplo, integer *n, complex *alpha, complex *
-	a, integer *lda, complex *x, integer *incx, complex *beta, complex *y,
-	 integer *incy)
+/* Subroutine */ int csymv_sluslu(char *uplo, int *n, complex *alpha, complex *
+	a, int *lda, complex *x, int *incx, complex *beta, complex *y,
+	 int *incy)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -106,10 +106,10 @@
 
     complex q__1, q__2, q__3, q__4;
     /* Local variables */
-    static integer info;
+    static int info;
     static complex temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    static int i, j;
+    static int ix, iy, jx, jy, kx, ky;
     extern int input_error(char *, int *);
 
 #define X(I) x[(I)-1]

--- a/TESTING/MATGEN/d_lg10.c
+++ b/TESTING/MATGEN/d_lg10.c
@@ -2,7 +2,6 @@
 
 #define log10e 0.43429448190325182765
 
-#undef abs
 #include "math.h"
 
 double d_lg10(doublereal *x)

--- a/TESTING/MATGEN/d_lg10.c
+++ b/TESTING/MATGEN/d_lg10.c
@@ -2,14 +2,10 @@
 
 #define log10e 0.43429448190325182765
 
-#ifdef KR_headers
-double log();
-double d_lg10(x) doublereal *x;
-#else
 #undef abs
 #include "math.h"
+
 double d_lg10(doublereal *x)
-#endif
 {
 return( log10e * log(*x) );
 }

--- a/TESTING/MATGEN/d_sign.c
+++ b/TESTING/MATGEN/d_sign.c
@@ -1,10 +1,6 @@
 #include "f2c.h"
 
-#ifdef KR_headers
-double d_sign(a,b) doublereal *a, *b;
-#else
 double d_sign(doublereal *a, doublereal *b)
-#endif
 {
 double x;
 x = (*a >= 0 ? *a : - *a);

--- a/TESTING/MATGEN/dlagge.c
+++ b/TESTING/MATGEN/dlagge.c
@@ -7,34 +7,34 @@
 
 /* Table of constant values */
 
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 static doublereal c_b11 = 1.;
 static doublereal c_b13 = 0.;
 
-/* Subroutine */ int dlagge_slu(integer *m, integer *n, integer *kl, integer *ku,
-	 doublereal *d, doublereal *a, integer *lda, integer *iseed, 
-	doublereal *work, integer *info)
+/* Subroutine */ int dlagge_slu(int *m, int *n, int *kl, int *ku,
+	 doublereal *d, doublereal *a, int *lda, int *iseed,
+	doublereal *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
 
     /* Builtin functions */
     double d_sign(doublereal *, doublereal *);
 
     /* Local variables */
-    extern /* Subroutine */ int dger_(integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    integer *);
-    extern doublereal dnrm2_(integer *, doublereal *, integer *);
-    static integer i, j;
-    extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
-	    integer *), dgemv_(char *, integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    doublereal *, integer *);
+    extern /* Subroutine */ int dger_(int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    int *);
+    extern doublereal dnrm2_(int *, doublereal *, int *);
+    static int i, j;
+    extern /* Subroutine */ int dscal_(int *, doublereal *, doublereal *,
+	    int *), dgemv_(char *, int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    doublereal *, int *);
     static doublereal wa, wb, wn;
-    extern /* Subroutine */ int dlarnv_slu(integer *, integer *, integer *, doublereal *);
+    extern /* Subroutine */ int dlarnv_slu(int *, int *, int *, doublereal *);
     extern int input_error(char *, int *);
     static doublereal tau;
 

--- a/TESTING/MATGEN/dlagsy.c
+++ b/TESTING/MATGEN/dlagsy.c
@@ -7,43 +7,43 @@
 
 /* Table of constant values */
 
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 static doublereal c_b12 = 0.;
 static doublereal c_b19 = -1.;
 static doublereal c_b26 = 1.;
 
-/* Subroutine */ int dlagsy_slu(integer *n, integer *k, doublereal *d, 
-	doublereal *a, integer *lda, integer *iseed, doublereal *work, 
-	integer *info)
+/* Subroutine */ int dlagsy_slu(int *n, int *k, doublereal *d,
+	doublereal *a, int *lda, int *iseed, doublereal *work,
+	int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
 
     /* Builtin functions */
     double d_sign(doublereal *, doublereal *);
 
     /* Local variables */
-    extern /* Subroutine */ int dger_(integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    integer *);
-    extern doublereal ddot_(integer *, doublereal *, integer *, doublereal *, 
-	    integer *), dnrm2_(integer *, doublereal *, integer *);
-    extern /* Subroutine */ int dsyr2_(char *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    integer *);
-    static integer i, j;
+    extern /* Subroutine */ int dger_(int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    int *);
+    extern doublereal ddot_(int *, doublereal *, int *, doublereal *,
+	    int *), dnrm2_(int *, doublereal *, int *);
+    extern /* Subroutine */ int dsyr2_(char *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    int *);
+    static int i, j;
     static doublereal alpha;
-    extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
-	    integer *), dgemv_(char *, integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    doublereal *, integer *), daxpy_(integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *), dsymv_(char *, 
-	    integer *, doublereal *, doublereal *, integer *, doublereal *, 
-	    integer *, doublereal *, doublereal *, integer *);
+    extern /* Subroutine */ int dscal_(int *, doublereal *, doublereal *,
+	    int *), dgemv_(char *, int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    doublereal *, int *), daxpy_(int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *), dsymv_(char *,
+	    int *, doublereal *, doublereal *, int *, doublereal *,
+	    int *, doublereal *, doublereal *, int *);
     static doublereal wa, wb, wn;
-    extern /* Subroutine */ int dlarnv_slu(integer *, integer *, integer *, doublereal *);
+    extern /* Subroutine */ int dlarnv_slu(int *, int *, int *, doublereal *);
     extern int input_error(char *, int *);
     static doublereal tau;
 

--- a/TESTING/MATGEN/dlaran.c
+++ b/TESTING/MATGEN/dlaran.c
@@ -5,13 +5,13 @@
 
 #include "f2c.h"
 
-doublereal dlaran_slu(integer *iseed)
+doublereal dlaran_slu(int *iseed)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    static integer it1, it2, it3, it4;
+    static int it1, it2, it3, it4;
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) --   

--- a/TESTING/MATGEN/dlarge.c
+++ b/TESTING/MATGEN/dlarge.c
@@ -7,33 +7,33 @@
 
 /* Table of constant values */
 
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 static doublereal c_b8 = 1.;
 static doublereal c_b10 = 0.;
 
-/* Subroutine */ int dlarge_slu(integer *n, doublereal *a, integer *lda, integer 
-	*iseed, doublereal *work, integer *info)
+/* Subroutine */ int dlarge_slu(int *n, doublereal *a, int *lda, int
+	*iseed, doublereal *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1;
+    int a_dim1, a_offset, i__1;
     doublereal d__1;
 
     /* Builtin functions */
     double d_sign(doublereal *, doublereal *);
 
     /* Local variables */
-    extern /* Subroutine */ int dger_(integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    integer *);
-    extern doublereal dnrm2_(integer *, doublereal *, integer *);
-    static integer i;
-    extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
-	    integer *), dgemv_(char *, integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    doublereal *, integer *);
+    extern /* Subroutine */ int dger_(int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    int *);
+    extern doublereal dnrm2_(int *, doublereal *, int *);
+    static int i;
+    extern /* Subroutine */ int dscal_(int *, doublereal *, doublereal *,
+	    int *), dgemv_(char *, int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    doublereal *, int *);
     static doublereal wa, wb, wn;
-    extern /* Subroutine */ int dlarnv_slu(integer *, integer *, integer *, doublereal *);
+    extern /* Subroutine */ int dlarnv_slu(int *, int *, int *, doublereal *);
     extern int input_error(char *, int *);
     static doublereal tau;
 

--- a/TESTING/MATGEN/dlarnd.c
+++ b/TESTING/MATGEN/dlarnd.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-doublereal dlarnd_slu(integer *idist, integer *iseed)
+doublereal dlarnd_slu(int *idist, int *iseed)
 {
     /* System generated locals */
     doublereal ret_val;
@@ -15,7 +15,7 @@ doublereal dlarnd_slu(integer *idist, integer *iseed)
 
     /* Local variables */
     static doublereal t1, t2;
-    extern doublereal dlaran_slu(integer *);
+    extern doublereal dlaran_slu(int *);
     extern int input_error(char *, int *);
 
 

--- a/TESTING/MATGEN/dlarnv.c
+++ b/TESTING/MATGEN/dlarnv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int dlarnv_slu(integer *idist, integer *iseed, integer *n, 
+/* Subroutine */ int dlarnv_slu(int *idist, int *iseed, int *n,
 	doublereal *x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -53,15 +53,15 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer i__2, i__3;
+    int i__2, i__3;
     /* Builtin functions */
     double log(doublereal), sqrt(doublereal), cos(doublereal);
     /* Local variables */
-    static integer i;
+    static int i;
     static doublereal u[128];
-    static integer il, iv;
-    extern /* Subroutine */ int dlaruv_slu(integer *, integer *, doublereal *);
-    static integer il2;
+    static int il, iv;
+    extern /* Subroutine */ int dlaruv_slu(int *, int *, doublereal *);
+    static int il2;
 
 
 #define U(I) u[(I)]

--- a/TESTING/MATGEN/dlaror.c
+++ b/TESTING/MATGEN/dlaror.c
@@ -10,38 +10,38 @@
 
 static doublereal c_b9 = 0.;
 static doublereal c_b10 = 1.;
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int dlaror_slu(char *side, char *init, integer *m, integer *n, 
-	doublereal *a, integer *lda, integer *iseed, doublereal *x, integer *
+/* Subroutine */ int dlaror_slu(char *side, char *init, int *m, int *n,
+	doublereal *a, int *lda, int *iseed, doublereal *x, int *
 	info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
+    int a_dim1, a_offset, i__1, i__2;
     doublereal d__1;
 
     /* Builtin functions */
     double d_sign(doublereal *, doublereal *);
 
     /* Local variables */
-    static integer kbeg;
-    extern /* Subroutine */ int dger_(integer *, integer *, doublereal *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *, 
-	    integer *);
-    static integer jcol, irow;
-    extern doublereal dnrm2_(integer *, doublereal *, integer *);
-    static integer j;
-    extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
-	    integer *);
-    extern /* Subroutine */ int dgemv_(char *, integer *, integer *, 
-	    doublereal *, doublereal *, integer *, doublereal *, integer *, 
-	    doublereal *, doublereal *, integer *);
-    static integer ixfrm, itype, nxfrm;
+    static int kbeg;
+    extern /* Subroutine */ int dger_(int *, int *, doublereal *,
+	    doublereal *, int *, doublereal *, int *, doublereal *,
+	    int *);
+    static int jcol, irow;
+    extern doublereal dnrm2_(int *, doublereal *, int *);
+    static int j;
+    extern /* Subroutine */ int dscal_(int *, doublereal *, doublereal *,
+	    int *);
+    extern /* Subroutine */ int dgemv_(char *, int *, int *,
+	    doublereal *, doublereal *, int *, doublereal *, int *,
+	    doublereal *, doublereal *, int *);
+    static int ixfrm, itype, nxfrm;
     static doublereal xnorm;
-    extern doublereal dlarnd_slu(integer *, integer *);
-    extern /* Subroutine */ int dlaset_slu(char *, integer *, integer *, 
-					doublereal *, doublereal *, doublereal *, integer *);
+    extern doublereal dlarnd_slu(int *, int *);
+    extern /* Subroutine */ int dlaset_slu(char *, int *, int *,
+					doublereal *, doublereal *, doublereal *, int *);
     extern int input_error(char *, int *);
     static doublereal factor, xnorms;
 

--- a/TESTING/MATGEN/dlaror.c
+++ b/TESTING/MATGEN/dlaror.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <math.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -225,7 +226,7 @@ static integer c__1 = 1;
 	d__1 = -x[kbeg];
 	x[kbeg + nxfrm] = d_sign(&c_b10, &d__1);
 	factor = xnorms * (xnorms + x[kbeg]);
-	if (abs(factor) < 1e-20) {
+	if (fabs(factor) < 1e-20) {
 	    *info = 1;
 	    input_error("DLAROR", info);
 	    return 0;

--- a/TESTING/MATGEN/dlarot.c
+++ b/TESTING/MATGEN/dlarot.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include "f2c.h"
 
 /* Table of constant values */
@@ -11,7 +12,8 @@ static integer c__4 = 4;
 static integer c__8 = 8;
 static integer c__1 = 1;
 
-/* Subroutine */ int dlarot_slu(logical *lrows, logical *lleft, logical *lright, 
+/* Subroutine */
+int dlarot_slu(bool *lrows, bool *lleft, bool *lright,
 	integer *nl, doublereal *c, doublereal *s, doublereal *a, integer *
 	lda, doublereal *xleft, doublereal *xright)
 {

--- a/TESTING/MATGEN/dlarot.c
+++ b/TESTING/MATGEN/dlarot.c
@@ -8,26 +8,26 @@
 
 /* Table of constant values */
 
-static integer c__4 = 4;
-static integer c__8 = 8;
-static integer c__1 = 1;
+static int c__4 = 4;
+static int c__8 = 8;
+static int c__1 = 1;
 
 /* Subroutine */
 int dlarot_slu(bool *lrows, bool *lleft, bool *lright,
-	integer *nl, doublereal *c, doublereal *s, doublereal *a, integer *
+	int *nl, doublereal *c, doublereal *s, doublereal *a, int *
 	lda, doublereal *xleft, doublereal *xright)
 {
     /* System generated locals */
-    integer i__1;
+    int i__1;
 
     /* Local variables */
-    static integer iinc;
-    extern /* Subroutine */ int drot_(integer *, doublereal *, integer *, 
-	    doublereal *, integer *, doublereal *, doublereal *);
-    static integer inext, ix, iy, nt;
+    static int iinc;
+    extern /* Subroutine */ int drot_(int *, doublereal *, int *,
+	    doublereal *, int *, doublereal *, doublereal *);
+    static int inext, ix, iy, nt;
     static doublereal xt[2], yt[2];
     extern int input_error(char *, int *);
-    static integer iyt;
+    static int iyt;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/dlartg.c
+++ b/TESTING/MATGEN/dlartg.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <math.h>
 #include "f2c.h"
 
 /* Subroutine */ int dlartg_slu(doublereal *f, doublereal *g, doublereal *cs, 
@@ -86,7 +87,7 @@
 	f1 = *f;
 	g1 = *g;
 /* Computing MAX */
-	d__1 = abs(f1), d__2 = abs(g1);
+	d__1 = fabs(f1), d__2 = fabs(g1);
 	scale = max(d__1,d__2);
 	if (scale >= safmx2) {
 	    count = 0;
@@ -95,7 +96,7 @@ L10:
 	    f1 *= safmn2;
 	    g1 *= safmn2;
 /* Computing MAX */
-	    d__1 = abs(f1), d__2 = abs(g1);
+	    d__1 = fabs(f1), d__2 = fabs(g1);
 	    scale = max(d__1,d__2);
 	    if (scale >= safmx2) {
 		goto L10;
@@ -119,7 +120,7 @@ L30:
 	    f1 *= safmx2;
 	    g1 *= safmx2;
 /* Computing MAX */
-	    d__1 = abs(f1), d__2 = abs(g1);
+	    d__1 = fabs(f1), d__2 = fabs(g1);
 	    scale = max(d__1,d__2);
 	    if (scale <= safmn2) {
 		goto L30;
@@ -145,7 +146,7 @@ L30:
 	    *cs = f1 / *r;
 	    *sn = g1 / *r;
 	}
-	if (abs(*f) > abs(*g) && *cs < 0.) {
+	if (fabs(*f) > fabs(*g) && *cs < 0.) {
 	    *cs = -(*cs);
 	    *sn = -(*sn);
 	    *r = -(*r);

--- a/TESTING/MATGEN/dlartg.c
+++ b/TESTING/MATGEN/dlartg.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include "f2c.h"
 
 /* Subroutine */ int dlartg_slu(doublereal *f, doublereal *g, doublereal *cs, 
@@ -48,7 +49,7 @@
     ===================================================================== 
 */
     /* Initialized data */
-    static logical first = TRUE_;
+    static bool first = true;
     /* System generated locals */
     integer i__1;
     doublereal d__1, d__2;
@@ -65,7 +66,7 @@
 
 
     if (first) {
-	first = FALSE_;
+	first = false;
 	safmin = dmach("S");
 	eps = dmach("E");
 	d__1 = dmach("B");

--- a/TESTING/MATGEN/dlartg.c
+++ b/TESTING/MATGEN/dlartg.c
@@ -52,14 +52,14 @@
     /* Initialized data */
     static bool first = true;
     /* System generated locals */
-    integer i__1;
+    int i__1;
     doublereal d__1, d__2;
     /* Builtin functions */
-    double log(doublereal), pow_di(doublereal *, integer *), sqrt(doublereal);
+    double log(doublereal), pow_di(doublereal *, int *), sqrt(doublereal);
     /* Local variables */
-    static integer i;
+    static int i;
     static doublereal scale;
-    static integer count;
+    static int count;
     static doublereal f1, g1, safmn2, safmx2;
     extern doublereal dmach(char *);
     static doublereal safmin, eps;
@@ -71,7 +71,7 @@
 	safmin = dmach("S");
 	eps = dmach("E");
 	d__1 = dmach("B");
-	i__1 = (integer) (log(safmin / eps) / log(dmach("B")) / 2.);
+	i__1 = (int) (log(safmin / eps) / log(dmach("B")) / 2.);
 	safmn2 = pow_di(&d__1, &i__1);
 	safmx2 = 1. / safmn2;
     }

--- a/TESTING/MATGEN/dlaruv.c
+++ b/TESTING/MATGEN/dlaruv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int dlaruv_slu(integer *iseed, integer *n, doublereal *x)
+/* Subroutine */ int dlaruv_slu(int *iseed, int *n, doublereal *x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -53,7 +53,7 @@
    Parameter adjustments   
        Function Body */
     /* Initialized data */
-    static integer mm[512]	/* was [128][4] */ = { 494,2637,255,2008,1253,
+    static int mm[512]	/* was [128][4] */ = { 494,2637,255,2008,1253,
 	    3344,4084,1739,3143,3468,688,1657,1238,3166,1292,3422,1270,2016,
 	    154,2862,697,1706,491,931,1444,444,3577,3944,2184,1661,3482,657,
 	    3023,3618,1267,1828,164,3798,3087,2400,2870,3876,1905,1593,1797,
@@ -94,7 +94,7 @@
 	    3537,517,3017,2141,1537 };
     /* System generated locals */
     /* Local variables */
-    static integer i, i1, i2, i3, i4, it1, it2, it3, it4;
+    static int i, i1, i2, i3, i4, it1, it2, it3, it4;
 
 
 #define MM(I) mm[(I)]

--- a/TESTING/MATGEN/dlaset.c
+++ b/TESTING/MATGEN/dlaset.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int dlaset_slu(char *uplo, integer *m, integer *n, doublereal *
-	alpha, doublereal *beta, doublereal *a, integer *lda)
+/* Subroutine */ int dlaset_slu(char *uplo, int *m, int *n, doublereal *
+	alpha, doublereal *beta, doublereal *a, int *lda)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -60,7 +60,7 @@
        Function Body */
     /* System generated locals */
     /* Local variables */
-    static integer i, j;
+    static int i, j;
 
 
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]

--- a/TESTING/MATGEN/dlatb4.c
+++ b/TESTING/MATGEN/dlatb4.c
@@ -4,6 +4,7 @@
 */
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/dlatb4.c
+++ b/TESTING/MATGEN/dlatb4.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -14,7 +15,7 @@
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bool first = true;
 
     /* System generated locals */
     integer i__1;
@@ -93,7 +94,7 @@
        Set some constants for use in the subroutine. */
 
     if (first) {
-	first = FALSE_;
+	first = false;
 	eps = dmach("Precision");
 	badc2 = .1 / eps;
 	badc1 = sqrt(badc2);

--- a/TESTING/MATGEN/dlatb4.c
+++ b/TESTING/MATGEN/dlatb4.c
@@ -10,8 +10,8 @@
 
 /* Table of constant values */
 
-/* Subroutine */ int dlatb4_slu(char *path, integer *imat, integer *m, integer *
-	n, char *type, integer *kl, integer *ku, doublereal *anorm, integer *
+/* Subroutine */ int dlatb4_slu(char *path, int *imat, int *m, int *
+	n, char *type, int *kl, int *ku, doublereal *anorm, int *
 	mode, doublereal *cndnum, char *dist)
 {
     /* Initialized data */
@@ -19,7 +19,7 @@
     static bool first = true;
 
     /* System generated locals */
-    integer i__1;
+    int i__1;
 
     /* Builtin functions */
     double sqrt(doublereal);
@@ -29,7 +29,7 @@
     static char c2[2];
     extern /* Subroutine */ int dlabad_slu(doublereal *, doublereal *);
     extern doublereal dmach(char *);
-    static integer mat;
+    static int mat;
     static doublereal eps;
 
 /*  -- LAPACK test routine (version 2.0) --   

--- a/TESTING/MATGEN/dlatm1.c
+++ b/TESTING/MATGEN/dlatm1.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdlib.h>
 #include "f2c.h"
 
 /* Subroutine */ int dlatm1_slu(integer *mode, doublereal *cond, integer *irsign,

--- a/TESTING/MATGEN/dlatm1.c
+++ b/TESTING/MATGEN/dlatm1.c
@@ -6,24 +6,24 @@
 #include <stdlib.h>
 #include "f2c.h"
 
-/* Subroutine */ int dlatm1_slu(integer *mode, doublereal *cond, integer *irsign,
-	 integer *idist, integer *iseed, doublereal *d, integer *n, integer *
+/* Subroutine */ int dlatm1_slu(int *mode, doublereal *cond, int *irsign,
+	 int *idist, int *iseed, doublereal *d, int *n, int *
 	info)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     doublereal d__1;
 
     /* Builtin functions */
-    double pow_dd(doublereal *, doublereal *), pow_di(doublereal *, integer *)
+    double pow_dd(doublereal *, doublereal *), pow_di(doublereal *, int *)
 	    , log(doublereal), exp(doublereal);
 
     /* Local variables */
     static doublereal temp;
-    static integer i;
+    static int i;
     static doublereal alpha;
-    extern doublereal dlaran_slu(integer *);
-    extern /* Subroutine */ int dlarnv_slu(integer *, integer *, integer *, doublereal *);
+    extern doublereal dlaran_slu(int *);
+    extern /* Subroutine */ int dlarnv_slu(int *, int *, int *, doublereal *);
     extern int input_error(char *, int *);
 
 

--- a/TESTING/MATGEN/dlatm2.c
+++ b/TESTING/MATGEN/dlatm2.c
@@ -5,18 +5,18 @@
 
 #include "f2c.h"
 
-doublereal dlatm2_slu(integer *m, integer *n, integer *i, integer *j, integer *
-	kl, integer *ku, integer *idist, integer *iseed, doublereal *d, 
-	integer *igrade, doublereal *dl, doublereal *dr, integer *ipvtng, 
-	integer *iwork, doublereal *sparse)
+doublereal dlatm2_slu(int *m, int *n, int *i, int *j, int *
+	kl, int *ku, int *idist, int *iseed, doublereal *d,
+	int *igrade, doublereal *dl, doublereal *dr, int *ipvtng,
+	int *iwork, doublereal *sparse)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
-    static integer isub, jsub;
+    static int isub, jsub;
     static doublereal temp;
-    extern doublereal dlaran_slu(integer *), dlarnd_slu(integer *, integer *);
+    extern doublereal dlaran_slu(int *), dlarnd_slu(int *, int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/dlatm3.c
+++ b/TESTING/MATGEN/dlatm3.c
@@ -5,17 +5,17 @@
 
 #include "f2c.h"
 
-doublereal dlatm3_slu(integer *m, integer *n, integer *i, integer *j, integer *
-	isub, integer *jsub, integer *kl, integer *ku, integer *idist, 
-	integer *iseed, doublereal *d, integer *igrade, doublereal *dl, 
-	doublereal *dr, integer *ipvtng, integer *iwork, doublereal *sparse)
+doublereal dlatm3_slu(int *m, int *n, int *i, int *j, int *
+	isub, int *jsub, int *kl, int *ku, int *idist,
+	int *iseed, doublereal *d, int *igrade, doublereal *dl,
+	doublereal *dr, int *ipvtng, int *iwork, doublereal *sparse)
 {
     /* System generated locals */
     doublereal ret_val;
 
     /* Local variables */
     static doublereal temp;
-    extern doublereal dlaran_slu(integer *), dlarnd_slu(integer *, integer *);
+    extern doublereal dlaran_slu(int *), dlarnd_slu(int *, int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/dlatms.c
+++ b/TESTING/MATGEN/dlatms.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/dlatms.c
+++ b/TESTING/MATGEN/dlatms.c
@@ -9,19 +9,19 @@
 
 /* Table of constant values */
 
-static integer c__1 = 1;
+static int c__1 = 1;
 static doublereal c_b22 = 0.;
 static bool c_true = true;
 static bool c_false = false;
 
 int
-dlatms_slu(integer *m, integer *n, char *dist, integer *
-	iseed, char *sym, doublereal *d, integer *mode, doublereal *cond, 
-	doublereal *dmax__, integer *kl, integer *ku, char *pack,
-	doublereal *a, integer *lda, doublereal *work, integer *info)
+dlatms_slu(int *m, int *n, char *dist, int *
+	iseed, char *sym, doublereal *d, int *mode, doublereal *cond,
+	doublereal *dmax__, int *kl, int *ku, char *pack,
+	doublereal *a, int *lda, doublereal *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     doublereal d__1, d__2, d__3;
     bool L__1;
 
@@ -29,41 +29,41 @@ dlatms_slu(integer *m, integer *n, char *dist, integer *
     double cos(doublereal), sin(doublereal);
 
     /* Local variables */
-    static integer ilda, icol;
+    static int ilda, icol;
     static doublereal temp;
-    static integer irow, isym;
+    static int irow, isym;
     static doublereal c;
-    static integer i, j, k;
+    static int i, j, k;
     static doublereal s, alpha, angle;
-    static integer ipack;
-    extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
-	    integer *);
-    static integer ioffg;
-    static integer iinfo, idist, mnmin;
-    extern /* Subroutine */ int dcopy_(integer *, doublereal *, integer *, 
-	    doublereal *, integer *);
-    static integer iskew;
+    static int ipack;
+    extern /* Subroutine */ int dscal_(int *, doublereal *, doublereal *,
+	    int *);
+    static int ioffg;
+    static int iinfo, idist, mnmin;
+    extern /* Subroutine */ int dcopy_(int *, doublereal *, int *,
+	    doublereal *, int *);
+    static int iskew;
     static doublereal extra, dummy;
-    extern /* Subroutine */ int dlatm1_slu(integer *, doublereal *, integer *, 
-	    integer *, integer *, doublereal *, integer *, integer *);
-    static integer ic, jc, nc;
-    extern /* Subroutine */ int dlagge_slu(integer *, integer *, integer *, 
-	    integer *, doublereal *, doublereal *, integer *, integer *, 
-	    doublereal *, integer *);
-    static integer il, iendch, ir, jr, ipackg, mr, minlda;
-    extern doublereal dlarnd_slu(integer *, integer *);
-    extern /* Subroutine */ int dlaset_slu(char *, integer *, integer *, 
-	    doublereal *, doublereal *, doublereal *, integer *), 
+    extern /* Subroutine */ int dlatm1_slu(int *, doublereal *, int *,
+	    int *, int *, doublereal *, int *, int *);
+    static int ic, jc, nc;
+    extern /* Subroutine */ int dlagge_slu(int *, int *, int *,
+	    int *, doublereal *, doublereal *, int *, int *,
+	    doublereal *, int *);
+    static int il, iendch, ir, jr, ipackg, mr, minlda;
+    extern doublereal dlarnd_slu(int *, int *);
+    extern /* Subroutine */ int dlaset_slu(char *, int *, int *,
+	    doublereal *, doublereal *, doublereal *, int *),
 	    dlartg_slu(doublereal *, doublereal *, doublereal *, doublereal *, doublereal *),
-	    dlagsy_slu(integer *, integer *, doublereal *, doublereal *, integer *, 
-	    integer *, doublereal *, integer *), dlarot_slu(bool *, bool *,
-	     bool *, integer *, doublereal *, doublereal *, doublereal *,
-	    integer *, doublereal *, doublereal *);
+	    dlagsy_slu(int *, int *, doublereal *, doublereal *, int *,
+	    int *, doublereal *, int *), dlarot_slu(bool *, bool *,
+	     bool *, int *, doublereal *, doublereal *, doublereal *,
+	    int *, doublereal *, doublereal *);
     extern int input_error(char *, int *);
     static bool iltemp, givens;
-    static integer ioffst, irsign;
+    static int ioffst, irsign;
     static bool ilextr, topdwn;
-    static integer ir1, ir2, isympk, jch, llb, jkl, jku, uub;
+    static int ir1, ir2, isympk, jch, llb, jkl, jku, uub;
 
 
 /*  -- LAPACK test routine (version 2.0) --   

--- a/TESTING/MATGEN/dlatms.c
+++ b/TESTING/MATGEN/dlatms.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -9,8 +10,8 @@
 
 static integer c__1 = 1;
 static doublereal c_b22 = 0.;
-static logical c_true = TRUE_;
-static logical c_false = FALSE_;
+static bool c_true = true;
+static bool c_false = false;
 
 int
 dlatms_slu(integer *m, integer *n, char *dist, integer *
@@ -21,7 +22,7 @@ dlatms_slu(integer *m, integer *n, char *dist, integer *
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     doublereal d__1, d__2, d__3;
-    logical L__1;
+    bool L__1;
 
     /* Builtin functions */
     double cos(doublereal), sin(doublereal);
@@ -54,13 +55,13 @@ dlatms_slu(integer *m, integer *n, char *dist, integer *
 	    doublereal *, doublereal *, doublereal *, integer *), 
 	    dlartg_slu(doublereal *, doublereal *, doublereal *, doublereal *, doublereal *),
 	    dlagsy_slu(integer *, integer *, doublereal *, doublereal *, integer *, 
-	    integer *, doublereal *, integer *), dlarot_slu(logical *, logical *,
-	     logical *, integer *, doublereal *, doublereal *, doublereal *, 
+	    integer *, doublereal *, integer *), dlarot_slu(bool *, bool *,
+	     bool *, integer *, doublereal *, doublereal *, doublereal *,
 	    integer *, doublereal *, doublereal *);
     extern int input_error(char *, int *);
-    static logical iltemp, givens;
+    static bool iltemp, givens;
     static integer ioffst, irsign;
-    static logical ilextr, topdwn;
+    static bool ilextr, topdwn;
     static integer ir1, ir2, isympk, jch, llb, jkl, jku, uub;
 
 
@@ -428,20 +429,20 @@ dlatms_slu(integer *m, integer *n, char *dist, integer *
 /*     Use Givens rotation method if bandwidth small enough,   
        or if LDA is too small to store the matrix unpacked. */
 
-    givens = FALSE_;
+    givens = false;
     if (isym == 1) {
 /* Computing MAX */
 	i__1 = 1, i__2 = mr + nc;
 	if ((doublereal) (llb + uub) < (doublereal) max(i__1,i__2) * .3) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     } else {
 	if (llb << 1 < *m) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     }
     if (*lda < *m && *lda >= minlda) {
-	givens = TRUE_;
+	givens = true;
     }
 
 /*     Set INFO if an error */
@@ -504,9 +505,9 @@ dlatms_slu(integer *m, integer *n, char *dist, integer *
        Bottom-Up if D is (apparently) decreasing. */
 
     if (abs(d[1]) <= (d__1 = d[mnmin], abs(d__1))) {
-	topdwn = TRUE_;
+	topdwn = true;
     } else {
-	topdwn = FALSE_;
+	topdwn = false;
     }
 
     if (*mode != 0 && abs(*mode) != 6) {

--- a/TESTING/MATGEN/f2c.h
+++ b/TESTING/MATGEN/f2c.h
@@ -33,7 +33,5 @@ typedef char integer1;
 
 #define min(a,b) ((a) <= (b) ? (a) : (b))
 #define max(a,b) ((a) >= (b) ? (a) : (b))
-#define dmin(a,b) (doublereal)min(a,b)
-#define dmax(a,b) (doublereal)max(a,b)
 
 #endif

--- a/TESTING/MATGEN/f2c.h
+++ b/TESTING/MATGEN/f2c.h
@@ -38,6 +38,4 @@ typedef char integer1;
 #define dmin(a,b) (doublereal)min(a,b)
 #define dmax(a,b) (doublereal)max(a,b)
 
-#define VOID void
-
 #endif

--- a/TESTING/MATGEN/f2c.h
+++ b/TESTING/MATGEN/f2c.h
@@ -9,27 +9,12 @@
 #ifndef F2C_INCLUDE
 #define F2C_INCLUDE
 
-#if 0
-typedef long int integer; /* 64 on 64-bit machine */
-#endif
-
 typedef int integer;
 
-typedef char *address;
-typedef short int shortint;
 typedef float real;
 typedef double doublereal;
 typedef struct { real r, i; } complex;
 typedef struct { doublereal r, i; } doublecomplex;
-typedef short int shortlogical;
-typedef char logical1;
-typedef char integer1;
-/* typedef long long longint; */ /* system-dependent */
-
-/* Extern is for use with -E */
-#ifndef Extern
-#define Extern extern
-#endif
 
 #define min(a,b) ((a) <= (b) ? (a) : (b))
 #define max(a,b) ((a) >= (b) ? (a) : (b))

--- a/TESTING/MATGEN/f2c.h
+++ b/TESTING/MATGEN/f2c.h
@@ -32,7 +32,6 @@ typedef char integer1;
 #endif
 
 #define abs(x) ((x) >= 0 ? (x) : -(x))
-#define dabs(x) (doublereal)abs(x)
 #define min(a,b) ((a) <= (b) ? (a) : (b))
 #define max(a,b) ((a) >= (b) ? (a) : (b))
 #define dmin(a,b) (doublereal)min(a,b)

--- a/TESTING/MATGEN/f2c.h
+++ b/TESTING/MATGEN/f2c.h
@@ -31,7 +31,6 @@ typedef char integer1;
 #define Extern extern
 #endif
 
-#define abs(x) ((x) >= 0 ? (x) : -(x))
 #define min(a,b) ((a) <= (b) ? (a) : (b))
 #define max(a,b) ((a) >= (b) ? (a) : (b))
 #define dmin(a,b) (doublereal)min(a,b)

--- a/TESTING/MATGEN/f2c.h
+++ b/TESTING/MATGEN/f2c.h
@@ -11,11 +11,9 @@
 
 #if 0
 typedef long int integer; /* 64 on 64-bit machine */
-typedef long int logical;
 #endif
 
 typedef int integer;
-typedef int logical;
 
 typedef char *address;
 typedef short int shortint;
@@ -27,9 +25,6 @@ typedef short int shortlogical;
 typedef char logical1;
 typedef char integer1;
 /* typedef long long longint; */ /* system-dependent */
-
-#define TRUE_ (1)
-#define FALSE_ (0)
 
 /* Extern is for use with -E */
 #ifndef Extern

--- a/TESTING/MATGEN/pow_dd.c
+++ b/TESTING/MATGEN/pow_dd.c
@@ -1,6 +1,5 @@
 #include "f2c.h"
 
-#undef abs
 #include "math.h"
 
 double pow_dd(doublereal *ap, doublereal *bp)

--- a/TESTING/MATGEN/pow_dd.c
+++ b/TESTING/MATGEN/pow_dd.c
@@ -1,13 +1,9 @@
 #include "f2c.h"
 
-#ifdef KR_headers
-double pow();
-double pow_dd(ap, bp) doublereal *ap, *bp;
-#else
 #undef abs
 #include "math.h"
+
 double pow_dd(doublereal *ap, doublereal *bp)
-#endif
 {
 return(pow(*ap, *bp) );
 }

--- a/TESTING/MATGEN/r_lg10.c
+++ b/TESTING/MATGEN/r_lg10.c
@@ -2,14 +2,10 @@
 
 #define log10e 0.43429448190325182765
 
-#ifdef KR_headers
-double log();
-double r_lg10(x) real *x;
-#else
 #undef abs
 #include "math.h"
+
 double r_lg10(real *x)
-#endif
 {
 return( log10e * log(*x) );
 }

--- a/TESTING/MATGEN/r_lg10.c
+++ b/TESTING/MATGEN/r_lg10.c
@@ -2,7 +2,6 @@
 
 #define log10e 0.43429448190325182765
 
-#undef abs
 #include "math.h"
 
 double r_lg10(real *x)

--- a/TESTING/MATGEN/r_sign.c
+++ b/TESTING/MATGEN/r_sign.c
@@ -1,10 +1,6 @@
 #include "f2c.h"
 
-#ifdef KR_headers
-double r_sign(a,b) real *a, *b;
-#else
 double r_sign(real *a, real *b)
-#endif
 {
 double x;
 x = (*a >= 0 ? *a : - *a);

--- a/TESTING/MATGEN/slagge.c
+++ b/TESTING/MATGEN/slagge.c
@@ -7,32 +7,32 @@
 
 /* Table of constant values */
 
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 static real c_b11 = 1.f;
 static real c_b13 = 0.f;
 
-/* Subroutine */ int slagge_slu(integer *m, integer *n, integer *kl, integer *ku,
-	 real *d, real *a, integer *lda, integer *iseed, real *work, integer *
+/* Subroutine */ int slagge_slu(int *m, int *n, int *kl, int *ku,
+	 real *d, real *a, int *lda, int *iseed, real *work, int *
 	info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     real r__1;
 
     /* Builtin functions */
     double r_sign(real *, real *);
 
     /* Local variables */
-    extern /* Subroutine */ int sger_(integer *, integer *, real *, real *, 
-	    integer *, real *, integer *, real *, integer *);
-    extern real snrm2_(integer *, real *, integer *);
-    static integer i, j;
-    extern /* Subroutine */ int sscal_(integer *, real *, real *, integer *), 
-	    sgemv_(char *, integer *, integer *, real *, real *, integer *, 
-	    real *, integer *, real *, real *, integer *);
+    extern /* Subroutine */ int sger_(int *, int *, real *, real *,
+	    int *, real *, int *, real *, int *);
+    extern real snrm2_(int *, real *, int *);
+    static int i, j;
+    extern /* Subroutine */ int sscal_(int *, real *, real *, int *),
+	    sgemv_(char *, int *, int *, real *, real *, int *,
+	    real *, int *, real *, real *, int *);
     static real wa, wb, wn;
-    extern /* Subroutine */ int slarnv_slu(integer *, integer *, integer *, real *);
+    extern /* Subroutine */ int slarnv_slu(int *, int *, int *, real *);
     extern int input_error(char *, int *);
     static real tau;
 

--- a/TESTING/MATGEN/slagsy.c
+++ b/TESTING/MATGEN/slagsy.c
@@ -7,39 +7,39 @@
 
 /* Table of constant values */
 
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 static real c_b12 = 0.f;
 static real c_b19 = -1.f;
 static real c_b26 = 1.f;
 
-/* Subroutine */ int slagsy_slu(integer *n, integer *k, real *d, real *a, 
-	integer *lda, integer *iseed, real *work, integer *info)
+/* Subroutine */ int slagsy_slu(int *n, int *k, real *d, real *a,
+	int *lda, int *iseed, real *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     real r__1;
 
     /* Builtin functions */
     double r_sign(real *, real *);
 
     /* Local variables */
-    extern /* Subroutine */ int sger_(integer *, integer *, real *, real *, 
-	    integer *, real *, integer *, real *, integer *);
-    extern real sdot_(integer *, real *, integer *, real *, integer *), 
-	    snrm2_(integer *, real *, integer *);
-    static integer i, j;
-    extern /* Subroutine */ int ssyr2_(char *, integer *, real *, real *, 
-	    integer *, real *, integer *, real *, integer *);
+    extern /* Subroutine */ int sger_(int *, int *, real *, real *,
+	    int *, real *, int *, real *, int *);
+    extern real sdot_(int *, real *, int *, real *, int *),
+	    snrm2_(int *, real *, int *);
+    static int i, j;
+    extern /* Subroutine */ int ssyr2_(char *, int *, real *, real *,
+	    int *, real *, int *, real *, int *);
     static real alpha;
-    extern /* Subroutine */ int sscal_(integer *, real *, real *, integer *), 
-	    sgemv_(char *, integer *, integer *, real *, real *, integer *, 
-	    real *, integer *, real *, real *, integer *), saxpy_(
-	    integer *, real *, real *, integer *, real *, integer *), ssymv_(
-	    char *, integer *, real *, real *, integer *, real *, integer *, 
-	    real *, real *, integer *);
+    extern /* Subroutine */ int sscal_(int *, real *, real *, int *),
+	    sgemv_(char *, int *, int *, real *, real *, int *,
+	    real *, int *, real *, real *, int *), saxpy_(
+	    int *, real *, real *, int *, real *, int *), ssymv_(
+	    char *, int *, real *, real *, int *, real *, int *,
+	    real *, real *, int *);
     static real wa, wb, wn;
-    extern /* Subroutine */ int slarnv_slu(integer *, integer *, integer *, real *);
+    extern /* Subroutine */ int slarnv_slu(int *, int *, int *, real *);
     extern int input_error(char *, int *);
     static real tau;
 

--- a/TESTING/MATGEN/slaran.c
+++ b/TESTING/MATGEN/slaran.c
@@ -5,13 +5,13 @@
 
 #include "f2c.h"
 
-doublereal dlaran_sluslu(integer *iseed)
+doublereal dlaran_sluslu(int *iseed)
 {
     /* System generated locals */
     real ret_val;
 
     /* Local variables */
-    static integer it1, it2, it3, it4;
+    static int it1, it2, it3, it4;
 
 
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -79,7 +79,7 @@ doublereal dlaran_sluslu(integer *iseed)
     iseed[3] = it3;
     iseed[4] = it4;
 
-/*     convert 48-bit integer to a real number in the interval (0,1) */
+/*     convert 48-bit int to a real number in the interval (0,1) */
 
     ret_val = ((real) it1 + ((real) it2 + ((real) it3 + (real) it4 * 
 	    2.44140625e-4f) * 2.44140625e-4f) * 2.44140625e-4f) * 

--- a/TESTING/MATGEN/slarge.c
+++ b/TESTING/MATGEN/slarge.c
@@ -7,31 +7,31 @@
 
 /* Table of constant values */
 
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 static real c_b8 = 1.f;
 static real c_b10 = 0.f;
 
-/* Subroutine */ int slarge_slu(integer *n, real *a, integer *lda, integer *
-	iseed, real *work, integer *info)
+/* Subroutine */ int slarge_slu(int *n, real *a, int *lda, int *
+	iseed, real *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1;
+    int a_dim1, a_offset, i__1;
     real r__1;
 
     /* Builtin functions */
     double r_sign(real *, real *);
 
     /* Local variables */
-    extern /* Subroutine */ int sger_(integer *, integer *, real *, real *, 
-	    integer *, real *, integer *, real *, integer *);
-    extern real snrm2_(integer *, real *, integer *);
-    static integer i;
-    extern /* Subroutine */ int sscal_(integer *, real *, real *, integer *), 
-	    sgemv_(char *, integer *, integer *, real *, real *, integer *, 
-	    real *, integer *, real *, real *, integer *);
+    extern /* Subroutine */ int sger_(int *, int *, real *, real *,
+	    int *, real *, int *, real *, int *);
+    extern real snrm2_(int *, real *, int *);
+    static int i;
+    extern /* Subroutine */ int sscal_(int *, real *, real *, int *),
+	    sgemv_(char *, int *, int *, real *, real *, int *,
+	    real *, int *, real *, real *, int *);
     static real wa, wb, wn;
-    extern /* Subroutine */ int slarnv_slu(integer *, integer *, integer *, real *);
+    extern /* Subroutine */ int slarnv_slu(int *, int *, int *, real *);
     extern int input_error(char *, int *);
     static real tau;
 

--- a/TESTING/MATGEN/slarnd.c
+++ b/TESTING/MATGEN/slarnd.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-doublereal slarnd_slu(integer *idist, integer *iseed)
+doublereal slarnd_slu(int *idist, int *iseed)
 {
     /* System generated locals */
     real ret_val;
@@ -15,7 +15,7 @@ doublereal slarnd_slu(integer *idist, integer *iseed)
 
     /* Local variables */
     static real t1, t2;
-    extern doublereal dlaran_sluslu(integer *);
+    extern doublereal dlaran_sluslu(int *);
     extern int input_error(char *, int *);
 
 

--- a/TESTING/MATGEN/slarnv.c
+++ b/TESTING/MATGEN/slarnv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int slarnv_slu(integer *idist, integer *iseed, integer *n, real 
+/* Subroutine */ int slarnv_slu(int *idist, int *iseed, int *n, real
 	*x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -53,14 +53,14 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer i__2, i__3;
+    int i__2, i__3;
     /* Builtin functions */
     double log(doublereal), sqrt(doublereal), cos(doublereal);
     /* Local variables */
-    static integer i;
+    static int i;
     static real u[128];
-    static integer il, iv, il2;
-    extern /* Subroutine */ int slaruv_slu(integer *, integer *, real *);
+    static int il, iv, il2;
+    extern /* Subroutine */ int slaruv_slu(int *, int *, real *);
 
 
 #define X(I) x[(I)-1]

--- a/TESTING/MATGEN/slaror.c
+++ b/TESTING/MATGEN/slaror.c
@@ -10,36 +10,36 @@
 
 static real c_b9 = 0.f;
 static real c_b10 = 1.f;
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int slaror_slu(char *side, char *init, integer *m, integer *n, 
-	real *a, integer *lda, integer *iseed, real *x, integer *info)
+/* Subroutine */ int slaror_slu(char *side, char *init, int *m, int *n,
+	real *a, int *lda, int *iseed, real *x, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2;
+    int a_dim1, a_offset, i__1, i__2;
     real r__1;
 
     /* Builtin functions */
     double r_sign(real *, real *);
 
     /* Local variables */
-    static integer kbeg, jcol;
-    extern /* Subroutine */ int sger_(integer *, integer *, real *, real *, 
-	    integer *, real *, integer *, real *, integer *);
-    static integer irow;
-    extern real snrm2_(integer *, real *, integer *);
-    static integer j;
-    extern /* Subroutine */ int sscal_(integer *, real *, real *, integer *), 
-	    sgemv_(char *, integer *, integer *, real *, real *, integer *, 
-	    real *, integer *, real *, real *, integer *);
-    static integer ixfrm, itype, nxfrm;
+    static int kbeg, jcol;
+    extern /* Subroutine */ int sger_(int *, int *, real *, real *,
+	    int *, real *, int *, real *, int *);
+    static int irow;
+    extern real snrm2_(int *, real *, int *);
+    static int j;
+    extern /* Subroutine */ int sscal_(int *, real *, real *, int *),
+	    sgemv_(char *, int *, int *, real *, real *, int *,
+	    real *, int *, real *, real *, int *);
+    static int ixfrm, itype, nxfrm;
     static real xnorm;
     extern int input_error(char *, int *);
     static real factor;
-    extern doublereal slarnd_slu(integer *, integer *);
-    extern /* Subroutine */ int slaset_slu(char *, integer *, integer *, real *, 
-	    real *, real *, integer *);
+    extern doublereal slarnd_slu(int *, int *);
+    extern /* Subroutine */ int slaset_slu(char *, int *, int *, real *,
+	    real *, real *, int *);
     static real xnorms;
 
 

--- a/TESTING/MATGEN/slaror.c
+++ b/TESTING/MATGEN/slaror.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <math.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -221,7 +222,7 @@ static integer c__1 = 1;
 	r__1 = -(doublereal)x[kbeg];
 	x[kbeg + nxfrm] = r_sign(&c_b10, &r__1);
 	factor = xnorms * (xnorms + x[kbeg]);
-	if (dabs(factor) < 1e-20f) {
+	if (fabs(factor) < 1e-20f) {
 	    *info = 1;
 	    input_error("SLAROR", info);
 	    return 0;

--- a/TESTING/MATGEN/slarot.c
+++ b/TESTING/MATGEN/slarot.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include "f2c.h"
 
 /* Table of constant values */
@@ -11,7 +12,8 @@ static integer c__4 = 4;
 static integer c__8 = 8;
 static integer c__1 = 1;
 
-/* Subroutine */ int slarot_slu(logical *lrows, logical *lleft, logical *lright, 
+/* Subroutine */
+int slarot_slu(bool *lrows, bool *lleft, bool *lright,
 	integer *nl, real *c, real *s, real *a, integer *lda, real *xleft, 
 	real *xright)
 {

--- a/TESTING/MATGEN/slarot.c
+++ b/TESTING/MATGEN/slarot.c
@@ -8,26 +8,26 @@
 
 /* Table of constant values */
 
-static integer c__4 = 4;
-static integer c__8 = 8;
-static integer c__1 = 1;
+static int c__4 = 4;
+static int c__8 = 8;
+static int c__1 = 1;
 
 /* Subroutine */
 int slarot_slu(bool *lrows, bool *lleft, bool *lright,
-	integer *nl, real *c, real *s, real *a, integer *lda, real *xleft, 
+	int *nl, real *c, real *s, real *a, int *lda, real *xleft,
 	real *xright)
 {
     /* System generated locals */
-    integer i__1;
+    int i__1;
 
     /* Local variables */
-    static integer iinc;
-    extern /* Subroutine */ int srot_(integer *, real *, integer *, real *, 
-	    integer *, real *, real *);
-    static integer inext, ix, iy, nt;
+    static int iinc;
+    extern /* Subroutine */ int srot_(int *, real *, int *, real *,
+	    int *, real *, real *);
+    static int inext, ix, iy, nt;
     static real xt[2], yt[2];
     extern int input_error(char *, int *);
-    static integer iyt;
+    static int iyt;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/slartg.c
+++ b/TESTING/MATGEN/slartg.c
@@ -86,7 +86,7 @@
 	g1 = *g;
 /* Computing MAX */
 	r__1 = fabs(f1), r__2 = fabs(g1);
-	scale = dmax(r__1,r__2);
+	scale = fmax(r__1,r__2);
 	if (scale >= safmx2) {
 	    count = 0;
 L10:
@@ -95,7 +95,7 @@ L10:
 	    g1 *= safmn2;
 /* Computing MAX */
 	    r__1 = fabs(f1), r__2 = fabs(g1);
-	    scale = dmax(r__1,r__2);
+	    scale = fmax(r__1,r__2);
 	    if (scale >= safmx2) {
 		goto L10;
 	    }
@@ -119,7 +119,7 @@ L30:
 	    g1 *= safmx2;
 /* Computing MAX */
 	    r__1 = fabs(f1), r__2 = fabs(g1);
-	    scale = dmax(r__1,r__2);
+	    scale = fmax(r__1,r__2);
 	    if (scale <= safmn2) {
 		goto L30;
 	    }

--- a/TESTING/MATGEN/slartg.c
+++ b/TESTING/MATGEN/slartg.c
@@ -51,14 +51,14 @@
     /* Initialized data */
     static bool first = true;
     /* System generated locals */
-    integer i__1;
+    int i__1;
     real r__1, r__2;
     /* Builtin functions */
-    double log(doublereal), pow_ri(real *, integer *), sqrt(doublereal);
+    double log(doublereal), pow_ri(real *, int *), sqrt(doublereal);
     /* Local variables */
-    static integer i;
+    static int i;
     static real scale;
-    static integer count;
+    static int count;
     static real f1, g1, safmn2, safmx2;
     extern float smach(char *);
     static real safmin, eps;
@@ -69,7 +69,7 @@
 	safmin = smach("S");
 	eps = smach("E");
 	r__1 = smach("B");
-	i__1 = (integer) (log(safmin / eps) / log(smach("B")) / 2.f);
+	i__1 = (int) (log(safmin / eps) / log(smach("B")) / 2.f);
 	safmn2 = pow_ri(&r__1, &i__1);
 	safmx2 = 1.f / safmn2;
     }

--- a/TESTING/MATGEN/slartg.c
+++ b/TESTING/MATGEN/slartg.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include "f2c.h"
 
 /* Subroutine */ int slartg_slu(real *f, real *g, real *cs, real *sn, real *r)
@@ -47,7 +48,7 @@
     ===================================================================== 
 */
     /* Initialized data */
-    static logical first = TRUE_;
+    static bool first = true;
     /* System generated locals */
     integer i__1;
     real r__1, r__2;
@@ -63,7 +64,7 @@
 
 
     if (first) {
-	first = FALSE_;
+	first = false;
 	safmin = smach("S");
 	eps = smach("E");
 	r__1 = smach("B");

--- a/TESTING/MATGEN/slartg.c
+++ b/TESTING/MATGEN/slartg.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <stdbool.h>
 #include "f2c.h"
 
@@ -84,7 +85,7 @@
 	f1 = *f;
 	g1 = *g;
 /* Computing MAX */
-	r__1 = dabs(f1), r__2 = dabs(g1);
+	r__1 = fabs(f1), r__2 = fabs(g1);
 	scale = dmax(r__1,r__2);
 	if (scale >= safmx2) {
 	    count = 0;
@@ -93,7 +94,7 @@ L10:
 	    f1 *= safmn2;
 	    g1 *= safmn2;
 /* Computing MAX */
-	    r__1 = dabs(f1), r__2 = dabs(g1);
+	    r__1 = fabs(f1), r__2 = fabs(g1);
 	    scale = dmax(r__1,r__2);
 	    if (scale >= safmx2) {
 		goto L10;
@@ -117,7 +118,7 @@ L30:
 	    f1 *= safmx2;
 	    g1 *= safmx2;
 /* Computing MAX */
-	    r__1 = dabs(f1), r__2 = dabs(g1);
+	    r__1 = fabs(f1), r__2 = fabs(g1);
 	    scale = dmax(r__1,r__2);
 	    if (scale <= safmn2) {
 		goto L30;
@@ -143,7 +144,7 @@ L30:
 	    *cs = f1 / *r;
 	    *sn = g1 / *r;
 	}
-	if (dabs(*f) > dabs(*g) && *cs < 0.f) {
+	if (fabs(*f) > fabs(*g) && *cs < 0.f) {
 	    *cs = -(doublereal)(*cs);
 	    *sn = -(doublereal)(*sn);
 	    *r = -(doublereal)(*r);

--- a/TESTING/MATGEN/slaruv.c
+++ b/TESTING/MATGEN/slaruv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int slaruv_slu(integer *iseed, integer *n, real *x)
+/* Subroutine */ int slaruv_slu(int *iseed, int *n, real *x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -53,7 +53,7 @@
    Parameter adjustments   
        Function Body */
     /* Initialized data */
-    static integer mm[512]	/* was [128][4] */ = { 494,2637,255,2008,1253,
+    static int mm[512]	/* was [128][4] */ = { 494,2637,255,2008,1253,
 	    3344,4084,1739,3143,3468,688,1657,1238,3166,1292,3422,1270,2016,
 	    154,2862,697,1706,491,931,1444,444,3577,3944,2184,1661,3482,657,
 	    3023,3618,1267,1828,164,3798,3087,2400,2870,3876,1905,1593,1797,
@@ -94,7 +94,7 @@
 	    3537,517,3017,2141,1537 };
     /* System generated locals */
     /* Local variables */
-    static integer i, i1, i2, i3, i4, it1, it2, it3, it4;
+    static int i, i1, i2, i3, i4, it1, it2, it3, it4;
 
 
 #define MM(I) mm[(I)]
@@ -127,7 +127,7 @@
 		i4 * MM(i - 1);
 	it1 %= 4096;
 
-/*        Convert 48-bit integer to a real number in the interval (0,1
+/*        Convert 48-bit int to a real number in the interval (0,1
 ) */
 
 	X(i) = ((real) it1 + ((real) it2 + ((real) it3 + (real) it4 * 

--- a/TESTING/MATGEN/slaset.c
+++ b/TESTING/MATGEN/slaset.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int slaset_slu(char *uplo, integer *m, integer *n, real *alpha, 
-	real *beta, real *a, integer *lda)
+/* Subroutine */ int slaset_slu(char *uplo, int *m, int *n, real *alpha,
+	real *beta, real *a, int *lda)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -64,7 +64,7 @@
        Function Body */
     /* System generated locals */
     /* Local variables */
-    static integer i, j;
+    static int i, j;
 
 
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]

--- a/TESTING/MATGEN/slatb4.c
+++ b/TESTING/MATGEN/slatb4.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -14,7 +15,7 @@
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bool first = true;
 
     /* System generated locals */
     integer i__1;
@@ -95,7 +96,7 @@
        Set some constants for use in the subroutine. */
 
     if (first) {
-	first = FALSE_;
+	first = false;
 	eps = smach("Precision");
 	badc2 = .1f / eps;
 	badc1 = sqrt(badc2);

--- a/TESTING/MATGEN/slatb4.c
+++ b/TESTING/MATGEN/slatb4.c
@@ -4,6 +4,7 @@
 */
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/slatb4.c
+++ b/TESTING/MATGEN/slatb4.c
@@ -10,8 +10,8 @@
 
 /* Table of constant values */
 
-/* Subroutine */ int slatb4_slu(char *path, integer *imat, integer *m, integer *
-	n, char *type, integer *kl, integer *ku, real *anorm, integer *mode, 
+/* Subroutine */ int slatb4_slu(char *path, int *imat, int *m, int *
+	n, char *type, int *kl, int *ku, real *anorm, int *mode,
 	real *cndnum, char *dist)
 {
     /* Initialized data */
@@ -19,7 +19,7 @@
     static bool first = true;
 
     /* System generated locals */
-    integer i__1;
+    int i__1;
 
     /* Builtin functions */
     double sqrt(doublereal);
@@ -29,7 +29,7 @@
     static char c2[2];
     extern /* Subroutine */ int slabad_slu(real *, real *);
     extern float smach(char *);
-    static integer mat;
+    static int mat;
     static real eps;
 
 

--- a/TESTING/MATGEN/slatm1.c
+++ b/TESTING/MATGEN/slatm1.c
@@ -6,24 +6,24 @@
 #include <stdlib.h>
 #include "f2c.h"
 
-/* Subroutine */ int slatm1_slu(integer *mode, real *cond, integer *irsign, 
-	integer *idist, integer *iseed, real *d, integer *n, integer *info)
+/* Subroutine */ int slatm1_slu(int *mode, real *cond, int *irsign,
+	int *idist, int *iseed, real *d, int *n, int *info)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     doublereal d__1, d__2;
 
     /* Builtin functions */
-    double pow_dd(doublereal *, doublereal *), pow_ri(real *, integer *), log(
+    double pow_dd(doublereal *, doublereal *), pow_ri(real *, int *), log(
 	    doublereal), exp(doublereal);
 
     /* Local variables */
     static real temp;
-    static integer i;
+    static int i;
     static real alpha;
     extern int input_error(char *, int *);
-    extern doublereal dlaran_sluslu(integer *);
-    extern /* Subroutine */ int slarnv_slu(integer *, integer *, integer *, real 
+    extern doublereal dlaran_sluslu(int *);
+    extern /* Subroutine */ int slarnv_slu(int *, int *, int *, real
 	    *);
 
 

--- a/TESTING/MATGEN/slatm1.c
+++ b/TESTING/MATGEN/slatm1.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdlib.h>
 #include "f2c.h"
 
 /* Subroutine */ int slatm1_slu(integer *mode, real *cond, integer *irsign, 

--- a/TESTING/MATGEN/slatm2.c
+++ b/TESTING/MATGEN/slatm2.c
@@ -5,18 +5,18 @@
 
 #include "f2c.h"
 
-doublereal slatm2_slu(integer *m, integer *n, integer *i, integer *j, integer *
-	kl, integer *ku, integer *idist, integer *iseed, real *d, integer *
-	igrade, real *dl, real *dr, integer *ipvtng, integer *iwork, real *
+doublereal slatm2_slu(int *m, int *n, int *i, int *j, int *
+	kl, int *ku, int *idist, int *iseed, real *d, int *
+	igrade, real *dl, real *dr, int *ipvtng, int *iwork, real *
 	sparse)
 {
     /* System generated locals */
     real ret_val;
 
     /* Local variables */
-    static integer isub, jsub;
+    static int isub, jsub;
     static real temp;
-    extern doublereal dlaran_sluslu(integer *), slarnd_slu(integer *, integer *);
+    extern doublereal dlaran_sluslu(int *), slarnd_slu(int *, int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/slatm3.c
+++ b/TESTING/MATGEN/slatm3.c
@@ -5,17 +5,17 @@
 
 #include "f2c.h"
 
-doublereal slatm3_slu(integer *m, integer *n, integer *i, integer *j, integer *
-	isub, integer *jsub, integer *kl, integer *ku, integer *idist, 
-	integer *iseed, real *d, integer *igrade, real *dl, real *dr, integer 
-	*ipvtng, integer *iwork, real *sparse)
+doublereal slatm3_slu(int *m, int *n, int *i, int *j, int *
+	isub, int *jsub, int *kl, int *ku, int *idist,
+	int *iseed, real *d, int *igrade, real *dl, real *dr, int
+	*ipvtng, int *iwork, real *sparse)
 {
     /* System generated locals */
     real ret_val;
 
     /* Local variables */
     static real temp;
-    extern doublereal dlaran_sluslu(integer *), slarnd_slu(integer *, integer *);
+    extern doublereal dlaran_sluslu(int *), slarnd_slu(int *, int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/slatms.c
+++ b/TESTING/MATGEN/slatms.c
@@ -2,7 +2,9 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <math.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -500,7 +502,7 @@ static bool c_false = false;
 /*     Choose Top-Down if D is (apparently) increasing,   
        Bottom-Up if D is (apparently) decreasing. */
 
-    if (dabs(d[1]) <= (r__1 = d[mnmin], dabs(r__1))) {
+    if (fabs(d[1]) <= (r__1 = d[mnmin], fabs(r__1))) {
 	topdwn = true;
     } else {
 	topdwn = false;
@@ -510,11 +512,11 @@ static bool c_false = false;
 
 /*        Scale by DMAX */
 
-	temp = dabs(d[1]);
+	temp = fabs(d[1]);
 	i__1 = mnmin;
 	for (i = 2; i <= i__1; ++i) {
 /* Computing MAX */
-	    r__2 = temp, r__3 = (r__1 = d[i], dabs(r__1));
+	    r__2 = temp, r__3 = (r__1 = d[i], fabs(r__1));
 	    temp = dmax(r__2,r__3);
 /* L20: */
 	}

--- a/TESTING/MATGEN/slatms.c
+++ b/TESTING/MATGEN/slatms.c
@@ -10,18 +10,18 @@
 
 /* Table of constant values */
 
-static integer c__1 = 1;
+static int c__1 = 1;
 static real c_b22 = 0.f;
 static bool c_true = true;
 static bool c_false = false;
 
-/* Subroutine */ int slatms_slu(integer *m, integer *n, char *dist, integer *
-	iseed, char *sym, real *d, integer *mode, real *cond, real *dmax__, 
-	integer *kl, integer *ku, char *pack, real *a, integer *lda, real *
-	work, integer *info)
+/* Subroutine */ int slatms_slu(int *m, int *n, char *dist, int *
+	iseed, char *sym, real *d, int *mode, real *cond, real *dmax__,
+	int *kl, int *ku, char *pack, real *a, int *lda, real *
+	work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     real r__1, r__2, r__3;
     bool L__1;
 
@@ -29,37 +29,37 @@ static bool c_false = false;
     double cos(doublereal), sin(doublereal);
 
     /* Local variables */
-    static integer ilda, icol;
+    static int ilda, icol;
     static real temp;
-    static integer irow, isym;
+    static int irow, isym;
     static real c;
-    static integer i, j, k;
+    static int i, j, k;
     static real s, alpha, angle;
-    static integer ipack, ioffg;
-    static integer iinfo;
-    extern /* Subroutine */ int sscal_(integer *, real *, real *, integer *);
-    static integer idist, mnmin, iskew;
+    static int ipack, ioffg;
+    static int iinfo;
+    extern /* Subroutine */ int sscal_(int *, real *, real *, int *);
+    static int idist, mnmin, iskew;
     static real extra, dummy;
-    extern /* Subroutine */ int scopy_(integer *, real *, integer *, real *, 
-	    integer *), slatm1_slu(integer *, real *, integer *, integer *, 
-	    integer *, real *, integer *, integer *);
-    static integer ic, jc, nc, il, iendch, ir, jr, ipackg, mr;
-    extern /* Subroutine */ int slagge_slu(integer *, integer *, integer *, 
-	    integer *, real *, real *, integer *, integer *, real *, integer *
+    extern /* Subroutine */ int scopy_(int *, real *, int *, real *,
+	    int *), slatm1_slu(int *, real *, int *, int *,
+	    int *, real *, int *, int *);
+    static int ic, jc, nc, il, iendch, ir, jr, ipackg, mr;
+    extern /* Subroutine */ int slagge_slu(int *, int *, int *,
+	    int *, real *, real *, int *, int *, real *, int *
 	    );
-    static integer minlda;
+    static int minlda;
     extern int input_error(char *, int *);
-    extern doublereal slarnd_slu(integer *, integer *);
+    extern doublereal slarnd_slu(int *, int *);
     static bool iltemp, givens;
-    static integer ioffst, irsign;
+    static int ioffst, irsign;
     extern /* Subroutine */ int slartg_slu(real *, real *, real *, real *, real *
-	    ), slaset_slu(char *, integer *, integer *, real *, real *, real *, 
-	    integer *), slagsy_slu(integer *, integer *, real *, real *, 
-	    integer *, integer *, real *, integer *), slarot_slu(bool *,
-	    bool *, bool *, integer *, real *, real *, real *, integer *
+	    ), slaset_slu(char *, int *, int *, real *, real *, real *,
+	    int *), slagsy_slu(int *, int *, real *, real *,
+	    int *, int *, real *, int *), slarot_slu(bool *,
+	    bool *, bool *, int *, real *, real *, real *, int *
 	    , real *, real *);
     static bool ilextr, topdwn;
-    static integer ir1, ir2, isympk, jch, llb, jkl, jku, uub;
+    static int ir1, ir2, isympk, jch, llb, jkl, jku, uub;
 
 
 /*  -- LAPACK test routine (version 2.0) --   

--- a/TESTING/MATGEN/slatms.c
+++ b/TESTING/MATGEN/slatms.c
@@ -517,7 +517,7 @@ static bool c_false = false;
 	for (i = 2; i <= i__1; ++i) {
 /* Computing MAX */
 	    r__2 = temp, r__3 = (r__1 = d[i], fabs(r__1));
-	    temp = dmax(r__2,r__3);
+	    temp = fmax(r__2,r__3);
 /* L20: */
 	}
 

--- a/TESTING/MATGEN/slatms.c
+++ b/TESTING/MATGEN/slatms.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -9,8 +10,8 @@
 
 static integer c__1 = 1;
 static real c_b22 = 0.f;
-static logical c_true = TRUE_;
-static logical c_false = FALSE_;
+static bool c_true = true;
+static bool c_false = false;
 
 /* Subroutine */ int slatms_slu(integer *m, integer *n, char *dist, integer *
 	iseed, char *sym, real *d, integer *mode, real *cond, real *dmax__, 
@@ -20,7 +21,7 @@ static logical c_false = FALSE_;
     /* System generated locals */
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     real r__1, r__2, r__3;
-    logical L__1;
+    bool L__1;
 
     /* Builtin functions */
     double cos(doublereal), sin(doublereal);
@@ -47,15 +48,15 @@ static logical c_false = FALSE_;
     static integer minlda;
     extern int input_error(char *, int *);
     extern doublereal slarnd_slu(integer *, integer *);
-    static logical iltemp, givens;
+    static bool iltemp, givens;
     static integer ioffst, irsign;
     extern /* Subroutine */ int slartg_slu(real *, real *, real *, real *, real *
 	    ), slaset_slu(char *, integer *, integer *, real *, real *, real *, 
 	    integer *), slagsy_slu(integer *, integer *, real *, real *, 
-	    integer *, integer *, real *, integer *), slarot_slu(logical *, 
-	    logical *, logical *, integer *, real *, real *, real *, integer *
+	    integer *, integer *, real *, integer *), slarot_slu(bool *,
+	    bool *, bool *, integer *, real *, real *, real *, integer *
 	    , real *, real *);
-    static logical ilextr, topdwn;
+    static bool ilextr, topdwn;
     static integer ir1, ir2, isympk, jch, llb, jkl, jku, uub;
 
 
@@ -424,20 +425,20 @@ static logical c_false = FALSE_;
 /*     Use Givens rotation method if bandwidth small enough,   
        or if LDA is too small to store the matrix unpacked. */
 
-    givens = FALSE_;
+    givens = false;
     if (isym == 1) {
 /* Computing MAX */
 	i__1 = 1, i__2 = mr + nc;
 	if ((real) (llb + uub) < (real) max(i__1,i__2) * .3f) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     } else {
 	if (llb << 1 < *m) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     }
     if (*lda < *m && *lda >= minlda) {
-	givens = TRUE_;
+	givens = true;
     }
 
 /*     Set INFO if an error */
@@ -500,9 +501,9 @@ static logical c_false = FALSE_;
        Bottom-Up if D is (apparently) decreasing. */
 
     if (dabs(d[1]) <= (r__1 = d[mnmin], dabs(r__1))) {
-	topdwn = TRUE_;
+	topdwn = true;
     } else {
-	topdwn = FALSE_;
+	topdwn = false;
     }
 
     if (*mode != 0 && abs(*mode) != 6) {

--- a/TESTING/MATGEN/zdotc.c
+++ b/TESTING/MATGEN/zdotc.c
@@ -5,20 +5,20 @@
 
 #include "f2c.h"
 
-/* Double Complex */ void zdotc_(doublecomplex * ret_val, integer *n,
-	doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy)
+/* Double Complex */ void zdotc_(doublecomplex * ret_val, int *n,
+	doublecomplex *zx, int *incx, doublecomplex *zy, int *incy)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     doublecomplex z__1, z__2, z__3;
 
     /* Builtin functions */
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer i;
+    static int i;
     static doublecomplex ztemp;
-    static integer ix, iy;
+    static int ix, iy;
 
 
 /*     forms the dot product of a vector.   

--- a/TESTING/MATGEN/zdotc.c
+++ b/TESTING/MATGEN/zdotc.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Double Complex */ VOID zdotc_(doublecomplex * ret_val, integer *n, 
+/* Double Complex */ void zdotc_(doublecomplex * ret_val, integer *n,
 	doublecomplex *zx, integer *incx, doublecomplex *zy, integer *incy)
 {
     /* System generated locals */

--- a/TESTING/MATGEN/zlacgv.c
+++ b/TESTING/MATGEN/zlacgv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int zlacgv_slu(integer *n, doublecomplex *x, integer *incx)
+/* Subroutine */ int zlacgv_slu(int *n, doublecomplex *x, int *incx)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -39,7 +39,7 @@
     /* Builtin functions */
     void d_cnjg(doublecomplex *, doublecomplex *);
     /* Local variables */
-    static integer ioff, i;
+    static int ioff, i;
 
 
 #define X(I) x[(I)-1]

--- a/TESTING/MATGEN/zlagge.c
+++ b/TESTING/MATGEN/zlagge.c
@@ -9,15 +9,15 @@
 
 static doublecomplex c_b1 = {0.,0.};
 static doublecomplex c_b2 = {1.,0.};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int zlagge_slu(integer *m, integer *n, integer *kl, integer *ku,
-	 doublereal *d, doublecomplex *a, integer *lda, integer *iseed, 
-	doublecomplex *work, integer *info)
+/* Subroutine */ int zlagge_slu(int *m, int *n, int *kl, int *ku,
+	 doublereal *d, doublecomplex *a, int *lda, int *iseed,
+	doublecomplex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
     doublecomplex z__1;
 
@@ -26,18 +26,18 @@ static integer c__1 = 1;
     void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer i, j;
-    extern /* Subroutine */ int zgerc_(integer *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
-	    doublecomplex *, integer *), zgemv_(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *, integer *);
-    extern doublereal dznrm2_(integer *, doublecomplex *, integer *);
+    static int i, j;
+    extern /* Subroutine */ int zgerc_(int *, int *, doublecomplex *,
+	    doublecomplex *, int *, doublecomplex *, int *,
+	    doublecomplex *, int *), zscal_(int *, doublecomplex *,
+	    doublecomplex *, int *), zgemv_(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *, int *);
+    extern doublereal dznrm2_(int *, doublecomplex *, int *);
     static doublecomplex wa, wb;
     static doublereal wn;
-    extern /* Subroutine */ int zlacgv_slu(integer *, doublecomplex *, integer *), zlarnv_slu(integer *, 
-	    integer *, integer *, doublecomplex *);
+    extern /* Subroutine */ int zlacgv_slu(int *, doublecomplex *, int *), zlarnv_slu(int *,
+	    int *, int *, doublecomplex *);
     extern int input_error(char *, int *);
     static doublecomplex tau;
 

--- a/TESTING/MATGEN/zlaghe.c
+++ b/TESTING/MATGEN/zlaghe.c
@@ -36,7 +36,7 @@ static integer c__1 = 1;
 	    doublecomplex *, integer *, doublecomplex *, integer *, 
 	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
 	    doublecomplex *, integer *);
-    extern /* Double Complex */ VOID zdotc_(doublecomplex *, integer *, 
+    extern /* Double Complex */ void zdotc_(doublecomplex *, integer *,
 	    doublecomplex *, integer *, doublecomplex *, integer *);
     extern /* Subroutine */ int zgemv_(char *, integer *, integer *, 
 	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 

--- a/TESTING/MATGEN/zlaghe.c
+++ b/TESTING/MATGEN/zlaghe.c
@@ -9,15 +9,15 @@
 
 static doublecomplex c_b1 = {0.,0.};
 static doublecomplex c_b2 = {1.,0.};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int zlaghe_slu(integer *n, integer *k, doublereal *d, 
-	doublecomplex *a, integer *lda, integer *iseed, doublecomplex *work, 
-	integer *info)
+/* Subroutine */ int zlaghe_slu(int *n, int *k, doublereal *d,
+	doublecomplex *a, int *lda, int *iseed, doublecomplex *work,
+	int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4;
 
@@ -27,29 +27,29 @@ static integer c__1 = 1;
 	    doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    extern /* Subroutine */ int zher2_(char *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *);
-    static integer i, j;
+    extern /* Subroutine */ int zher2_(char *, int *, doublecomplex *,
+	    doublecomplex *, int *, doublecomplex *, int *,
+	    doublecomplex *, int *);
+    static int i, j;
     static doublecomplex alpha;
-    extern /* Subroutine */ int zgerc_(integer *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
-	    doublecomplex *, integer *);
-    extern /* Double Complex */ void zdotc_(doublecomplex *, integer *,
-	    doublecomplex *, integer *, doublecomplex *, integer *);
-    extern /* Subroutine */ int zgemv_(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *, integer *), 
-	    zhemv_(char *, integer *, doublecomplex *, doublecomplex *, 
-	    integer *, doublecomplex *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *), zaxpy_(integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *);
-    extern doublereal dznrm2_(integer *, doublecomplex *, integer *);
+    extern /* Subroutine */ int zgerc_(int *, int *, doublecomplex *,
+	    doublecomplex *, int *, doublecomplex *, int *,
+	    doublecomplex *, int *), zscal_(int *, doublecomplex *,
+	    doublecomplex *, int *);
+    extern /* Double Complex */ void zdotc_(doublecomplex *, int *,
+	    doublecomplex *, int *, doublecomplex *, int *);
+    extern /* Subroutine */ int zgemv_(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *, int *),
+	    zhemv_(char *, int *, doublecomplex *, doublecomplex *,
+	    int *, doublecomplex *, int *, doublecomplex *,
+	    doublecomplex *, int *), zaxpy_(int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *);
+    extern doublereal dznrm2_(int *, doublecomplex *, int *);
     static doublecomplex wa, wb;
     static doublereal wn;
-    extern /* Subroutine */ int zlarnv_slu(integer *, integer *, integer *, doublecomplex *);
+    extern /* Subroutine */ int zlarnv_slu(int *, int *, int *, doublecomplex *);
     extern int input_error(char *, int *);
     static doublecomplex tau;
 

--- a/TESTING/MATGEN/zlagsy.c
+++ b/TESTING/MATGEN/zlagsy.c
@@ -9,15 +9,15 @@
 
 static doublecomplex c_b1 = {0.,0.};
 static doublecomplex c_b2 = {1.,0.};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int zlagsy_slu(integer *n, integer *k, doublereal *d, 
-	doublecomplex *a, integer *lda, integer *iseed, doublecomplex *work, 
-	integer *info)
+/* Subroutine */ int zlagsy_slu(int *n, int *k, doublereal *d,
+	doublecomplex *a, int *lda, int *iseed, doublecomplex *work,
+	int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6, i__7, i__8, 
+    int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6, i__7, i__8,
 	    i__9;
     doublereal d__1;
     doublecomplex z__1, z__2, z__3, z__4;
@@ -27,27 +27,27 @@ static integer c__1 = 1;
     void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer i, j;
+    static int i, j;
     static doublecomplex alpha;
-    extern /* Subroutine */ int zgerc_(integer *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
-	    doublecomplex *, integer *);
-    extern /* Double Complex */ void zdotc_(doublecomplex *, integer *,
-	    doublecomplex *, integer *, doublecomplex *, integer *);
-    extern /* Subroutine */ int zgemv_(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *, integer *), 
-	    zaxpy_(integer *, doublecomplex *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *), zsymv_(char *, integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *, integer *);
-    extern doublereal dznrm2_(integer *, doublecomplex *, integer *);
-    static integer ii, jj;
+    extern /* Subroutine */ int zgerc_(int *, int *, doublecomplex *,
+	    doublecomplex *, int *, doublecomplex *, int *,
+	    doublecomplex *, int *), zscal_(int *, doublecomplex *,
+	    doublecomplex *, int *);
+    extern /* Double Complex */ void zdotc_(doublecomplex *, int *,
+	    doublecomplex *, int *, doublecomplex *, int *);
+    extern /* Subroutine */ int zgemv_(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *, int *),
+	    zaxpy_(int *, doublecomplex *, doublecomplex *, int *,
+	    doublecomplex *, int *), zsymv_(char *, int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *, int *);
+    extern doublereal dznrm2_(int *, doublecomplex *, int *);
+    static int ii, jj;
     static doublecomplex wa, wb;
     static doublereal wn;
-    extern /* Subroutine */ int zlacgv_slu(integer *, doublecomplex *, integer *), zlarnv_slu(integer *, 
-	    integer *, integer *, doublecomplex *);
+    extern /* Subroutine */ int zlacgv_slu(int *, doublecomplex *, int *), zlarnv_slu(int *,
+	    int *, int *, doublecomplex *);
     extern int input_error(char *, int *);
     static doublecomplex tau;
 

--- a/TESTING/MATGEN/zlagsy.c
+++ b/TESTING/MATGEN/zlagsy.c
@@ -33,7 +33,7 @@ static integer c__1 = 1;
 	    doublecomplex *, integer *, doublecomplex *, integer *, 
 	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
 	    doublecomplex *, integer *);
-    extern /* Double Complex */ VOID zdotc_(doublecomplex *, integer *, 
+    extern /* Double Complex */ void zdotc_(doublecomplex *, integer *,
 	    doublecomplex *, integer *, doublecomplex *, integer *);
     extern /* Subroutine */ int zgemv_(char *, integer *, integer *, 
 	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 

--- a/TESTING/MATGEN/zlarge.c
+++ b/TESTING/MATGEN/zlarge.c
@@ -9,14 +9,14 @@
 
 static doublecomplex c_b1 = {0.,0.};
 static doublecomplex c_b2 = {1.,0.};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int zlarge_slu(integer *n, doublecomplex *a, integer *lda, 
-	integer *iseed, doublecomplex *work, integer *info)
+/* Subroutine */ int zlarge_slu(int *n, doublecomplex *a, int *lda,
+	int *iseed, doublecomplex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1;
+    int a_dim1, a_offset, i__1;
     doublereal d__1;
     doublecomplex z__1;
 
@@ -25,17 +25,17 @@ static integer c__1 = 1;
     void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer i;
-    extern /* Subroutine */ int zgerc_(integer *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
-	    doublecomplex *, integer *), zgemv_(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *, integer *);
-    extern doublereal dznrm2_(integer *, doublecomplex *, integer *);
+    static int i;
+    extern /* Subroutine */ int zgerc_(int *, int *, doublecomplex *,
+	    doublecomplex *, int *, doublecomplex *, int *,
+	    doublecomplex *, int *), zscal_(int *, doublecomplex *,
+	    doublecomplex *, int *), zgemv_(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *, int *);
+    extern doublereal dznrm2_(int *, doublecomplex *, int *);
     static doublecomplex wa, wb;
     static doublereal wn;
-    extern /* Subroutine */ int zlarnv_slu(integer *, integer *, integer *, doublecomplex *);
+    extern /* Subroutine */ int zlarnv_slu(int *, int *, int *, doublecomplex *);
     extern int input_error(char *, int *);
     static doublecomplex tau;
 

--- a/TESTING/MATGEN/zlarnd.c
+++ b/TESTING/MATGEN/zlarnd.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Double Complex */ VOID zlarnd_slu(doublecomplex * ret_val, integer *idist, 
+/* Double Complex */ void zlarnd_slu(doublecomplex * ret_val, integer *idist,
 	integer *iseed)
 {
     /* System generated locals */

--- a/TESTING/MATGEN/zlarnd.c
+++ b/TESTING/MATGEN/zlarnd.c
@@ -5,8 +5,8 @@
 
 #include "f2c.h"
 
-/* Double Complex */ void zlarnd_slu(doublecomplex * ret_val, integer *idist,
-	integer *iseed)
+/* Double Complex */ void zlarnd_slu(doublecomplex * ret_val, int *idist,
+	int *iseed)
 {
     /* System generated locals */
     doublereal d__1, d__2;
@@ -18,7 +18,7 @@
 
     /* Local variables */
     static doublereal t1, t2;
-    extern doublereal dlaran_slu(integer *);
+    extern doublereal dlaran_slu(int *);
     extern int input_error(char *, int *);
 
 

--- a/TESTING/MATGEN/zlarnv.c
+++ b/TESTING/MATGEN/zlarnv.c
@@ -1,6 +1,6 @@
 #include "f2c.h"
 
-/* Subroutine */ int zlarnv_slu(integer *idist, integer *iseed, integer *n, 
+/* Subroutine */ int zlarnv_slu(int *idist, int *iseed, int *n,
 	doublecomplex *x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -56,17 +56,17 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    integer i__2, i__3;
+    int i__2, i__3;
     doublereal d__1, d__2;
     doublecomplex z__1, z__2, z__3;
     /* Builtin functions */
     double log(doublereal), sqrt(doublereal);
     void z_exp(doublecomplex *, doublecomplex *);
     /* Local variables */
-    static integer i;
+    static int i;
     static doublereal u[128];
-    static integer il, iv;
-    extern /* Subroutine */ int dlaruv_slu(integer *, integer *, doublereal *);
+    static int il, iv;
+    extern /* Subroutine */ int dlaruv_slu(int *, int *, doublereal *);
 
 
 #define U(I) u[(I)]

--- a/TESTING/MATGEN/zlaror.c
+++ b/TESTING/MATGEN/zlaror.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/zlaror.c
+++ b/TESTING/MATGEN/zlaror.c
@@ -10,15 +10,15 @@
 
 static doublecomplex c_b1 = {0.,0.};
 static doublecomplex c_b2 = {1.,0.};
-static integer c__3 = 3;
-static integer c__1 = 1;
+static int c__3 = 3;
+static int c__1 = 1;
 
-/* Subroutine */ int zlaror_slu(char *side, char *init, integer *m, integer *n, 
-	doublecomplex *a, integer *lda, integer *iseed, doublecomplex *x, 
-	integer *info)
+/* Subroutine */ int zlaror_slu(char *side, char *init, int *m, int *n,
+	doublecomplex *a, int *lda, int *iseed, doublecomplex *x,
+	int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3;
+    int a_dim1, a_offset, i__1, i__2, i__3;
     doublecomplex z__1, z__2;
 
     /* Builtin functions */
@@ -26,29 +26,27 @@ static integer c__1 = 1;
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer kbeg, jcol;
+    static int kbeg, jcol;
     static doublereal xabs;
-    static integer irow, j;
+    static int irow, j;
     static doublecomplex csign;
-    extern /* Subroutine */ int zgerc_(integer *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, 
-	    doublecomplex *, integer *), zscal_(integer *, doublecomplex *, 
-	    doublecomplex *, integer *);
-    static integer ixfrm;
-    extern /* Subroutine */ int zgemv_(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, integer *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *, integer *);
-    static integer itype, nxfrm;
+    extern /* Subroutine */ int zgerc_(int *, int *, doublecomplex *,
+	    doublecomplex *, int *, doublecomplex *, int *,
+	    doublecomplex *, int *), zscal_(int *, doublecomplex *,
+	    doublecomplex *, int *);
+    static int ixfrm;
+    extern /* Subroutine */ int zgemv_(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, int *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *, int *);
+    static int itype, nxfrm;
     static doublereal xnorm;
-    extern doublereal dznrm2_(integer *, doublecomplex *, integer *);
+    extern doublereal dznrm2_(int *, doublecomplex *, int *);
     extern int input_error(char *, int *);
     static doublereal factor;
-    extern /* Subroutine */ int zlacgv_slu(integer *, doublecomplex *, integer *)
-	    ;
-    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *,
-	    integer *);
-    extern /* Subroutine */ int zlaset_slu(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, doublecomplex *, integer *);
+    extern /* Subroutine */ int zlacgv_slu(int *, doublecomplex *, int *);
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, int *, int *);
+    extern /* Subroutine */ int zlaset_slu(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, doublecomplex *, int *);
     static doublecomplex xnorms;
 
 

--- a/TESTING/MATGEN/zlaror.c
+++ b/TESTING/MATGEN/zlaror.c
@@ -44,7 +44,7 @@ static integer c__1 = 1;
     static doublereal factor;
     extern /* Subroutine */ int zlacgv_slu(integer *, doublecomplex *, integer *)
 	    ;
-    extern /* Double Complex */ VOID zlarnd_slu(doublecomplex *, integer *, 
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *,
 	    integer *);
     extern /* Subroutine */ int zlaset_slu(char *, integer *, integer *, 
 	    doublecomplex *, doublecomplex *, doublecomplex *, integer *);

--- a/TESTING/MATGEN/zlarot.c
+++ b/TESTING/MATGEN/zlarot.c
@@ -8,28 +8,28 @@
 
 /* Table of constant values */
 
-static integer c__4 = 4;
-static integer c__8 = 8;
+static int c__4 = 4;
+static int c__8 = 8;
 
 /* Subroutine */
 int zlarot_slu(bool *lrows, bool *lleft, bool *lright,
-	integer *nl, doublecomplex *c, doublecomplex *s, doublecomplex *a, 
-	integer *lda, doublecomplex *xleft, doublecomplex *xright)
+	int *nl, doublecomplex *c, doublecomplex *s, doublecomplex *a,
+	int *lda, doublecomplex *xleft, doublecomplex *xright)
 {
     /* System generated locals */
-    integer i__1, i__2, i__3, i__4;
+    int i__1, i__2, i__3, i__4;
     doublecomplex z__1, z__2, z__3, z__4, z__5, z__6;
 
     /* Builtin functions */
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer iinc, j, inext;
+    static int iinc, j, inext;
     static doublecomplex tempx;
-    static integer ix, iy, nt;
+    static int ix, iy, nt;
     static doublecomplex xt[2], yt[2];
     extern int input_error(char *, int *);
-    static integer iyt;
+    static int iyt;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/zlarot.c
+++ b/TESTING/MATGEN/zlarot.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include "f2c.h"
 
 /* Table of constant values */
@@ -10,7 +11,8 @@
 static integer c__4 = 4;
 static integer c__8 = 8;
 
-/* Subroutine */ int zlarot_slu(logical *lrows, logical *lleft, logical *lright, 
+/* Subroutine */
+int zlarot_slu(bool *lrows, bool *lleft, bool *lright,
 	integer *nl, doublecomplex *c, doublecomplex *s, doublecomplex *a, 
 	integer *lda, doublecomplex *xleft, doublecomplex *xright)
 {

--- a/TESTING/MATGEN/zlartg.c
+++ b/TESTING/MATGEN/zlartg.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "f2c.h"
 
 /* Subroutine */ int zlartg_slu(doublecomplex *f, doublecomplex *g, doublereal *

--- a/TESTING/MATGEN/zlaset.c
+++ b/TESTING/MATGEN/zlaset.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int zlaset_slu(char *uplo, integer *m, integer *n, 
-	doublecomplex *alpha, doublecomplex *beta, doublecomplex *a, integer *
+/* Subroutine */ int zlaset_slu(char *uplo, int *m, int *n,
+	doublecomplex *alpha, doublecomplex *beta, doublecomplex *a, int *
 	lda)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -60,7 +60,7 @@
     /* System generated locals */
 
     /* Local variables */
-    static integer i, j;
+    static int i, j;
 
 
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]

--- a/TESTING/MATGEN/zlatb4.c
+++ b/TESTING/MATGEN/zlatb4.c
@@ -10,8 +10,8 @@
 
 /* Table of constant values */
 
-/* Subroutine */ int zlatb4_slu(char *path, integer *imat, integer *m, integer *
-	n, char *type, integer *kl, integer *ku, doublereal *anorm, integer *
+/* Subroutine */ int zlatb4_slu(char *path, int *imat, int *m, int *
+	n, char *type, int *kl, int *ku, doublereal *anorm, int *
 	mode, doublereal *cndnum, char *dist)
 {
     /* Initialized data */
@@ -19,7 +19,7 @@
     static bool first = true;
 
     /* System generated locals */
-    integer i__1;
+    int i__1;
 
     /* Builtin functions */
     double sqrt(doublereal);
@@ -30,7 +30,7 @@
     static char c2[2];
     extern /* Subroutine */ int dlabad_slu(doublereal *, doublereal *);
     extern doublereal dmach(char *);
-    static integer mat;
+    static int mat;
     static doublereal eps;
 
 

--- a/TESTING/MATGEN/zlatb4.c
+++ b/TESTING/MATGEN/zlatb4.c
@@ -4,6 +4,7 @@
 */
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/zlatb4.c
+++ b/TESTING/MATGEN/zlatb4.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -14,7 +15,7 @@
 {
     /* Initialized data */
 
-    static logical first = TRUE_;
+    static bool first = true;
 
     /* System generated locals */
     integer i__1;
@@ -96,7 +97,7 @@
        Set some constants for use in the subroutine. */
 
     if (first) {
-	first = FALSE_;
+	first = false;
 	eps = dmach("Precision");
 	badc2 = .1 / eps;
 	badc1 = sqrt(badc2);

--- a/TESTING/MATGEN/zlatm2.c
+++ b/TESTING/MATGEN/zlatm2.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Double Complex */ VOID zlatm2_slu(doublecomplex * ret_val, integer *m, 
+/* Double Complex */ void zlatm2_slu(doublecomplex * ret_val, integer *m,
 	integer *n, integer *i, integer *j, integer *kl, integer *ku, integer 
 	*idist, integer *iseed, doublecomplex *d, integer *igrade, 
 	doublecomplex *dl, doublecomplex *dr, integer *ipvtng, integer *iwork,
@@ -23,7 +23,7 @@
     static integer isub, jsub;
     static doublecomplex ctemp;
     extern doublereal dlaran_slu(integer *);
-    extern /* Double Complex */ VOID zlarnd_slu(doublecomplex *, integer *, 
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *,
 	    integer *);
 
 

--- a/TESTING/MATGEN/zlatm2.c
+++ b/TESTING/MATGEN/zlatm2.c
@@ -5,14 +5,14 @@
 
 #include "f2c.h"
 
-/* Double Complex */ void zlatm2_slu(doublecomplex * ret_val, integer *m,
-	integer *n, integer *i, integer *j, integer *kl, integer *ku, integer 
-	*idist, integer *iseed, doublecomplex *d, integer *igrade, 
-	doublecomplex *dl, doublecomplex *dr, integer *ipvtng, integer *iwork,
+/* Double Complex */ void zlatm2_slu(doublecomplex * ret_val, int *m,
+	int *n, int *i, int *j, int *kl, int *ku, int
+	*idist, int *iseed, doublecomplex *d, int *igrade,
+	doublecomplex *dl, doublecomplex *dr, int *ipvtng, int *iwork,
 	 doublereal *sparse)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     doublecomplex z__1, z__2, z__3;
 
     /* Builtin functions */
@@ -20,11 +20,11 @@
 	    doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer isub, jsub;
+    static int isub, jsub;
     static doublecomplex ctemp;
-    extern doublereal dlaran_slu(integer *);
-    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *,
-	    integer *);
+    extern doublereal dlaran_slu(int *);
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, int *,
+	    int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/zlatm3.c
+++ b/TESTING/MATGEN/zlatm3.c
@@ -5,14 +5,14 @@
 
 #include "f2c.h"
 
-/* Double Complex */ void zlatm3_slu(doublecomplex * ret_val, integer *m,
-	integer *n, integer *i, integer *j, integer *isub, integer *jsub, 
-	integer *kl, integer *ku, integer *idist, integer *iseed, 
-	doublecomplex *d, integer *igrade, doublecomplex *dl, doublecomplex *
-	dr, integer *ipvtng, integer *iwork, doublereal *sparse)
+/* Double Complex */ void zlatm3_slu(doublecomplex * ret_val, int *m,
+	int *n, int *i, int *j, int *isub, int *jsub,
+	int *kl, int *ku, int *idist, int *iseed,
+	doublecomplex *d, int *igrade, doublecomplex *dl, doublecomplex *
+	dr, int *ipvtng, int *iwork, doublereal *sparse)
 {
     /* System generated locals */
-    integer i__1, i__2;
+    int i__1, i__2;
     doublecomplex z__1, z__2, z__3;
 
     /* Builtin functions */
@@ -21,9 +21,9 @@
 
     /* Local variables */
     static doublecomplex ctemp;
-    extern doublereal dlaran_slu(integer *);
-    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *,
-	    integer *);
+    extern doublereal dlaran_slu(int *);
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, int *,
+	    int *);
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/zlatm3.c
+++ b/TESTING/MATGEN/zlatm3.c
@@ -5,7 +5,7 @@
 
 #include "f2c.h"
 
-/* Double Complex */ VOID zlatm3_slu(doublecomplex * ret_val, integer *m, 
+/* Double Complex */ void zlatm3_slu(doublecomplex * ret_val, integer *m,
 	integer *n, integer *i, integer *j, integer *isub, integer *jsub, 
 	integer *kl, integer *ku, integer *idist, integer *iseed, 
 	doublecomplex *d, integer *igrade, doublecomplex *dl, doublecomplex *
@@ -22,7 +22,7 @@
     /* Local variables */
     static doublecomplex ctemp;
     extern doublereal dlaran_slu(integer *);
-    extern /* Double Complex */ VOID zlarnd_slu(doublecomplex *, integer *, 
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *,
 	    integer *);
 
 

--- a/TESTING/MATGEN/zlatms.c
+++ b/TESTING/MATGEN/zlatms.c
@@ -3,6 +3,7 @@
 	-lf2c -lm   (in that order)
 */
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include "f2c.h"
 

--- a/TESTING/MATGEN/zlatms.c
+++ b/TESTING/MATGEN/zlatms.c
@@ -10,18 +10,18 @@
 /* Table of constant values */
 
 static doublecomplex c_b1 = {0.,0.};
-static integer c__1 = 1;
-static integer c__5 = 5;
+static int c__1 = 1;
+static int c__5 = 5;
 static bool c_true = true;
 static bool c_false = false;
 
-/* Subroutine */ int zlatms_slu(integer *m, integer *n, char *dist, integer *
-	iseed, char *sym, doublereal *d, integer *mode, doublereal *cond, 
-	doublereal *dmax__, integer *kl, integer *ku, char *pack, 
-	doublecomplex *a, integer *lda, doublecomplex *work, integer *info)
+/* Subroutine */ int zlatms_slu(int *m, int *n, char *dist, int *
+	iseed, char *sym, doublereal *d, int *mode, doublereal *cond,
+	doublereal *dmax__, int *kl, int *ku, char *pack,
+	doublecomplex *a, int *lda, doublecomplex *work, int *info)
 {
     /* System generated locals */
-    integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
+    int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     doublereal d__1, d__2, d__3;
     doublecomplex z__1, z__2, z__3;
     bool L__1;
@@ -31,53 +31,53 @@ static bool c_false = false;
     void d_cnjg(doublecomplex *, doublecomplex *);
 
     /* Local variables */
-    static integer ilda, icol;
+    static int ilda, icol;
     static doublereal temp;
-    static integer irow, isym;
+    static int irow, isym;
     static bool zsym;
     static doublecomplex c;
-    static integer i, j, k;
+    static int i, j, k;
     static doublecomplex s;
     static doublereal alpha, angle;
-    static integer ipack;
+    static int ipack;
     static doublereal realc;
-    static integer ioffg;
-    extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
-	    integer *);
-    static integer iinfo;
+    static int ioffg;
+    extern /* Subroutine */ int dscal_(int *, doublereal *, doublereal *,
+	    int *);
+    static int iinfo;
     static doublecomplex ctemp;
-    static integer idist, mnmin, iskew;
+    static int idist, mnmin, iskew;
     static doublecomplex extra, dummy;
-    extern /* Subroutine */ int dlatm1_slu(integer *, doublereal *, integer *, 
-	    integer *, integer *, doublereal *, integer *, integer *);
-    static integer ic, jc, nc, il;
+    extern /* Subroutine */ int dlatm1_slu(int *, doublereal *, int *,
+	    int *, int *, doublereal *, int *, int *);
+    static int ic, jc, nc, il;
     static doublecomplex ct;
-    static integer iendch, ir, jr, ipackg, mr, minlda;
-    extern doublereal dlarnd_slu(integer *, integer *);
+    static int iendch, ir, jr, ipackg, mr, minlda;
+    extern doublereal dlarnd_slu(int *, int *);
     static doublecomplex st;
-    extern /* Subroutine */ int zlagge_slu(integer *, integer *, integer *, 
-	    integer *, doublereal *, doublecomplex *, integer *, integer *, 
-	    doublecomplex *, integer *), zlaghe_slu(integer *, integer *, 
-	    doublereal *, doublecomplex *, integer *, integer *, 
-						 doublecomplex *, integer *);
+    extern /* Subroutine */ int zlagge_slu(int *, int *, int *,
+	    int *, doublereal *, doublecomplex *, int *, int *,
+	    doublecomplex *, int *), zlaghe_slu(int *, int *,
+	    doublereal *, doublecomplex *, int *, int *,
+						 doublecomplex *, int *);
     extern int input_error(char *, int *);
     static bool iltemp, givens;
-    static integer ioffst, irsign;
-    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *, 
-	    integer *);
-    extern /* Subroutine */ int zlaset_slu(char *, integer *, integer *, 
-	    doublecomplex *, doublecomplex *, doublecomplex *, integer *), zlartg_slu(doublecomplex *, doublecomplex *, doublereal *, 
+    static int ioffst, irsign;
+    extern /* Double Complex */ void zlarnd_slu(doublecomplex *, int *,
+	    int *);
+    extern /* Subroutine */ int zlaset_slu(char *, int *, int *,
+	    doublecomplex *, doublecomplex *, doublecomplex *, int *), zlartg_slu(doublecomplex *, doublecomplex *, doublereal *,
 	    doublecomplex *, doublecomplex *);
     static bool ilextr;
-    extern /* Subroutine */ int zlagsy_slu(integer *, integer *, doublereal *, 
-	    doublecomplex *, integer *, integer *, doublecomplex *, integer *)
+    extern /* Subroutine */ int zlagsy_slu(int *, int *, doublereal *,
+	    doublecomplex *, int *, int *, doublecomplex *, int *)
 	    ;
     static bool topdwn;
-    static integer ir1, ir2, isympk;
+    static int ir1, ir2, isympk;
     extern /* Subroutine */ int zlarot_slu(bool *, bool *, bool *,
-	    integer *, doublecomplex *, doublecomplex *, doublecomplex *, 
-	    integer *, doublecomplex *, doublecomplex *);
-    static integer jch, llb, jkl, jku, uub;
+	    int *, doublecomplex *, doublecomplex *, doublecomplex *,
+	    int *, doublecomplex *, doublecomplex *);
+    static int jch, llb, jkl, jku, uub;
 
 
 /*  -- LAPACK test routine (version 2.0) --   

--- a/TESTING/MATGEN/zlatms.c
+++ b/TESTING/MATGEN/zlatms.c
@@ -2,6 +2,7 @@
    You must link the resulting object file with the libraries:
 	-lf2c -lm   (in that order)
 */
+#include <stdbool.h>
 #include <string.h>
 #include "f2c.h"
 
@@ -10,8 +11,8 @@
 static doublecomplex c_b1 = {0.,0.};
 static integer c__1 = 1;
 static integer c__5 = 5;
-static logical c_true = TRUE_;
-static logical c_false = FALSE_;
+static bool c_true = true;
+static bool c_false = false;
 
 /* Subroutine */ int zlatms_slu(integer *m, integer *n, char *dist, integer *
 	iseed, char *sym, doublereal *d, integer *mode, doublereal *cond, 
@@ -22,7 +23,7 @@ static logical c_false = FALSE_;
     integer a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     doublereal d__1, d__2, d__3;
     doublecomplex z__1, z__2, z__3;
-    logical L__1;
+    bool L__1;
 
     /* Builtin functions */
     double cos(doublereal), sin(doublereal);
@@ -32,7 +33,7 @@ static logical c_false = FALSE_;
     static integer ilda, icol;
     static doublereal temp;
     static integer irow, isym;
-    static logical zsym;
+    static bool zsym;
     static doublecomplex c;
     static integer i, j, k;
     static doublecomplex s;
@@ -59,20 +60,20 @@ static logical c_false = FALSE_;
 	    doublereal *, doublecomplex *, integer *, integer *, 
 						 doublecomplex *, integer *);
     extern int input_error(char *, int *);
-    static logical iltemp, givens;
+    static bool iltemp, givens;
     static integer ioffst, irsign;
     extern /* Double Complex */ void zlarnd_slu(doublecomplex *, integer *, 
 	    integer *);
     extern /* Subroutine */ int zlaset_slu(char *, integer *, integer *, 
 	    doublecomplex *, doublecomplex *, doublecomplex *, integer *), zlartg_slu(doublecomplex *, doublecomplex *, doublereal *, 
 	    doublecomplex *, doublecomplex *);
-    static logical ilextr;
+    static bool ilextr;
     extern /* Subroutine */ int zlagsy_slu(integer *, integer *, doublereal *, 
 	    doublecomplex *, integer *, integer *, doublecomplex *, integer *)
 	    ;
-    static logical topdwn;
+    static bool topdwn;
     static integer ir1, ir2, isympk;
-    extern /* Subroutine */ int zlarot_slu(logical *, logical *, logical *, 
+    extern /* Subroutine */ int zlarot_slu(bool *, bool *, bool *,
 	    integer *, doublecomplex *, doublecomplex *, doublecomplex *, 
 	    integer *, doublecomplex *, doublecomplex *);
     static integer jch, llb, jkl, jku, uub;
@@ -386,19 +387,19 @@ static logical c_false = FALSE_;
     if (strncmp(sym, "N", 1)==0) {
 	isym = 1;
 	irsign = 0;
-	zsym = FALSE_;
+	zsym = false;
     } else if (strncmp(sym, "P", 1)==0) {
 	isym = 2;
 	irsign = 0;
-	zsym = FALSE_;
+	zsym = false;
     } else if (strncmp(sym, "S", 1)==0) {
 	isym = 2;
 	irsign = 0;
-	zsym = TRUE_;
+	zsym = true;
     } else if (strncmp(sym, "H", 1)==0) {
 	isym = 2;
 	irsign = 1;
-	zsym = FALSE_;
+	zsym = false;
     } else {
 	isym = -1;
     }
@@ -459,20 +460,20 @@ static logical c_false = FALSE_;
 /*     Use Givens rotation method if bandwidth small enough,   
        or if LDA is too small to store the matrix unpacked. */
 
-    givens = FALSE_;
+    givens = false;
     if (isym == 1) {
 /* Computing MAX */
 	i__1 = 1, i__2 = mr + nc;
 	if ((doublereal) (llb + uub) < (doublereal) max(i__1,i__2) * .3) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     } else {
 	if (llb << 1 < *m) {
-	    givens = TRUE_;
+	    givens = true;
 	}
     }
     if (*lda < *m && *lda >= minlda) {
-	givens = TRUE_;
+	givens = true;
     }
 
 /*     Set INFO if an error */
@@ -535,9 +536,9 @@ static logical c_false = FALSE_;
        Bottom-Up if D is (apparently) decreasing. */
 
     if (abs(d[1]) <= (d__1 = d[mnmin], abs(d__1))) {
-	topdwn = TRUE_;
+	topdwn = true;
     } else {
-	topdwn = FALSE_;
+	topdwn = false;
     }
 
     if (*mode != 0 && abs(*mode) != 6) {

--- a/TESTING/MATGEN/zsymv.c
+++ b/TESTING/MATGEN/zsymv.c
@@ -1,9 +1,9 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int zsymv_(char *uplo, integer *n, doublecomplex *alpha, 
-	doublecomplex *a, integer *lda, doublecomplex *x, integer *incx, 
-	doublecomplex *beta, doublecomplex *y, integer *incy)
+/* Subroutine */ int zsymv_(char *uplo, int *n, doublecomplex *alpha,
+	doublecomplex *a, int *lda, doublecomplex *x, int *incx,
+	doublecomplex *beta, doublecomplex *y, int *incy)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -106,10 +106,10 @@
 
     doublecomplex z__1, z__2, z__3, z__4;
     /* Local variables */
-    static integer info;
+    static int info;
     static doublecomplex temp1, temp2;
-    static integer i, j;
-    static integer ix, iy, jx, jy, kx, ky;
+    static int i, j;
+    static int ix, iy, jx, jy, kx, ky;
     extern int input_error(char *, int *);
 
 #define X(I) x[(I)-1]


### PR DESCRIPTION
All contents of TESTING/MATGEN does not feel to be C code, it is rather awkward Fortran code. I replaced some of the typedefs inspired by Fortran. My goal is to get rid of f2c.h altogether for TESTING/MATGEN. But I piled up to many changes, once they get merged I will carry on.

Further, when using CMake, I forced the use of C99 mode , if nothing is defined by the user.