### PR TITLE
Fix CMake test setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -14,23 +14,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get install csh clang
+        run: sudo apt-get install cmake
+
+      - name: Configure
+        run: cmake -B build
 
       - name: Build
-        run: |
-          cp MAKE_INC/make.linux make.inc
-          # We use ~ instead of / as a separator in sed, since $(pwd)
-          # also includes /
-          sed -i  "s~^SuperLUroot\s*=.*~SuperLUroot = $(pwd)~g" make.inc
-          sed -i  "s/^CC\s*=.*/CC = ${CC_CI}/g" make.inc
-          mkdir lib
-          make install lib
-        env:
-          CC_CI: ${{ matrix.compiler }}
-                
+        run: cmake --build build --parallel
+
       - name: Test
-        run: |
-          make testing
+        run: ctest --test-dir build --output-on-failure

--- a/TESTING/CMakeLists.txt
+++ b/TESTING/CMakeLists.txt
@@ -5,82 +5,47 @@ set(test_link_libs matgen)
 
 add_subdirectory(MATGEN)
 
-set(ALINTST sp_ienv.c)
 set(NVAL   9 19)
 set(NRHS   2)
 set(LWORK  0 10000000)
 
-function(cat IN_FILE OUT_FILE)
-  file(READ ${IN_FILE} CONTENTS)
-  file(APPEND ${OUT_FILE} "${CONTENTS}")
-endfunction()
-
-
-function(add_superlu_test output input target)
+function(add_superlu_test target input)
   set(TEST_INPUT "${SuperLU_SOURCE_DIR}/EXAMPLE/${input}")
-  set(TEST_OUTPUT "${SuperLU_BINARY_DIR}/TESTING/${output}")
-
-  # Prepare a temporary file to "cat" to:
-  # "== LAPACK test matrices"
-  file(WRITE ${TEST_OUTPUT} "")
-
-##  get_target_property(TEST_LOC ${target} LOCATION)
-  set(TEST_LOC ${CMAKE_CURRENT_BINARY_DIR})
-
-  foreach (n ${NVAL})
-    foreach (s ${NRHS})
-      foreach(l ${LWORK})
-          set(testName "${target}_${n}_${s}_${l}")
-	  set(SINGLE_OUTPUT ${SuperLU_BINARY_DIR}/TESTING/${testName}.out)
-          add_test( ${testName}_LA  "${CMAKE_COMMAND}"
-	    -DTEST=${TEST_LOC} -t "LA" -n ${n} -s ${s} -l ${l}
-	    -DOUTPUT=${SINGLE_OUTPUT}
-	    -DALL_OUTPUT=${TEST_OUTPUT}
-	    -DHEADING=Dense\ matrix\ --\ n=${n},\ s=${s},\ lwork=${l}
-	    -P "${SuperLU_SOURCE_DIR}/TESTING/runtest.cmake"
-	  )
-      endforeach()
-    endforeach()
-  endforeach()
-
-#  file(APPEND ${TEST_OUTPUT} "== sparse matrix\n")
 
   foreach (s ${NRHS})
-      foreach(l ${LWORK})
-          set(testName "${target}_${s}_${l}")
-	  set(SINGLE_OUTPUT ${SuperLU_BINARY_DIR}/TESTING/${testName}.out)
-          add_test( ${testName}_SP  "${CMAKE_COMMAND}"
-	    -DTEST=${TEST_LOC} -t "SP" -s ${s} -l ${l} -f ${TEST_INPUT}
-	    -DOUTPUT=${SINGLE_OUTPUT}
-	    -DALL_OUTPUT=${TEST_OUTPUT}
-	    -DHEADING=Sparse\ matrix\ ${TEST_INPUT}\ --\ s=${s},\ lwork=${l}
-	    -P "${SuperLU_SOURCE_DIR}/TESTING/runtest.cmake")
+    foreach(l ${LWORK})
+      # LA tests
+      foreach (n ${NVAL})
+        set(testName "${target}_${n}_${s}_${l}")
+        add_test(
+          NAME ${testName}_LA
+          COMMAND ${target} -t "LA" -n ${n} -s ${s} -l ${l})
       endforeach()
