### PR TITLE
[cmake] Fix Doxygen call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Required version
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 
 # Project Version
 project(SuperLU C)

--- a/DOC/CMakeLists.txt
+++ b/DOC/CMakeLists.txt
@@ -15,10 +15,10 @@ if(enable_doc)
 endif()
 
 doxygen_add_docs(doc
-                 "${_DEPENDENCY_ALL}"
                  "${CMAKE_CURRENT_SOURCE_DIR}/mainpage.txt"
                  "${CMAKE_CURRENT_SOURCE_DIR}/modules.txt"
                  "${PROJECT_SOURCE_DIR}/EXAMPLE"
                  "${PROJECT_SOURCE_DIR}/SRC"
                  "${PROJECT_SOURCE_DIR}/TESTING"
+                 "${_DEPENDENCY_ALL}"
                  COMMENT "Generate HTML documentation with Doxygen")

--- a/DOC/CMakeLists.txt
+++ b/DOC/CMakeLists.txt
@@ -14,11 +14,15 @@ if(enable_doc)
   set(_DEPENDENCY_ALL "ALL")
 endif()
 
-doxygen_add_docs(doc
-                 "${CMAKE_CURRENT_SOURCE_DIR}/mainpage.txt"
-                 "${CMAKE_CURRENT_SOURCE_DIR}/modules.txt"
-                 "${PROJECT_SOURCE_DIR}/EXAMPLE"
-                 "${PROJECT_SOURCE_DIR}/SRC"
-                 "${PROJECT_SOURCE_DIR}/TESTING"
-                 "${_DEPENDENCY_ALL}"
-                 COMMENT "Generate HTML documentation with Doxygen")
+if(DOXYGEN_FOUND)
+  doxygen_add_docs(doc
+                  "${CMAKE_CURRENT_SOURCE_DIR}/mainpage.txt"
+                  "${CMAKE_CURRENT_SOURCE_DIR}/modules.txt"
+                  "${PROJECT_SOURCE_DIR}/EXAMPLE"
+                  "${PROJECT_SOURCE_DIR}/SRC"
+                  "${PROJECT_SOURCE_DIR}/TESTING"
+                  "${_DEPENDENCY_ALL}"
+                  COMMENT "Generate HTML documentation with Doxygen")
+elseif(enable_doc)
+  message(WARNING "Disabling building documentation as Doxygen is missing.")
+endif()


### PR DESCRIPTION
doxygen_add_docs must not be called when Doxygen was not found.
ALL in doxygen_add_docs requries CMake 3.12 or newer.
ALL in doxygen_add_docs comes after files or dirs

Fixes #101 