### PR TITLE
[cmake] Alter way of handling enable_doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,9 +215,7 @@ if (XSDK_ENABLE_Fortran)
   add_subdirectory(FORTRAN)
 endif()
 
-if(enable_doc)
-  add_subdirectory(DOC)
-endif()
+add_subdirectory(DOC)
 
 # Generate various configure files with proper definitions
 

--- a/DOC/CMakeLists.txt
+++ b/DOC/CMakeLists.txt
@@ -9,7 +9,13 @@ set_package_properties("Doxygen" PROPERTIES
 # set Doxygen options
 set(DOXYGEN_WARN_LOGFILE "doxygen.log")
 
+# build documentation for target "all" if enable_doc is set
+if(enable_doc)
+  set(_DEPENDENCY_ALL "ALL")
+endif()
+
 doxygen_add_docs(doc
+                 "${_DEPENDENCY_ALL}"
                  "${CMAKE_CURRENT_SOURCE_DIR}/mainpage.txt"
                  "${CMAKE_CURRENT_SOURCE_DIR}/modules.txt"
                  "${PROJECT_SOURCE_DIR}/EXAMPLE"


### PR DESCRIPTION
From now on, "make doc" (or ninja doc or whatever) does always build the Doxygen documentation, given Doxygen is found. When passing "enable_doc=1" to cmake, "make doc" is added to the default target, i.e., when running "make" (or "make all" or "ninja") Doxygen documentation is automatically created.