+
+      # SP tests
+      set(testName "${target}_${s}_${l}")
+      add_test(
+        NAME ${testName}_SP
+        COMMAND ${target} -t "SP" -s ${s} -l ${l} -f "${TEST_INPUT}")
+    endforeach()
   endforeach()
 
 endfunction(add_superlu_test)
 
 
 if(enable_single)
-  set(SLINTST sdrive.c sp_sconvert.c sgst01.c sgst02.c sgst04.c sgst07.c)
+  set(SLINTST sdrive.c sp_ienv.c sp_sconvert.c sgst01.c sgst02.c sgst04.c sgst07.c)
 
-  add_executable(s_test ${ALINTST} ${SLINTST})
+  add_executable(s_test ${SLINTST})
   target_link_libraries(s_test ${test_link_libs})
-  
-  if(MSVC)
-    target_include_directories(s_test PRIVATE ${WinGetOpt_INCLUDE_DIR})
-    target_link_libraries(s_test ${WinGetOpt_LIBRARY})
-  endif()
-  
-  add_superlu_test(s_test.out g20.rua s_test)
 
+  add_superlu_test(s_test g20.rua)
 endif()
 
-
 if(enable_double)
-  set(DLINTST ddrive.c sp_dconvert.c dgst01.c dgst02.c dgst04.c dgst07.c)
+  set(DLINTST ddrive.c sp_ienv.c sp_dconvert.c dgst01.c dgst02.c dgst04.c dgst07.c)
 
-  add_executable(d_test ${ALINTST} ${DLINTST})
+  add_executable(d_test ${DLINTST})
   target_link_libraries(d_test ${test_link_libs})
   
   if(MSVC)
@@ -88,13 +53,13 @@ if(enable_double)
     target_link_libraries(d_test ${WinGetOpt_LIBRARY})
   endif()
 
-  add_superlu_test(d_test.out g20.rua d_test)
+  add_superlu_test(d_test g20.rua)
 endif()
 
 if(enable_complex)
-  set(CLINTST cdrive.c sp_cconvert.c cgst01.c cgst02.c cgst04.c cgst07.c)
+  set(CLINTST cdrive.c sp_ienv.c sp_cconvert.c cgst01.c cgst02.c cgst04.c cgst07.c)
 
-  add_executable(c_test ${ALINTST} ${CLINTST})
+  add_executable(c_test ${CLINTST})
   target_link_libraries(c_test ${test_link_libs})
   
   if(MSVC)
@@ -102,14 +67,14 @@ if(enable_complex)
     target_link_libraries(c_test ${WinGetOpt_LIBRARY})
   endif()
 
-  add_superlu_test(c_test.out cg20.cua c_test)
+  add_superlu_test(c_test cg20.cua)
 endif()
 
 
 if(enable_complex16)
-  set(ZLINTST zdrive.c sp_zconvert.c zgst01.c zgst02.c zgst04.c zgst07.c)
+  set(ZLINTST zdrive.c sp_ienv.c sp_zconvert.c zgst01.c zgst02.c zgst04.c zgst07.c)
 
-  add_executable(z_test ${ALINTST} ${ZLINTST})
+  add_executable(z_test ${ZLINTST})
   target_link_libraries(z_test ${test_link_libs})
   
   if(MSVC)
@@ -117,5 +82,5 @@ if(enable_complex16)
     target_link_libraries(z_test ${WinGetOpt_LIBRARY})
   endif()
 
-  add_superlu_test(z_test.out cg20.cua z_test)
+  add_superlu_test(z_test cg20.cua)
 endif()

--- a/TESTING/CMakeLists.txt
+++ b/TESTING/CMakeLists.txt
@@ -30,6 +30,12 @@ function(add_superlu_test target input)
     endforeach()
   endforeach()
 
