### PR TITLE
Fix uninitialized pointer warning in examples and tests

### DIFF
--- a/EXAMPLE/clinsolx.c
+++ b/EXAMPLE/clinsolx.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, ldx;
     int_t          info, lwork, nnz;
     int            m, n;

--- a/EXAMPLE/clinsolx1.c
+++ b/EXAMPLE/clinsolx1.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     complex         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/clinsolx2.c
+++ b/EXAMPLE/clinsolx2.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     complex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/clinsolx3.c
+++ b/EXAMPLE/clinsolx3.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     complex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx.c
+++ b/EXAMPLE/dlinsolx.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, ldx;
     int_t          info, lwork, nnz;
     int            m, n;

--- a/EXAMPLE/dlinsolx1.c
+++ b/EXAMPLE/dlinsolx1.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     double         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx2.c
+++ b/EXAMPLE/dlinsolx2.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     double         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/dlinsolx3.c
+++ b/EXAMPLE/dlinsolx3.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     double         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/slinsolx.c
+++ b/EXAMPLE/slinsolx.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, ldx;
     int_t          info, lwork, nnz;
     int            m, n;

--- a/EXAMPLE/slinsolx1.c
+++ b/EXAMPLE/slinsolx1.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     float         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/slinsolx2.c
+++ b/EXAMPLE/slinsolx2.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     float         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/slinsolx3.c
+++ b/EXAMPLE/slinsolx3.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     float         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx.c
+++ b/EXAMPLE/zlinsolx.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, ldx;
     int_t          info, lwork, nnz;
     int            m, n;

--- a/EXAMPLE/zlinsolx1.c
+++ b/EXAMPLE/zlinsolx1.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     doublecomplex         *rhsb, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx2.c
+++ b/EXAMPLE/zlinsolx2.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     doublecomplex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/EXAMPLE/zlinsolx3.c
+++ b/EXAMPLE/zlinsolx3.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
     int            *etree;
-    void           *work;
+    void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
     doublecomplex         *rhsb, *rhsb1, *rhsx, *xact;

--- a/TESTING/cdrive.c
+++ b/TESTING/cdrive.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     float         *ferr, *berr;
     float         *rwork;
     complex	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, panel_size, relax;
     int            m, n, info1;
     int_t          nnz, lwork, info;

--- a/TESTING/ddrive.c
+++ b/TESTING/ddrive.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     double         *ferr, *berr;
     double         *rwork;
     double	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, panel_size, relax;
     int            m, n, info1;
     int_t          nnz, lwork, info;

--- a/TESTING/sdrive.c
+++ b/TESTING/sdrive.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     float         *ferr, *berr;
     float         *rwork;
     float	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, panel_size, relax;
     int            m, n, info1;
     int_t          nnz, lwork, info;

--- a/TESTING/zdrive.c
+++ b/TESTING/zdrive.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     double         *ferr, *berr;
     double         *rwork;
     doublecomplex	   *wwork;
-    void           *work;
+    void           *work = NULL;
     int            nrhs, panel_size, relax;
     int            m, n, info1;
     int_t          nnz, lwork, info;


### PR DESCRIPTION
This fixes a MSVC warning about uninitialized pointers of the `work` arrays in examples and tests.

As per request in https://github.com/xiaoyeli/superlu/pull/107#issuecomment-1666471748

