### PR TITLE
Adjust forward delcaration of float/double Malloc/Calloc

### DIFF
--- a/SRC/slu_cdefs.h
+++ b/SRC/slu_cdefs.h
@@ -236,8 +236,8 @@ extern int_t   cLUMemXpand (int, int_t, MemType, int_t *, GlobalLU_t *);
 
 extern complex  *complexMalloc(size_t);
 extern complex  *complexCalloc(size_t);
-extern float  *floatMalloc(int);
-extern float  *floatCalloc(int);
+extern float  *floatMalloc(size_t);
+extern float  *floatCalloc(size_t);
 extern int_t   cmemory_usage(const int_t, const int_t, const int_t, const int);
 extern int     cQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern int     ilu_cQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);

--- a/SRC/slu_zdefs.h
+++ b/SRC/slu_zdefs.h
@@ -236,8 +236,8 @@ extern int_t   zLUMemXpand (int, int_t, MemType, int_t *, GlobalLU_t *);
 
 extern doublecomplex  *doublecomplexMalloc(size_t);
 extern doublecomplex  *doublecomplexCalloc(size_t);
-extern double  *doubleMalloc(int);
-extern double  *doubleCalloc(int);
+extern double  *doubleMalloc(size_t);
+extern double  *doubleCalloc(size_t);
 extern int_t   zmemory_usage(const int_t, const int_t, const int_t, const int);
 extern int     zQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern int     ilu_zQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);


### PR DESCRIPTION
The argument was changed in slu_sdefs.h / slu_ddefs.h and remained in slu_cdefs.h / slu_zdefs.h. This leads to incompatible declarations.

This problem occurs when slu_sdefs.h and slu_cdefs.h are included together, see for example https://github.com/FreeFem/FreeFem-sources/issues/272