+  # Add getopt dependency to target in case of MSVC
+  if(MSVC)
+    target_include_directories(${target} PRIVATE ${WinGetOpt_INCLUDE_DIR})
+    target_link_libraries(${target} ${WinGetOpt_LIBRARY})
+  endif()
+
 endfunction(add_superlu_test)
 
 
@@ -47,11 +53,6 @@ if(enable_double)
 
   add_executable(d_test ${DLINTST})
   target_link_libraries(d_test ${test_link_libs})
-  
-  if(MSVC)
-    target_include_directories(d_test PRIVATE ${WinGetOpt_INCLUDE_DIR})
-    target_link_libraries(d_test ${WinGetOpt_LIBRARY})
-  endif()
 
   add_superlu_test(d_test g20.rua)
 endif()
@@ -61,11 +62,6 @@ if(enable_complex)
 
   add_executable(c_test ${CLINTST})
   target_link_libraries(c_test ${test_link_libs})
-  
-  if(MSVC)
-    target_include_directories(c_test PRIVATE ${WinGetOpt_INCLUDE_DIR})
-    target_link_libraries(c_test ${WinGetOpt_LIBRARY})
-  endif()
 
   add_superlu_test(c_test cg20.cua)
 endif()
@@ -76,11 +72,6 @@ if(enable_complex16)
 
   add_executable(z_test ${ZLINTST})
   target_link_libraries(z_test ${test_link_libs})
-  
-  if(MSVC)
-    target_include_directories(z_test PRIVATE ${WinGetOpt_INCLUDE_DIR})
-    target_link_libraries(z_test ${WinGetOpt_LIBRARY})
-  endif()
 
   add_superlu_test(z_test cg20.cua)
 endif()

--- a/TESTING/cdrive.c
+++ b/TESTING/cdrive.c
@@ -513,7 +513,7 @@ int main(int argc, char *argv[])
 	Destroy_SuperMatrix_Store(&U);
     }
 
-    return 0;
+    return nfail == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 /*!

--- a/TESTING/ddrive.c
+++ b/TESTING/ddrive.c
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
 	Destroy_SuperMatrix_Store(&U);
     }
 
-    return 0;
+    return nfail == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 /*!

--- a/TESTING/runtest.cmake
+++ b/TESTING/runtest.cmake
@@ -1,9 +1,0 @@
-# execute the test command that was added earlier.
-execute_process( COMMAND "${TEST}" 
-                 OUTPUT_FILE "${OUTPUT}"
-		 RESULT_VARIABLE RET )
-file(APPEND ${ALL_OUTPUT} ${HEADING})
-file(APPEND ${ALL_OUTPUT} "\n")
-file(READ "${OUTPUT}" SINGLE_OUTPUT)
-file(APPEND ${ALL_OUTPUT} "${SINGLE_OUTPUT}\n")
-file(REMOVE ${OUTPUT})   # remove the individual output file.

--- a/TESTING/sdrive.c
+++ b/TESTING/sdrive.c
@@ -513,7 +513,7 @@ int main(int argc, char *argv[])
 	Destroy_SuperMatrix_Store(&U);
     }
 
-    return 0;
+    return nfail == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 /*!

--- a/TESTING/zdrive.c
+++ b/TESTING/zdrive.c
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
 	Destroy_SuperMatrix_Store(&U);
     }
 
-    return 0;
+    return nfail == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 /*!


### PR DESCRIPTION
WARNING: this pull request will make the tests fail due to currently unresolved issue #108 

That being said, I think it's important to have tests reflecting reality and I think that this should be merged rather sooner than later (even if the issue remains unresolved for now).

As explained in above mentioned issue, the current CMake test setup is rather complex. This is due mainly to the logging implemented. This pull request removes all those logging features, which greatly simplifies the setup. After all, I think logging should not be part of automated tests - at least not on the test subject side, the testing framework should handle that, and if anybody wants verbose output, ctest can be called like
```
ctest -VV -C Debug
```
Additionally, the test executables can still be run by hand to get the test output
```
./d_test -t "SP" -s 5 -l 20000000 -f "../../EXAMPLE/g20.rua"
```