### PR TITLE
Rename complex occurences to singlecomplex

### DIFF
--- a/CBLAS/caxpy.c
+++ b/CBLAS/caxpy.c
@@ -6,18 +6,18 @@
 
 #include "f2c.h"
 
-/* Subroutine */ int caxpy_(integer *n, complex *ca, complex *cx, integer *
-	incx, complex *cy, integer *incy)
+/* Subroutine */ int caxpy_(integer *n, singlecomplex *ca, singlecomplex *cx, integer *
+	incx, singlecomplex *cy, integer *incy)
 {
 
 
     /* System generated locals */
 
     real r__1, r__2;
-    complex q__1, q__2;
+    singlecomplex q__1, q__2;
 
     /* Builtin functions */
-    double r_imag(complex *);
+    double r_imag(singlecomplex *);
 
     /* Local variables */
     integer i, ix, iy;

--- a/CBLAS/ccopy.c
+++ b/CBLAS/ccopy.c
@@ -6,7 +6,7 @@
 
 #include "f2c.h"
 
-/* Subroutine */ int ccopy_(integer *n, complex *cx, integer *incx, complex *
+/* Subroutine */ int ccopy_(integer *n, singlecomplex *cx, integer *incx, singlecomplex *
 	cy, integer *incy)
 {
 

--- a/CBLAS/cdotc.c
+++ b/CBLAS/cdotc.c
@@ -5,19 +5,19 @@
 
 #include "f2c.h"
 
-/* Complex */ VOID cdotc_(complex * ret_val, integer *n, complex *cx, integer 
-	*incx, complex *cy, integer *incy)
+/* Complex */ VOID cdotc_(singlecomplex * ret_val, integer *n, singlecomplex *cx, integer 
+	*incx, singlecomplex *cy, integer *incy)
 {
     /* System generated locals */
  
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     integer i;
-    complex ctemp;
+    singlecomplex ctemp;
     integer ix, iy;
 
 

--- a/CBLAS/cgemv.c
+++ b/CBLAS/cgemv.c
@@ -6,22 +6,22 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int cgemv_(char *trans, integer *m, integer *n, complex *
-	alpha, complex *a, integer *lda, complex *x, integer *incx, complex *
-	beta, complex *y, integer *incy)
+/* Subroutine */ int cgemv_(char *trans, integer *m, integer *n, singlecomplex *
+	alpha, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *
+	beta, singlecomplex *y, integer *incy)
 {
 
 
     /* System generated locals */
 
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     integer info;
-    complex temp;
+    singlecomplex temp;
     integer lenx, leny, i, j;
     integer ix, iy, jx, jy, kx, ky;
     logical noconj;

--- a/CBLAS/cgerc.c
+++ b/CBLAS/cgerc.c
@@ -6,21 +6,21 @@
 
 #include "f2c.h"
 
-/* Subroutine */ int cgerc_(integer *m, integer *n, complex *alpha, complex *
-	x, integer *incx, complex *y, integer *incy, complex *a, integer *lda)
+/* Subroutine */ int cgerc_(integer *m, integer *n, singlecomplex *alpha, singlecomplex *
+	x, integer *incx, singlecomplex *y, integer *incy, singlecomplex *a, integer *lda)
 {
 
 
     /* System generated locals */
 
-    complex q__1, q__2;
+    singlecomplex q__1, q__2;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     integer info;
-    complex temp;
+    singlecomplex temp;
     integer i, j, ix, jy, kx;
 
     extern int input_error(char *, int *);

--- a/CBLAS/chemv.c
+++ b/CBLAS/chemv.c
@@ -6,8 +6,8 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int chemv_(char *uplo, integer *n, complex *alpha, complex *
-	a, integer *lda, complex *x, integer *incx, complex *beta, complex *y,
+/* Subroutine */ int chemv_(char *uplo, integer *n, singlecomplex *alpha, singlecomplex *
+	a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y,
 	 integer *incy)
 {
 
@@ -15,14 +15,14 @@
     /* System generated locals */
 
     doublereal d__1;
-    complex q__1, q__2, q__3, q__4;
+    singlecomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     integer info;
-    complex temp1, temp2;
+    singlecomplex temp1, temp2;
     integer i, j;
     integer ix, iy, jx, jy, kx, ky;
 

--- a/CBLAS/cher2.c
+++ b/CBLAS/cher2.c
@@ -6,22 +6,22 @@
 #include <string.h>
 #include "f2c.h"
 
-/* Subroutine */ int cher2_(char *uplo, integer *n, complex *alpha, complex *
-	x, integer *incx, complex *y, integer *incy, complex *a, integer *lda)
+/* Subroutine */ int cher2_(char *uplo, integer *n, singlecomplex *alpha, singlecomplex *
+	x, integer *incx, singlecomplex *y, integer *incy, singlecomplex *a, integer *lda)
 {
 
 
     /* System generated locals */
 
     doublereal d__1;
-    complex q__1, q__2, q__3, q__4;
+    singlecomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     integer info;
-    complex temp1, temp2;
+    singlecomplex temp1, temp2;
     integer i, j;
     integer ix, iy, jx, jy, kx, ky;
 

--- a/CBLAS/complex_to_singlecomplex.patch
+++ b/CBLAS/complex_to_singlecomplex.patch
@@ -1,0 +1,359 @@
+diff --git a/CBLAS/caxpy.c b/CBLAS/caxpy.c
+index 26c31e2..abe8d2a 100644
+--- a/CBLAS/caxpy.c
++++ b/CBLAS/caxpy.c
+@@ -6,18 +6,18 @@
+ 
+ #include "f2c.h"
+ 
+-/* Subroutine */ int caxpy_(integer *n, complex *ca, complex *cx, integer *
+-	incx, complex *cy, integer *incy)
++/* Subroutine */ int caxpy_(integer *n, singlecomplex *ca, singlecomplex *cx, integer *
++	incx, singlecomplex *cy, integer *incy)
+ {
+ 
+ 
+     /* System generated locals */
+ 
+     real r__1, r__2;
+-    complex q__1, q__2;
++    singlecomplex q__1, q__2;
+ 
+     /* Builtin functions */
+-    double r_imag(complex *);
++    double r_imag(singlecomplex *);
+ 
+     /* Local variables */
+     integer i, ix, iy;
+diff --git a/CBLAS/ccopy.c b/CBLAS/ccopy.c
+index 919360d..8e0fde1 100644
+--- a/CBLAS/ccopy.c
++++ b/CBLAS/ccopy.c
+@@ -6,7 +6,7 @@
+ 
+ #include "f2c.h"
+ 
+-/* Subroutine */ int ccopy_(integer *n, complex *cx, integer *incx, complex *
++/* Subroutine */ int ccopy_(integer *n, singlecomplex *cx, integer *incx, singlecomplex *
+ 	cy, integer *incy)
+ {
+ 
+diff --git a/CBLAS/cdotc.c b/CBLAS/cdotc.c
+index 08b900a..53ab7a7 100644
+--- a/CBLAS/cdotc.c
++++ b/CBLAS/cdotc.c
+@@ -5,19 +5,19 @@
+ 
+ #include "f2c.h"
+ 
+-/* Complex */ VOID cdotc_(complex * ret_val, integer *n, complex *cx, integer 
+-	*incx, complex *cy, integer *incy)
++/* Complex */ VOID cdotc_(singlecomplex * ret_val, integer *n, singlecomplex *cx, integer 
++	*incx, singlecomplex *cy, integer *incy)
+ {
+     /* System generated locals */
+  
+-    complex q__1, q__2, q__3;
++    singlecomplex q__1, q__2, q__3;
+ 
+     /* Builtin functions */
+-    void r_cnjg(complex *, complex *);
++    void r_cnjg(singlecomplex *, singlecomplex *);
+ 
+     /* Local variables */
+     integer i;
+-    complex ctemp;
++    singlecomplex ctemp;
+     integer ix, iy;
+ 
+ 
+diff --git a/CBLAS/cgemv.c b/CBLAS/cgemv.c
+index d98a8cd..1fe25a0 100644
+--- a/CBLAS/cgemv.c
++++ b/CBLAS/cgemv.c
+@@ -6,22 +6,22 @@
+ #include <string.h>
+ #include "f2c.h"
+ 
+-/* Subroutine */ int cgemv_(char *trans, integer *m, integer *n, complex *
+-	alpha, complex *a, integer *lda, complex *x, integer *incx, complex *
+-	beta, complex *y, integer *incy)
++/* Subroutine */ int cgemv_(char *trans, integer *m, integer *n, singlecomplex *
++	alpha, singlecomplex *a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *
++	beta, singlecomplex *y, integer *incy)
+ {
+ 
+ 
+     /* System generated locals */
+ 
+-    complex q__1, q__2, q__3;
++    singlecomplex q__1, q__2, q__3;
+ 
+     /* Builtin functions */
+-    void r_cnjg(complex *, complex *);
++    void r_cnjg(singlecomplex *, singlecomplex *);
+ 
+     /* Local variables */
+     integer info;
+-    complex temp;
++    singlecomplex temp;
+     integer lenx, leny, i, j;
+     integer ix, iy, jx, jy, kx, ky;
+     logical noconj;
+diff --git a/CBLAS/cgerc.c b/CBLAS/cgerc.c
+index abb5a82..14fa883 100644
+--- a/CBLAS/cgerc.c
++++ b/CBLAS/cgerc.c
+@@ -6,21 +6,21 @@
+ 
+ #include "f2c.h"
+ 
+-/* Subroutine */ int cgerc_(integer *m, integer *n, complex *alpha, complex *
+-	x, integer *incx, complex *y, integer *incy, complex *a, integer *lda)
++/* Subroutine */ int cgerc_(integer *m, integer *n, singlecomplex *alpha, singlecomplex *
++	x, integer *incx, singlecomplex *y, integer *incy, singlecomplex *a, integer *lda)
+ {
+ 
+ 
+     /* System generated locals */
+ 
+-    complex q__1, q__2;
++    singlecomplex q__1, q__2;
+ 
+     /* Builtin functions */
+-    void r_cnjg(complex *, complex *);
++    void r_cnjg(singlecomplex *, singlecomplex *);
+ 
+     /* Local variables */
+     integer info;
+-    complex temp;
++    singlecomplex temp;
+     integer i, j, ix, jy, kx;
+ 
+     extern int input_error(char *, int *);
+diff --git a/CBLAS/chemv.c b/CBLAS/chemv.c
+index a8ac576..2c2a4f2 100644
+--- a/CBLAS/chemv.c
++++ b/CBLAS/chemv.c
+@@ -6,8 +6,8 @@
+ #include <string.h>
+ #include "f2c.h"
+ 
+-/* Subroutine */ int chemv_(char *uplo, integer *n, complex *alpha, complex *
+-	a, integer *lda, complex *x, integer *incx, complex *beta, complex *y,
++/* Subroutine */ int chemv_(char *uplo, integer *n, singlecomplex *alpha, singlecomplex *
++	a, integer *lda, singlecomplex *x, integer *incx, singlecomplex *beta, singlecomplex *y,
+ 	 integer *incy)
+ {
+ 
+@@ -15,14 +15,14 @@
+     /* System generated locals */
+ 
+     doublereal d__1;
+-    complex q__1, q__2, q__3, q__4;
++    singlecomplex q__1, q__2, q__3, q__4;
+ 
+     /* Builtin functions */
+-    void r_cnjg(complex *, complex *);
++    void r_cnjg(singlecomplex *, singlecomplex *);
+ 
+     /* Local variables */
+     integer info;
+-    complex temp1, temp2;
++    singlecomplex temp1, temp2;
+     integer i, j;
+     integer ix, iy, jx, jy, kx, ky;
+ 
+diff --git a/CBLAS/cher2.c b/CBLAS/cher2.c
+index 101b28f..074ae77 100644
+--- a/CBLAS/cher2.c
++++ b/CBLAS/cher2.c
+@@ -6,22 +6,22 @@
+ #include <string.h>
+ #include "f2c.h"
+ 
+-/* Subroutine */ int cher2_(char *uplo, integer *n, complex *alpha, complex *
+-	x, integer *incx, complex *y, integer *incy, complex *a, integer *lda)
++/* Subroutine */ int cher2_(char *uplo, integer *n, singlecomplex *alpha, singlecomplex *
++	x, integer *incx, singlecomplex *y, integer *incy, singlecomplex *a, integer *lda)
+ {
+ 
+ 
+     /* System generated locals */
+ 
+     doublereal d__1;
+-    complex q__1, q__2, q__3, q__4;
++    singlecomplex q__1, q__2, q__3, q__4;
+ 
+     /* Builtin functions */
+-    void r_cnjg(complex *, complex *);
++    void r_cnjg(singlecomplex *, singlecomplex *);
+ 
+     /* Local variables */
+     integer info;
+-    complex temp1, temp2;
++    singlecomplex temp1, temp2;
+     integer i, j;
+     integer ix, iy, jx, jy, kx, ky;
+ 
+diff --git a/CBLAS/cscal.c b/CBLAS/cscal.c
+index bd0cdf2..3738df4 100644
+--- a/CBLAS/cscal.c
++++ b/CBLAS/cscal.c
+@@ -6,14 +6,14 @@
+ 
+ #include "f2c.h"
+ 
+-/* Subroutine */ int cscal_(integer *n, complex *ca, complex *cx, integer *
++/* Subroutine */ int cscal_(integer *n, singlecomplex *ca, singlecomplex *cx, integer *
+ 	incx)
+ {
+ 
+ 
+     /* System generated locals */
+ 
+-    complex q__1;
++    singlecomplex q__1;
+ 
+     /* Local variables */
+     integer i, nincx;
+diff --git a/CBLAS/cswap.c b/CBLAS/cswap.c
+index 9c3dea2..5ab2e0d 100644
+--- a/CBLAS/cswap.c
++++ b/CBLAS/cswap.c
+@@ -1,7 +1,7 @@
+ #include "f2c.h"
+ /*#include "blaswrap.h"*/
+ 
+-/* Subroutine */ int cswap_(integer *n, complex *cx, integer *incx, complex *
++/* Subroutine */ int cswap_(integer *n, singlecomplex *cx, integer *incx, singlecomplex *
+ 	cy, integer *incy)
+ {
+     /* System generated locals */
+@@ -9,7 +9,7 @@
+ 
+     /* Local variables */
+     integer i__, ix, iy;
+-    complex ctemp;
++    singlecomplex ctemp;
+ 
+ /*     .. Scalar Arguments .. */
+ /*     .. */
+diff --git a/CBLAS/ctrsv.c b/CBLAS/ctrsv.c
+index e791a0c..01335b5 100644
+--- a/CBLAS/ctrsv.c
++++ b/CBLAS/ctrsv.c
+@@ -7,20 +7,20 @@
+ #include "f2c.h"
+ 
+ /* Subroutine */ int ctrsv_(char *uplo, char *trans, char *diag, integer *n, 
+-	complex *a, integer *lda, complex *x, integer *incx)
++	singlecomplex *a, integer *lda, singlecomplex *x, integer *incx)
+ {
+ 
+ 
+     /* System generated locals */
+ 
+-    complex q__1, q__2, q__3;
++    singlecomplex q__1, q__2, q__3;
+ 
+     /* Builtin functions */
+-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
++    void c_div(singlecomplex *, singlecomplex *, singlecomplex *), r_cnjg(singlecomplex *, singlecomplex *);
+ 
+     /* Local variables */
+     integer info;
+-    complex temp;
++    singlecomplex temp;
+     integer i, j;
+     integer ix, jx, kx;
+     logical noconj, nounit;
+diff --git a/CBLAS/f2c.h b/CBLAS/f2c.h
+index 3116864..5a91474 100644
+--- a/CBLAS/f2c.h
++++ b/CBLAS/f2c.h
+@@ -21,7 +21,7 @@ typedef char *address;
+ typedef short int shortint;
+ typedef float real;
+ typedef double doublereal;
+-typedef struct { real r, i; } complex;
++typedef struct { real r, i; } singlecomplex;
+ typedef struct { doublereal r, i; } doublecomplex;
+ typedef short int shortlogical;
+ typedef char logical1;
+diff --git a/CBLAS/icamax.c b/CBLAS/icamax.c
+index 1e83173..a2df71f 100644
+--- a/CBLAS/icamax.c
++++ b/CBLAS/icamax.c
+@@ -1,12 +1,12 @@
+ #include "f2c.h"
+ 
+-integer icamax_(integer *n, complex *cx, integer *incx)
++integer icamax_(integer *n, singlecomplex *cx, integer *incx)
+ {
+     /* System generated locals */
+ integer ret_val, i__1, i__2;
+     real r__1, r__2;
+     /* Builtin functions */
+-    double r_imag(complex *);
++    double r_imag(singlecomplex *);
+     /* Local variables */
+     real smax;
+     integer i, ix;
+diff --git a/CBLAS/scasum.c b/CBLAS/scasum.c
+index 7f11321..e9298fa 100644
+--- a/CBLAS/scasum.c
++++ b/CBLAS/scasum.c
+@@ -6,7 +6,7 @@
+ 
+ #include "f2c.h"
+ 
+-real scasum_(integer *n, complex *cx, integer *incx)
++real scasum_(integer *n, singlecomplex *cx, integer *incx)
+ {
+ 
+ 
+@@ -15,7 +15,7 @@ real scasum_(integer *n, complex *cx, integer *incx)
+     real ret_val, r__1, r__2;
+ 
+     /* Builtin functions */
+-    double r_imag(complex *);
++    double r_imag(singlecomplex *);
+ 
+     /* Local variables */
+     integer i, nincx;
+diff --git a/CBLAS/scnrm2.c b/CBLAS/scnrm2.c
+index 287fd26..b22ac86 100644
+--- a/CBLAS/scnrm2.c
++++ b/CBLAS/scnrm2.c
+@@ -6,7 +6,7 @@
+ 
+ #include "f2c.h"
+ 
+-real scnrm2_(integer *n, complex *x, integer *incx)
++real scnrm2_(integer *n, singlecomplex *x, integer *incx)
+ {
+ 
+ 
+@@ -15,7 +15,7 @@ real scnrm2_(integer *n, complex *x, integer *incx)
+     real ret_val, r__1;
+ 
+     /* Builtin functions */
+-    double r_imag(complex *), sqrt(doublereal);
++    double r_imag(singlecomplex *), sqrt(doublereal);
+ 
+     /* Local variables */
+     real temp, norm, scale;
+diff --git a/CBLAS/superlu_f2c.h b/CBLAS/superlu_f2c.h
+index caa33e1..ad43283 100644
+--- a/CBLAS/superlu_f2c.h
++++ b/CBLAS/superlu_f2c.h
+@@ -21,7 +21,7 @@ typedef char *address;
+ typedef short int shortint;
+ typedef float real;
+ typedef double doublereal;
+-typedef struct { real r, i; } complex;
++typedef struct { real r, i; } singlecomplex;
+ typedef struct { doublereal r, i; } doublecomplex;
+ typedef short int shortlogical;
+ typedef char logical1;

--- a/CBLAS/cscal.c
+++ b/CBLAS/cscal.c
@@ -6,14 +6,14 @@
 
 #include "f2c.h"
 
-/* Subroutine */ int cscal_(integer *n, complex *ca, complex *cx, integer *
+/* Subroutine */ int cscal_(integer *n, singlecomplex *ca, singlecomplex *cx, integer *
 	incx)
 {
 
 
     /* System generated locals */
 
-    complex q__1;
+    singlecomplex q__1;
 
     /* Local variables */
     integer i, nincx;

--- a/CBLAS/cswap.c
+++ b/CBLAS/cswap.c
@@ -1,7 +1,7 @@
 #include "f2c.h"
 /*#include "blaswrap.h"*/
 
-/* Subroutine */ int cswap_(integer *n, complex *cx, integer *incx, complex *
+/* Subroutine */ int cswap_(integer *n, singlecomplex *cx, integer *incx, singlecomplex *
 	cy, integer *incy)
 {
     /* System generated locals */
@@ -9,7 +9,7 @@
 
     /* Local variables */
     integer i__, ix, iy;
-    complex ctemp;
+    singlecomplex ctemp;
 
 /*     .. Scalar Arguments .. */
 /*     .. */

--- a/CBLAS/ctrsv.c
+++ b/CBLAS/ctrsv.c
@@ -7,20 +7,20 @@
 #include "f2c.h"
 
 /* Subroutine */ int ctrsv_(char *uplo, char *trans, char *diag, integer *n, 
-	complex *a, integer *lda, complex *x, integer *incx)
+	singlecomplex *a, integer *lda, singlecomplex *x, integer *incx)
 {
 
 
     /* System generated locals */
 
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *), r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     integer info;
-    complex temp;
+    singlecomplex temp;
     integer i, j;
     integer ix, jx, kx;
     logical noconj, nounit;

--- a/CBLAS/f2c.h
+++ b/CBLAS/f2c.h
@@ -21,7 +21,7 @@ typedef char *address;
 typedef short int shortint;
 typedef float real;
 typedef double doublereal;
-typedef struct { real r, i; } complex;
+typedef struct { real r, i; } singlecomplex;
 typedef struct { doublereal r, i; } doublecomplex;
 typedef short int shortlogical;
 typedef char logical1;

--- a/CBLAS/icamax.c
+++ b/CBLAS/icamax.c
@@ -1,12 +1,12 @@
 #include "f2c.h"
 
-integer icamax_(integer *n, complex *cx, integer *incx)
+integer icamax_(integer *n, singlecomplex *cx, integer *incx)
 {
     /* System generated locals */
 integer ret_val, i__1, i__2;
     real r__1, r__2;
     /* Builtin functions */
-    double r_imag(complex *);
+    double r_imag(singlecomplex *);
     /* Local variables */
     real smax;
     integer i, ix;

--- a/CBLAS/scasum.c
+++ b/CBLAS/scasum.c
@@ -6,7 +6,7 @@
 
 #include "f2c.h"
 
-real scasum_(integer *n, complex *cx, integer *incx)
+real scasum_(integer *n, singlecomplex *cx, integer *incx)
 {
 
 
@@ -15,7 +15,7 @@ real scasum_(integer *n, complex *cx, integer *incx)
     real ret_val, r__1, r__2;
 
     /* Builtin functions */
-    double r_imag(complex *);
+    double r_imag(singlecomplex *);
 
     /* Local variables */
     integer i, nincx;

--- a/CBLAS/scnrm2.c
+++ b/CBLAS/scnrm2.c
@@ -6,7 +6,7 @@
 
 #include "f2c.h"
 
-real scnrm2_(integer *n, complex *x, integer *incx)
+real scnrm2_(integer *n, singlecomplex *x, integer *incx)
 {
 
 
@@ -15,7 +15,7 @@ real scnrm2_(integer *n, complex *x, integer *incx)
     real ret_val, r__1;
 
     /* Builtin functions */
-    double r_imag(complex *), sqrt(doublereal);
+    double r_imag(singlecomplex *), sqrt(doublereal);
 
     /* Local variables */
     real temp, norm, scale;

--- a/CBLAS/superlu_f2c.h
+++ b/CBLAS/superlu_f2c.h
@@ -21,7 +21,7 @@ typedef char *address;
 typedef short int shortint;
 typedef float real;
 typedef double doublereal;
-typedef struct { real r, i; } complex;
+typedef struct { real r, i; } singlecomplex;
 typedef struct { doublereal r, i; } doublecomplex;
 typedef short int shortlogical;
 typedef char logical1;

--- a/EXAMPLE/cfgmr.c
+++ b/EXAMPLE/cfgmr.c
@@ -34,8 +34,8 @@ For information on ITSOL contact saad@cs.umn.edu
 
 #define  epsmac  1.0e-16
 
-extern void cdotc_(complex *, int *, complex [], int *, complex [], int *);
-extern float scnrm2_(int *, complex [], int *);
+extern void cdotc_(singlecomplex *, int *, singlecomplex [], int *, singlecomplex [], int *);
+extern float scnrm2_(int *, singlecomplex [], int *);
 
 
 /*!
@@ -63,29 +63,29 @@ extern float scnrm2_(int *, complex [], int *);
  * \return Whether the algorithm finished successfully.
  */
 int cfgmr(int n,
-     void (*cmatvec) (complex, complex[], complex, complex[]),
-     void (*cpsolve) (int, complex[], complex[]),
-     complex *rhs, complex *sol, double tol, int im, int *itmax, FILE * fits)
+     void (*cmatvec) (singlecomplex, singlecomplex[], singlecomplex, singlecomplex[]),
+     void (*cpsolve) (int, singlecomplex[], singlecomplex[]),
+     singlecomplex *rhs, singlecomplex *sol, double tol, int im, int *itmax, FILE * fits)
 {
     int maxits = *itmax;
     int its, i_1 = 1, i_2 = 2;
     float eps1 = 0.0;
-    complex **hh, *c, *s, *rs;
-    complex **vv, **z;
-    complex zero = {0.0, 0.0};
-    complex one = {1.0, 0.0};
-    complex tt1, tt2;
+    singlecomplex **hh, *c, *s, *rs;
+    singlecomplex **vv, **z;
+    singlecomplex zero = {0.0, 0.0};
+    singlecomplex one = {1.0, 0.0};
+    singlecomplex tt1, tt2;
 
     /* prototypes */
-    extern int ccopy_(int *, complex *, int *, complex *, int *);
-    extern int caxpy_(int *, complex *, complex [], int *, complex [], int *);
+    extern int ccopy_(int *, singlecomplex *, int *, singlecomplex *, int *);
+    extern int caxpy_(int *, singlecomplex *, singlecomplex [], int *, singlecomplex [], int *);
 
     its = 0;
-    vv = (complex **)SUPERLU_MALLOC((im + 1) * sizeof(complex *));
+    vv = (singlecomplex **)SUPERLU_MALLOC((im + 1) * sizeof(singlecomplex *));
     for (int i = 0; i <= im; i++)
         vv[i] = complexMalloc(n);
-    z = (complex **)SUPERLU_MALLOC(im * sizeof(complex *));
-    hh = (complex **)SUPERLU_MALLOC(im * sizeof(complex *));
+    z = (singlecomplex **)SUPERLU_MALLOC(im * sizeof(singlecomplex *));
+    hh = (singlecomplex **)SUPERLU_MALLOC(im * sizeof(singlecomplex *));
     for (int i = 0; i < im; i++)
     {
 	hh[i] = complexMalloc(i + 2);
@@ -146,11 +146,11 @@ int cfgmr(int n,
             float t0 = scnrm2_(&n, vv[i1], &i_1);
             for (int j = 0; j <= i; j++)
             {
-		complex negt;
+		singlecomplex negt;
 #if 0
 		cdotc_(&tt, &n, vv[j], &i_1, vv[i1], &i_1);
 #else
-                complex tt = zero;
+                singlecomplex tt = zero;
                 for (int k = 0; k < n; ++k) {
 		    cc_conj(&tt1, &vv[j][k]);
 		    cc_mult(&tt2, &tt1, &vv[i1][k]);
@@ -170,11 +170,11 @@ int cfgmr(int n,
 		t0 = t;
                 for (int j = 0; j <= i; j++)
                 {
-		    complex negt;
+		    singlecomplex negt;
 #if 0
 		    cdotc_(&tt, &n, vv[j], &i_1, vv[i1], &i_1);
 #else
-                    complex tt = zero;
+                    singlecomplex tt = zero;
                     for (int k = 0; k < n; ++k) {
 		        cc_conj(&tt1, &vv[j][k]);
 		        cc_mult(&tt2, &tt1, &vv[i1][k]);
@@ -210,7 +210,7 @@ int cfgmr(int n,
             for (int k = 1; k <= i; k++)
             {
                 int k1 = k - 1;
-                complex tt = hh[i][k1];
+                singlecomplex tt = hh[i][k1];
                 cc_mult(&tt1, &c[k1], &tt);
                 cc_mult(&tt2, &s[k1], &hh[i][k]);
                 c_add(&hh[i][k1], &tt1, &tt2);
@@ -266,7 +266,7 @@ int cfgmr(int n,
         for (int ii = 1; ii <= i; ii++)
         {
             int k = i - ii;
-            complex tt = rs[k];
+            singlecomplex tt = rs[k];
             for (int j = k + 1; j <= i; j++) {
                 cc_mult(&tt1, &hh[j][k], &rs[j]);
 		c_sub(&tt, &tt, &tt1);
@@ -277,7 +277,7 @@ int cfgmr(int n,
         /*---- linear combination of v[i]'s to get sol. ----*/
         for (int j = 0; j <= i; j++)
         {
-            complex tt = rs[j];
+            singlecomplex tt = rs[j];
             for (int k = 0; k < n; k++) {
                 cc_mult(&tt1, &tt, &z[j][k]);
 		c_add(&sol[k], &sol[k], &tt1);

--- a/EXAMPLE/citersol.c
+++ b/EXAMPLE/citersol.c
@@ -57,8 +57,8 @@ mem_usage_t   *GLOBAL_MEM_USAGE;
  * \param [in,out] y Right-hand side
  */
 void cpsolve(int n,
-                  complex x[], /* solution */
-                  complex y[]  /* right-hand side */
+                  singlecomplex x[], /* solution */
+                  singlecomplex y[]  /* right-hand side */
 )
 {
     SuperMatrix *A = GLOBAL_A, *L = GLOBAL_L, *U = GLOBAL_U;
@@ -101,7 +101,7 @@ void cpsolve(int n,
  * \param [in,out] y Vector to add to to matrix-vector multiplication and
  *                   storage for result.
  */
-void cmatvec_mult(complex alpha, complex x[], complex beta, complex y[])
+void cmatvec_mult(singlecomplex alpha, singlecomplex x[], singlecomplex beta, singlecomplex y[])
 {
     SuperMatrix *A = GLOBAL_A;
 
@@ -110,12 +110,12 @@ void cmatvec_mult(complex alpha, complex x[], complex beta, complex y[])
 
 int main(int argc, char *argv[])
 {
-    void cmatvec_mult(complex alpha, complex x[], complex beta, complex y[]);
-    void cpsolve(int n, complex x[], complex y[]);
+    void cmatvec_mult(singlecomplex alpha, singlecomplex x[], singlecomplex beta, singlecomplex y[]);
+    void cpsolve(int n, singlecomplex x[], singlecomplex y[]);
     extern int cfgmr( int n,
-	void (*matvec_mult)(complex, complex [], complex, complex []),
-	void (*psolve)(int n, complex [], complex[]),
-	complex *rhs, complex *sol, double tol, int restrt, int *itmax,
+	void (*matvec_mult)(singlecomplex, singlecomplex [], singlecomplex, singlecomplex []),
+	void (*psolve)(int n, singlecomplex [], singlecomplex[]),
+	singlecomplex *rhs, singlecomplex *sol, double tol, int restrt, int *itmax,
 	FILE *fits);
     extern int cfill_diag(int n, NCformat *Astore);
 
@@ -128,26 +128,26 @@ int main(int argc, char *argv[])
     SCformat *Lstore;
     GlobalLU_t	   Glu; /* facilitate multiple factorizations with 
                            SamePattern_SameRowPerm                  */
-    complex   *a;
+    singlecomplex   *a;
     int_t    *asub, *xa;
     int      *etree;
     int      *perm_c; /* column permutation vector */
     int      *perm_r; /* row permutations from partial pivoting */
     int      nrhs, ldx, m, n;
     int_t    info, nnz, lwork;
-    complex   *rhsb, *rhsx, *xact;
-    complex   *work = NULL;
+    singlecomplex   *rhsb, *rhsx, *xact;
+    singlecomplex   *work = NULL;
     float   *R, *C;
     float   rpg, rcond;
-    complex zero = {0.0, 0.0};
-    complex one = {1.0, 0.0};
-    complex none = {-1.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
+    singlecomplex one = {1.0, 0.0};
+    singlecomplex none = {-1.0, 0.0};
     mem_usage_t   mem_usage;
     superlu_options_t options;
     SuperLUStat_t stat;
     FILE 	  *fp = stdin;
 
-    complex *x, *b;
+    singlecomplex *x, *b;
 
 #ifdef DEBUG
     extern int num_drop_L, num_drop_U;
@@ -331,9 +331,9 @@ int main(int argc, char *argv[])
     {
 	int i_1 = 1, nnz32;
 	double maxferr = 0.0, nrmA, nrmB, res, t;
-        complex temp;
-	extern float scnrm2_(int *, complex [], int *);
-	extern void caxpy_(int *, complex *, complex [], int *, complex [], int *);
+        singlecomplex temp;
+	extern float scnrm2_(int *, singlecomplex [], int *);
+	extern void caxpy_(int *, singlecomplex *, singlecomplex [], int *, singlecomplex [], int *);
 
         /* Initial guess */
         for (int i = 0; i < n; i++)
@@ -348,7 +348,7 @@ int main(int argc, char *argv[])
 
 	/* Output the result. */
 	nnz32 = Astore->nnz;
-	nrmA = scnrm2_(&nnz32, (complex *)((DNformat *)A.Store)->nzval,
+	nrmA = scnrm2_(&nnz32, (singlecomplex *)((DNformat *)A.Store)->nzval,
 		&i_1);
 	nrmB = scnrm2_(&m, b, &i_1);
 	sp_cgemv("N", none, &A, x, 1, one, b, 1);

--- a/EXAMPLE/citersol1.c
+++ b/EXAMPLE/citersol1.c
@@ -56,7 +56,7 @@ mem_usage_t   *GLOBAL_MEM_USAGE;
  * \param [out] x    Solution
  * \param [in,out] y Right-hand side
  */
-void cpsolve(int n, complex x[], complex y[])
+void cpsolve(int n, singlecomplex x[], singlecomplex y[])
 {
     SuperMatrix *A = GLOBAL_A, *L = GLOBAL_L, *U = GLOBAL_U;
     SuperLUStat_t *stat = GLOBAL_STAT;
@@ -98,7 +98,7 @@ void cpsolve(int n, complex x[], complex y[])
  * \param [in,out] y Vector to add to to matrix-vector multiplication and
  *                   storage for result.
  */
-void cmatvec_mult(complex alpha, complex x[], complex beta, complex y[])
+void cmatvec_mult(singlecomplex alpha, singlecomplex x[], singlecomplex beta, singlecomplex y[])
 {
     SuperMatrix *A = GLOBAL_A_ORIG;
 
@@ -107,12 +107,12 @@ void cmatvec_mult(complex alpha, complex x[], complex beta, complex y[])
 
 int main(int argc, char *argv[])
 {
-    void cmatvec_mult(complex alpha, complex x[], complex beta, complex y[]);
-    void cpsolve(int n, complex x[], complex y[]);
+    void cmatvec_mult(singlecomplex alpha, singlecomplex x[], singlecomplex beta, singlecomplex y[]);
+    void cpsolve(int n, singlecomplex x[], singlecomplex y[]);
     extern int cfgmr( int n,
-	void (*matvec_mult)(complex, complex [], complex, complex []),
-	void (*psolve)(int n, complex [], complex[]),
-	complex *rhs, complex *sol, double tol, int restrt, int *itmax,
+	void (*matvec_mult)(singlecomplex, singlecomplex [], singlecomplex, singlecomplex []),
+	void (*psolve)(int n, singlecomplex [], singlecomplex[]),
+	singlecomplex *rhs, singlecomplex *sol, double tol, int restrt, int *itmax,
 	FILE *fits);
     extern int cfill_diag(int n, NCformat *Astore);
 
@@ -125,26 +125,26 @@ int main(int argc, char *argv[])
     SCformat *Lstore;
     GlobalLU_t	   Glu; /* facilitate multiple factorizations with 
                            SamePattern_SameRowPerm                  */
-    complex   *a, *a_orig;
+    singlecomplex   *a, *a_orig;
     int_t    *asub, *xa, *asub_orig, *xa_orig;
     int      *etree;
     int      *perm_c; /* column permutation vector */
     int      *perm_r; /* row permutations from partial pivoting */
     int      nrhs, ldx, m, n;
     int_t    lwork, info, nnz;
-    complex   *rhsb, *rhsx, *xact;
-    complex   *work = NULL;
+    singlecomplex   *rhsb, *rhsx, *xact;
+    singlecomplex   *work = NULL;
     float   *R, *C;
     float   rpg, rcond;
-    complex zero = {0.0, 0.0};
-    complex one = {1.0, 0.0};
-    complex none = {-1.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
+    singlecomplex one = {1.0, 0.0};
+    singlecomplex none = {-1.0, 0.0};
     mem_usage_t   mem_usage;
     superlu_options_t options;
     SuperLUStat_t stat;
     FILE    *fp = stdin;
 
-    complex *x, *b;
+    singlecomplex *x, *b;
 
 #ifdef DEBUG
     extern int num_drop_L, num_drop_U;
@@ -237,7 +237,7 @@ int main(int argc, char *argv[])
     asub_orig = intMalloc(nnz);
     xa_orig = intMalloc(n+1);
     for (int i = 0; i < nnz; ++i) {
-	a_orig[i] = ((complex *)Astore->nzval)[i];
+	a_orig[i] = ((singlecomplex *)Astore->nzval)[i];
 	asub_orig[i] = Astore->rowind[i];
     }
     for (int i = 0; i <= n; ++i)
@@ -339,9 +339,9 @@ int main(int argc, char *argv[])
     {
 	int i_1 = 1;
 	double maxferr = 0.0, nrmA, nrmB, res, t;
-        complex temp;
-	extern float scnrm2_(int *, complex [], int *);
-	extern void caxpy_(int *, complex *, complex [], int *, complex [], int *);
+        singlecomplex temp;
+	extern float scnrm2_(int *, singlecomplex [], int *);
+	extern void caxpy_(int *, singlecomplex *, singlecomplex [], int *, singlecomplex [], int *);
 
         /* Initial guess */
         for (int i = 0; i < n; i++) x[i] = zero;
@@ -355,7 +355,7 @@ int main(int argc, char *argv[])
 
 	/* Output the result. */
 	int nnz32 = Astore->nnz;
-	nrmA = scnrm2_(&nnz32, (complex *)((DNformat *)A.Store)->nzval,
+	nrmA = scnrm2_(&nnz32, (singlecomplex *)((DNformat *)A.Store)->nzval,
 		&i_1);
 	nrmB = scnrm2_(&m, b, &i_1);
 	sp_cgemv("N", none, &AA, x, 1, one, b, 1); /* Original matrix */

--- a/EXAMPLE/clinsol.c
+++ b/EXAMPLE/clinsol.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 {
     SuperMatrix A;
     NCformat *Astore;
-    complex   *a;
+    singlecomplex   *a;
     int_t    *asub, *xa;
     int      *perm_c; /* column permutation vector */
     int      *perm_r; /* row permutations from partial pivoting */
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     SuperMatrix B;
     int      nrhs, ldx, m, n;
     int_t    nnz, info;
-    complex   *xact, *rhs;
+    singlecomplex   *xact, *rhs;
     mem_usage_t   mem_usage;
     superlu_options_t options;
     SuperLUStat_t stat;
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     if ( info == 0 ) {
 
 	/* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) B.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) B.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	 /* Compute the infinity norm of the error. */

--- a/EXAMPLE/clinsol1.c
+++ b/EXAMPLE/clinsol1.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 {
     SuperMatrix A;
     NCformat *Astore;
-    complex   *a;
+    singlecomplex   *a;
     int_t    *asub, *xa;
     int      *perm_c; /* column permutation vector */
     int      *perm_r; /* row permutations from partial pivoting */
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     SuperMatrix B;
     int      nrhs, ldx, m, n;
     int_t    info, nnz;
-    complex   *xact, *rhs;
+    singlecomplex   *xact, *rhs;
     mem_usage_t   mem_usage;
     superlu_options_t options;
     SuperLUStat_t stat;
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
     if ( info == 0 ) {
 
 	/* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) B.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) B.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	 /* Compute the infinity norm of the error. */

--- a/EXAMPLE/clinsolx.c
+++ b/EXAMPLE/clinsolx.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     SCformat       *Lstore;
     GlobalLU_t	   Glu; /* facilitate multiple factorizations with 
                            SamePattern_SameRowPerm                  */
-    complex         *a;
+    singlecomplex         *a;
     int_t          *asub, *xa;
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     int            nrhs, ldx;
     int_t          info, lwork, nnz;
     int            m, n;
-    complex         *rhsb, *rhsx, *xact;
+    singlecomplex         *rhsb, *rhsx, *xact;
     float         *R, *C;
     float         *ferr, *berr;
     float         u, rpg, rcond;
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
     if ( info == 0 || info == n+1 ) {
 
         /* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) X.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) X.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	if ( options.PivotGrowth == YES )

--- a/EXAMPLE/clinsolx1.c
+++ b/EXAMPLE/clinsolx1.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     SCformat       *Lstore;
     GlobalLU_t	   Glu; /* facilitate multiple factorizations with 
                            SamePattern_SameRowPerm                  */
-    complex         *a;
+    singlecomplex         *a;
     int_t          *asub, *xa;
     int            *perm_c; /* column permutation vector */
     int            *perm_r; /* row permutations from partial pivoting */
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
-    complex         *rhsb, *rhsx, *xact;
+    singlecomplex         *rhsb, *rhsx, *xact;
     float         *R, *C;
     float         *ferr, *berr;
     float         u, rpg, rcond;
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
     if ( info == 0 || info == n+1 ) {
 
         /* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) X.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) X.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	if ( options.IterRefine ) {

--- a/EXAMPLE/clinsolx2.c
+++ b/EXAMPLE/clinsolx2.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     SCformat       *Lstore;
     GlobalLU_t	   Glu; /* facilitate multiple factorizations with 
                            SamePattern_SameRowPerm                  */
-    complex         *a, *a1;
+    singlecomplex         *a, *a1;
     int_t          *asub, *xa, *asub1, *xa1;
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
-    complex         *rhsb, *rhsb1, *rhsx, *xact;
+    singlecomplex         *rhsb, *rhsb1, *rhsx, *xact;
     float         *R, *C;
     float         *ferr, *berr;
     float         u, rpg, rcond;
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
     if ( info == 0 || info == n+1 ) {
 
         /* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) X.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) X.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	if ( options.PivotGrowth ) printf("Recip. pivot growth = %e\n", rpg);
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
     if ( info == 0 || info == n+1 ) {
 
         /* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) X.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) X.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	if ( options.PivotGrowth ) printf("Recip. pivot growth = %e\n", rpg);

--- a/EXAMPLE/clinsolx3.c
+++ b/EXAMPLE/clinsolx3.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     NCformat       *Ustore;
     SCformat       *Lstore;
     GlobalLU_t 	   Glu;
-    complex         *a, *a1;
+    singlecomplex         *a, *a1;
     int_t          *asub, *xa, *asub1, *xa1;
     int            *perm_r; /* row permutations from partial pivoting */
     int            *perm_c; /* column permutation vector */
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
     void           *work = NULL;
     int            m, n, nrhs, ldx;
     int_t          info, lwork, nnz;
-    complex         *rhsb, *rhsb1, *rhsx, *xact;
+    singlecomplex         *rhsb, *rhsb1, *rhsx, *xact;
     float         *R, *C;
     float         *ferr, *berr;
     float         u, rpg, rcond;
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     if ( info == 0 || info == n+1 ) {
 
         /* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) X.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) X.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	if ( options.PivotGrowth ) printf("Recip. pivot growth = %e\n", rpg);
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
     if ( info == 0 || info == n+1 ) {
 
         /* This is how you could access the solution matrix. */
-        complex *sol = (complex*) ((DNformat*) X.Store)->nzval; 
+        singlecomplex *sol = (singlecomplex*) ((DNformat*) X.Store)->nzval; 
         (void)sol;  // suppress unused variable warning
 
 	if ( options.PivotGrowth ) printf("Recip. pivot growth = %e\n", rpg);

--- a/FORTRAN/c_fortran_cgssv.c
+++ b/FORTRAN/c_fortran_cgssv.c
@@ -38,8 +38,8 @@ typedef struct {
  */
 void
 c_fortran_cgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
-                 complex *values, int_t *rowind, int_t *colptr,
-                 complex *b, int *ldb,
+                 singlecomplex *values, int_t *rowind, int_t *colptr,
+                 singlecomplex *b, int *ldb,
                  fptr *f_factors, /* a handle containing the address
                                      pointing to the factored matrices */
                  int_t *info)

--- a/SRC/ccolumn_bmod.c
+++ b/SRC/ccolumn_bmod.c
@@ -52,8 +52,8 @@ int
 ccolumn_bmod (
 	     const int  jcol,	  /* in */
 	     const int  nseg,	  /* in */
-	     complex     *dense,	  /* in */
-	     complex     *tempv,	  /* working array */
+	     singlecomplex     *dense,	  /* in */
+	     singlecomplex     *tempv,	  /* working array */
 	     int        *segrep,  /* in */
 	     int        *repfnz,  /* in */
 	     int        fpanelc,  /* in -- first column in the current panel */
@@ -68,7 +68,7 @@ ccolumn_bmod (
          ftcs3 = _cptofcd("U", strlen("U"));
 #endif
     int         incx = 1, incy = 1;
-    complex      alpha, beta;
+    singlecomplex      alpha, beta;
     
     /* krep = representative of current k-th supernode
      * fsupc = first supernodal column
@@ -78,7 +78,7 @@ ccolumn_bmod (
      * kfnz = first nonz in the k-th supernodal segment
      * no_zeros = no of leading zeros in a supernodal U-segment
      */
-    complex      ukj, ukj1, ukj2;
+    singlecomplex      ukj, ukj1, ukj2;
     int_t        luptr, luptr1, luptr2;
     int          fsupc, nsupc, nsupr, segsze;
     int          nrow;	  /* No of rows in the matrix of matrix-vector */
@@ -90,14 +90,14 @@ ccolumn_bmod (
 			     panel and the first column of the current snode. */
     int          *xsup, *supno;
     int_t        *lsub, *xlsub;
-    complex       *lusup;
+    singlecomplex       *lusup;
     int_t        *xlusup;
     int_t        nzlumax;
-    complex       *tempv1;
-    complex      zero = {0.0, 0.0};
-    complex      one = {1.0, 0.0};
-    complex      none = {-1.0, 0.0};
-    complex	 comp_temp, comp_temp1;
+    singlecomplex       *tempv1;
+    singlecomplex      zero = {0.0, 0.0};
+    singlecomplex      one = {1.0, 0.0};
+    singlecomplex      none = {-1.0, 0.0};
+    singlecomplex	 comp_temp, comp_temp1;
     int_t        mem_error;
     flops_t      *ops = stat->ops;
 
@@ -105,7 +105,7 @@ ccolumn_bmod (
     supno   = Glu->supno;
     lsub    = Glu->lsub;
     xlsub   = Glu->xlsub;
-    lusup   = (complex *) Glu->lusup;
+    lusup   = (singlecomplex *) Glu->lusup;
     xlusup  = Glu->xlusup;
     nzlumax = Glu->nzlumax;
     jcolp1 = jcol + 1;
@@ -286,7 +286,7 @@ ccolumn_bmod (
     while ( new_next > nzlumax ) {
 	mem_error = cLUMemXpand(jcol, nextlu, LUSUP, &nzlumax, Glu);
 	if (mem_error) return (mem_error);
-	lusup = (complex *) Glu->lusup;
+	lusup = (singlecomplex *) Glu->lusup;
 	lsub = Glu->lsub;
     }
 

--- a/SRC/ccopy_to_ucol.c
+++ b/SRC/ccopy_to_ucol.c
@@ -39,7 +39,7 @@ ccopy_to_ucol(
 	      int        *segrep,  /* in */
 	      int        *repfnz,  /* in */
 	      int        *perm_r,  /* in */
-	      complex     *dense,   /* modified - reset to zero on return */
+	      singlecomplex     *dense,   /* modified - reset to zero on return */
 	      GlobalLU_t *Glu      /* modified */
 	      )
 {
@@ -52,16 +52,16 @@ ccopy_to_ucol(
     int_t isub, nextu, new_next, mem_error;
     int       *xsup, *supno;
     int_t     *lsub, *xlsub;
-    complex    *ucol;
+    singlecomplex    *ucol;
     int_t     *usub, *xusub;
     int_t       nzumax;
-    complex zero = {0.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
 
     xsup    = Glu->xsup;
     supno   = Glu->supno;
     lsub    = Glu->lsub;
     xlsub   = Glu->xlsub;
-    ucol    = (complex *) Glu->ucol;
+    ucol    = (singlecomplex *) Glu->ucol;
     usub    = Glu->usub;
     xusub   = Glu->xusub;
     nzumax  = Glu->nzumax;
@@ -85,7 +85,7 @@ ccopy_to_ucol(
 		while ( new_next > nzumax ) {
 		    mem_error = cLUMemXpand(jcol, nextu, UCOL, &nzumax, Glu);
 		    if (mem_error) return (mem_error);
-		    ucol = (complex *) Glu->ucol;
+		    ucol = (singlecomplex *) Glu->ucol;
 		    mem_error = cLUMemXpand(jcol, nextu, USUB, &nzumax, Glu);
 		    if (mem_error) return (mem_error);
 		    usub = Glu->usub;

--- a/SRC/cdiagonal.c
+++ b/SRC/cdiagonal.c
@@ -25,13 +25,13 @@ int cfill_diag(int n, NCformat *Astore)
 /* fill explicit zeros on the diagonal entries, so that the matrix is not
    structurally singular. */
 {
-    complex *nzval = (complex *)Astore->nzval;
+    singlecomplex *nzval = (singlecomplex *)Astore->nzval;
     int_t *rowind = Astore->rowind;
     int_t *colptr = Astore->colptr;
     int_t nnz = colptr[n];
     int fill = 0;
-    complex *nzval_new;
-    complex zero = {0.0, 0.0};
+    singlecomplex *nzval_new;
+    singlecomplex zero = {0.0, 0.0};
     int_t *rowind_new;
     int i, j, diag;
 
@@ -75,12 +75,12 @@ int cfill_diag(int n, NCformat *Astore)
 int cdominate(int n, NCformat *Astore)
 /* make the matrix diagonally dominant */
 {
-    complex *nzval = (complex *)Astore->nzval;
+    singlecomplex *nzval = (singlecomplex *)Astore->nzval;
     int_t *rowind = Astore->rowind;
     int_t *colptr = Astore->colptr;
     int_t nnz = colptr[n];
     int fill = 0;
-    complex *nzval_new;
+    singlecomplex *nzval_new;
     int_t *rowind_new;
     int_t i, j, diag;
     double s;

--- a/SRC/cgscon.c
+++ b/SRC/cgscon.c
@@ -89,11 +89,11 @@ cgscon(char *norm, SuperMatrix *L, SuperMatrix *U,
     /* Local variables */
     int    kase, kase1, onenrm;
     float ainvnm;
-    complex *work;
+    singlecomplex *work;
     int    isave[3];
-    extern int crscl_(int *, complex *, complex *, int *);
+    extern int crscl_(int *, singlecomplex *, singlecomplex *, int *);
 
-    extern int clacon2_(int *, complex *, complex *, float *, int *, int []);
+    extern int clacon2_(int *, singlecomplex *, singlecomplex *, float *, int *, int []);
 
     
     /* Test the input parameters. */

--- a/SRC/cgsequ.c
+++ b/SRC/cgsequ.c
@@ -98,7 +98,7 @@ cgsequ(SuperMatrix *A, float *r, float *c, float *rowcnd,
 
     /* Local variables */
     NCformat *Astore;
-    complex   *Aval;
+    singlecomplex   *Aval;
     int_t i, j;
     int   irow;
     float rcmin, rcmax;

--- a/SRC/cgsisx.c
+++ b/SRC/cgsisx.c
@@ -411,7 +411,7 @@ cgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 {
 
     DNformat  *Bstore, *Xstore;
-    complex    *Bmat, *Xmat;
+    singlecomplex    *Bmat, *Xmat;
     int       ldb, ldx, nrhs, n;
     SuperMatrix *AA;/* A in SLU_NC format used by the factorization routine.*/
     SuperMatrix AC; /* Matrix postmultiplied by Pc */
@@ -544,7 +544,7 @@ cgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 	int_t nnz = Astore->nnz;
 	int_t *colptr = Astore->colptr;
 	int_t *rowind = Astore->rowind;
-	complex *nzval = (complex *)Astore->nzval;
+	singlecomplex *nzval = (singlecomplex *)Astore->nzval;
 
 	if ( mc64 ) {
 	    t0 = SuperLU_timer_();

--- a/SRC/cgsitrf.c
+++ b/SRC/cgsitrf.c
@@ -201,23 +201,23 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
 				iswap is the inverse of swap. After the
 				factorization, it is equal to perm_r. */
     int       *iwork;
-    complex   *cwork;
+    singlecomplex   *cwork;
     int       *segrep, *repfnz, *parent;
     int_t     *xplore;
     int       *panel_lsub; /* dense[]/panel_lsub[] pair forms a w-wide SPA */
     int       *marker;
     int       *marker_relax;
-    complex    *dense, *tempv;
+    singlecomplex    *dense, *tempv;
     float *stempv;
     int       *relax_end, *relax_fsupc;
-    complex    *a;
+    singlecomplex    *a;
     int_t     *asub;
     int_t     *xa_begin, *xa_end;
     int       *xsup, *supno;
     int_t     *xlsub, *xlusup, *xusub;
     int_t     nzlumax;
     float    *amax; 
-    complex    drop_sum;
+    singlecomplex    drop_sum;
     float alpha, omega;  /* used in MILU, mimicing DRIC */
     float    *swork2;	   /* used by the second dropping rule */
 
@@ -250,7 +250,7 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     int       nnzAj;	/* number of nonzeros in A(:,1:j) */
     int       nnzLj, nnzUj;
     double    tol_L = drop_tol, tol_U = drop_tol;
-    complex zero = {0.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
     float one = 1.0;
 
     /* Executable */	   
@@ -499,7 +499,7 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
 		    xlsub[jj + 1]++;
 		    assert(xlusup[jj]==xlusup[jj+1]);
 		    xlusup[jj + 1]++;
-		    ((complex *) Glu->lusup)[xlusup[jj]] = zero;
+		    ((singlecomplex *) Glu->lusup)[xlusup[jj]] = zero;
 
 		    /* Choose a row index (pivrow) for fill-in */
 		    for (i = jj; i < n; i++)
@@ -637,21 +637,21 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
 	   may have changed, */
 	((SCformat *)L->Store)->nnz = nnzL;
 	((SCformat *)L->Store)->nsuper = Glu->supno[n];
-	((SCformat *)L->Store)->nzval = (complex *) Glu->lusup;
+	((SCformat *)L->Store)->nzval = (singlecomplex *) Glu->lusup;
 	((SCformat *)L->Store)->nzval_colptr = Glu->xlusup;
 	((SCformat *)L->Store)->rowind = Glu->lsub;
 	((SCformat *)L->Store)->rowind_colptr = Glu->xlsub;
 	((NCformat *)U->Store)->nnz = nnzU;
-	((NCformat *)U->Store)->nzval = (complex *) Glu->ucol;
+	((NCformat *)U->Store)->nzval = (singlecomplex *) Glu->ucol;
 	((NCformat *)U->Store)->rowind = Glu->usub;
 	((NCformat *)U->Store)->colptr = Glu->xusub;
     } else {
 	cCreate_SuperNode_Matrix(L, A->nrow, min_mn, nnzL,
-              (complex *) Glu->lusup, Glu->xlusup,
+              (singlecomplex *) Glu->lusup, Glu->xlusup,
               Glu->lsub, Glu->xlsub, Glu->supno, Glu->xsup,
 	      SLU_SC, SLU_C, SLU_TRLU);
 	cCreate_CompCol_Matrix(U, min_mn, min_mn, nnzU,
-	      (complex *) Glu->ucol, Glu->usub, Glu->xusub,
+	      (singlecomplex *) Glu->ucol, Glu->usub, Glu->xusub,
 	      SLU_NC, SLU_C, SLU_TRU);
     }
 

--- a/SRC/cgsrfs.c
+++ b/SRC/cgsrfs.c
@@ -149,15 +149,15 @@ cgsrfs(trans_t trans, SuperMatrix *A, SuperMatrix *L, SuperMatrix *U,
     
     /* Table of constant values */
     int    ione = 1, nrow = A->nrow;
-    complex ndone = {-1., 0.};
-    complex done = {1., 0.};
+    singlecomplex ndone = {-1., 0.};
+    singlecomplex done = {1., 0.};
     
     /* Local variables */
     NCformat *Astore;
-    complex   *Aval;
+    singlecomplex   *Aval;
     SuperMatrix Bjcol;
     DNformat *Bstore, *Xstore, *Bjcol_store;
-    complex   *Bmat, *Xmat, *Bptr, *Xptr;
+    singlecomplex   *Bmat, *Xmat, *Bptr, *Xptr;
     int      kase;
     float   safe1, safe2;
     int      i, j, k, irow, nz, count, notran, rowequ, colequ;
@@ -165,18 +165,18 @@ cgsrfs(trans_t trans, SuperMatrix *A, SuperMatrix *L, SuperMatrix *U,
     float   s, xk, lstres, eps, safmin;
     char     transc[1];
     trans_t  transt;
-    complex   *work;
+    singlecomplex   *work;
     float   *rwork;
     int      *iwork;
     int      isave[3];
 
-    extern int clacon2_(int *, complex *, complex *, float *, int *, int []);
+    extern int clacon2_(int *, singlecomplex *, singlecomplex *, float *, int *, int []);
 #ifdef _CRAY
-    extern int CCOPY(int *, complex *, int *, complex *, int *);
-    extern int CSAXPY(int *, complex *, complex *, int *, complex *, int *);
+    extern int CCOPY(int *, singlecomplex *, int *, singlecomplex *, int *);
+    extern int CSAXPY(int *, singlecomplex *, singlecomplex *, int *, singlecomplex *, int *);
 #else
-    extern int ccopy_(int *, complex *, int *, complex *, int *);
-    extern int caxpy_(int *, complex *, complex *, int *, complex *, int *);
+    extern int ccopy_(int *, singlecomplex *, int *, singlecomplex *, int *);
+    extern int caxpy_(int *, singlecomplex *, singlecomplex *, int *, singlecomplex *, int *);
 #endif
 
     Astore = A->Store;

--- a/SRC/cgssvx.c
+++ b/SRC/cgssvx.c
@@ -366,7 +366,7 @@ cgssvx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 
 
     DNformat  *Bstore, *Xstore;
-    complex    *Bmat, *Xmat;
+    singlecomplex    *Bmat, *Xmat;
     int       ldb, ldx, nrhs;
     SuperMatrix *AA;/* A in SLU_NC format used by the factorization routine.*/
     SuperMatrix AC; /* Matrix postmultiplied by Pc */

--- a/SRC/cgstrf.c
+++ b/SRC/cgstrf.c
@@ -209,14 +209,14 @@ cgstrf (superlu_options_t *options, SuperMatrix *A,
                                   options->Fact == SamePattern_SameRowPerm */
     int       *iperm_c; /* inverse of perm_c */
     int       *iwork;
-    complex    *cwork;
+    singlecomplex    *cwork;
     int	      *segrep, *repfnz, *parent;
     int	      *panel_lsub; /* dense[]/panel_lsub[] pair forms a w-wide SPA */
     int_t     *xprune, *xplore;
     int	      *marker;
-    complex    *dense, *tempv;
+    singlecomplex    *dense, *tempv;
     int       *relax_end;
-    complex    *a;
+    singlecomplex    *a;
     int_t     *asub, *xa_begin, *xa_end;
     int_t     *xlsub, *xlusup, *xusub;
     int       *xsup, *supno;
@@ -432,21 +432,21 @@ cgstrf (superlu_options_t *options, SuperMatrix *A,
            may have changed, */
         ((SCformat *)L->Store)->nnz = nnzL;
 	((SCformat *)L->Store)->nsuper = Glu->supno[n];
-	((SCformat *)L->Store)->nzval = (complex *) Glu->lusup;
+	((SCformat *)L->Store)->nzval = (singlecomplex *) Glu->lusup;
 	((SCformat *)L->Store)->nzval_colptr = Glu->xlusup;
 	((SCformat *)L->Store)->rowind = Glu->lsub;
 	((SCformat *)L->Store)->rowind_colptr = Glu->xlsub;
 	((NCformat *)U->Store)->nnz = nnzU;
-	((NCformat *)U->Store)->nzval = (complex *) Glu->ucol;
+	((NCformat *)U->Store)->nzval = (singlecomplex *) Glu->ucol;
 	((NCformat *)U->Store)->rowind = Glu->usub;
 	((NCformat *)U->Store)->colptr = Glu->xusub;
     } else {
         cCreate_SuperNode_Matrix(L, A->nrow, min_mn, nnzL, 
-	      (complex *) Glu->lusup, Glu->xlusup, 
+	      (singlecomplex *) Glu->lusup, Glu->xlusup, 
               Glu->lsub, Glu->xlsub, Glu->supno, Glu->xsup,
               SLU_SC, SLU_C, SLU_TRLU);
     	cCreate_CompCol_Matrix(U, min_mn, min_mn, nnzU, 
-	      (complex *) Glu->ucol, Glu->usub, Glu->xusub,
+	      (singlecomplex *) Glu->ucol, Glu->usub, Glu->xusub,
               SLU_NC, SLU_C, SLU_TRU);
     }
     

--- a/SRC/cgstrs.c
+++ b/SRC/cgstrs.c
@@ -99,21 +99,21 @@ cgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     _fcd ftcs1, ftcs2, ftcs3, ftcs4;
 #endif
 #ifdef USE_VENDOR_BLAS
-    complex   alpha = {1.0, 0.0}, beta = {1.0, 0.0};
-    complex   *work_col;
+    singlecomplex   alpha = {1.0, 0.0}, beta = {1.0, 0.0};
+    singlecomplex   *work_col;
 #endif
-    complex   temp_comp;
+    singlecomplex   temp_comp;
     DNformat *Bstore;
-    complex   *Bmat;
+    singlecomplex   *Bmat;
     SCformat *Lstore;
     NCformat *Ustore;
-    complex   *Lval, *Uval;
+    singlecomplex   *Lval, *Uval;
     int      fsupc, nrow, nsupr, nsupc, irow;
     int_t    i, j, k, luptr, istart, iptr;
     int      jcol, n, ldb, nrhs;
-    complex   *work, *rhs_work, *soln;
+    singlecomplex   *work, *rhs_work, *soln;
     flops_t  solve_ops;
-    void cprint_soln(int n, int nrhs, complex *soln);
+    void cprint_soln(int n, int nrhs, singlecomplex *soln);
 
     /* Test input parameters ... */
     *info = 0;
@@ -344,7 +344,7 @@ cgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
  * Diagnostic print of the solution vector 
  */
 void
-cprint_soln(int n, int nrhs, complex *soln)
+cprint_soln(int n, int nrhs, singlecomplex *soln)
 {
     int i;
 

--- a/SRC/clacon2.c
+++ b/SRC/clacon2.c
@@ -87,12 +87,12 @@ at the top-level directory.
  */
 
 int
-clacon2_(int *n, complex *v, complex *x, float *est, int *kase, int isave[3])
+clacon2_(int *n, singlecomplex *v, singlecomplex *x, float *est, int *kase, int isave[3])
 {
     /* Table of constant values */
     int c__1 = 1;
-    complex      zero = {0.0, 0.0};
-    complex      one = {1.0, 0.0};
+    singlecomplex      zero = {0.0, 0.0};
+    singlecomplex      one = {1.0, 0.0};
 
     /* System generated locals */
     float d__1;
@@ -104,9 +104,9 @@ clacon2_(int *n, complex *v, complex *x, float *est, int *kase, int isave[3])
     float temp;
     float safmin;
     extern float smach(char *);
-    extern int icmax1_slu(int *, complex *, int *);
-    extern double scsum1_slu(int *, complex *, int *);
-    extern int ccopy_(int *, complex *, int *, complex *, int *);
+    extern int icmax1_slu(int *, singlecomplex *, int *);
+    extern double scsum1_slu(int *, singlecomplex *, int *);
+    extern int ccopy_(int *, singlecomplex *, int *, singlecomplex *, int *);
 
     safmin = smach("Safe minimum");
     if ( *kase == 0 ) {

--- a/SRC/clangs.c
+++ b/SRC/clangs.c
@@ -73,7 +73,7 @@ float clangs(char *norm, SuperMatrix *A)
     
     /* Local variables */
     NCformat *Astore;
-    complex   *Aval;
+    singlecomplex   *Aval;
     int      i, j, irow;
     float   value, sum;
     float   *rwork;

--- a/SRC/claqgs.c
+++ b/SRC/claqgs.c
@@ -98,7 +98,7 @@ claqgs(SuperMatrix *A, float *r, float *c,
     
     /* Local variables */
     NCformat *Astore;
-    complex   *Aval;
+    singlecomplex   *Aval;
     int_t i, j;
     int   irow;
     float large, small, cj;

--- a/SRC/cldperm.c
+++ b/SRC/cldperm.c
@@ -74,7 +74,7 @@ extern int_t mc64ad_(int_t *job, int_t *n, int_t *ne, int_t *ip,
  * colptr (input) int*, of size n+1
  *        The pointers to the beginning of each column in ADJNCY.
  *
- * nzval  (input) complex*, of size nnz
+ * nzval  (input) singlecomplex*, of size nnz
  *        The nonzero values of the matrix. nzval[k] is the value of
  *        the entry corresponding to adjncy[k].
  *        It is not used if job = 1.
@@ -94,7 +94,7 @@ extern int_t mc64ad_(int_t *job, int_t *n, int_t *ne, int_t *ip,
 
 int
 cldperm(int job, int n, int_t nnz, int_t colptr[], int_t adjncy[],
-	complex nzval[], int *perm, float u[], float v[])
+	singlecomplex nzval[], int *perm, float u[], float v[])
 {
     int_t i, num;
     int_t icntl[10], info[10];

--- a/SRC/cmyblas2.c
+++ b/SRC/cmyblas2.c
@@ -36,12 +36,12 @@ at the top-level directory.
  * triangular matrix is stored in a 2D array M(1:nrow,1:ncol). 
  * The solution will be returned in the rhs vector.
  */
-void clsolve ( int ldm, int ncol, complex *M, complex *rhs )
+void clsolve ( int ldm, int ncol, singlecomplex *M, singlecomplex *rhs )
 {
     int k;
-    complex x0, x1, x2, x3, temp;
-    complex *M0;
-    complex *Mki0, *Mki1, *Mki2, *Mki3;
+    singlecomplex x0, x1, x2, x3, temp;
+    singlecomplex *M0;
+    singlecomplex *Mki0, *Mki1, *Mki2, *Mki3;
     register int firstcol = 0;
 
     M0 = &M[0];
@@ -113,9 +113,9 @@ void clsolve ( int ldm, int ncol, complex *M, complex *rhs )
  * stored in a 2-dim array M(1:ldm,1:ncol). The solution will be returned
  * in the rhs vector.
  */
-void cusolve (int ldm, int ncol, complex *M, complex *rhs)
+void cusolve (int ldm, int ncol, singlecomplex *M, singlecomplex *rhs)
 {
-    complex xj, temp;
+    singlecomplex xj, temp;
     int jcol, j, irow;
 
     jcol = ncol - 1;
@@ -140,11 +140,11 @@ void cusolve (int ldm, int ncol, complex *M, complex *rhs)
  *
  * The input matrix is M(1:nrow,1:ncol); The product is returned in Mxvec[].
  */
-void cmatvec (int ldm, int nrow, int ncol, complex *M, complex *vec, complex *Mxvec)
+void cmatvec (int ldm, int nrow, int ncol, singlecomplex *M, singlecomplex *vec, singlecomplex *Mxvec)
 {
-    complex vi0, vi1, vi2, vi3;
-    complex *M0, temp;
-    complex *Mki0, *Mki1, *Mki2, *Mki3;
+    singlecomplex vi0, vi1, vi2, vi3;
+    singlecomplex *M0, temp;
+    singlecomplex *Mki0, *Mki1, *Mki2, *Mki3;
     register int firstcol = 0;
     int k;
 

--- a/SRC/cpanel_bmod.c
+++ b/SRC/cpanel_bmod.c
@@ -63,8 +63,8 @@ cpanel_bmod (
 	    const int  w,          /* in */
 	    const int  jcol,       /* in */
 	    const int  nseg,       /* in */
-	    complex     *dense,     /* out, of size n by w */
-	    complex     *tempv,     /* working array */
+	    singlecomplex     *dense,     /* out, of size n by w */
+	    singlecomplex     *tempv,     /* working array */
 	    int        *segrep,    /* in */
 	    int        *repfnz,    /* in, of size n by w */
 	    GlobalLU_t *Glu,       /* modified */
@@ -80,13 +80,13 @@ cpanel_bmod (
          ftcs3 = _cptofcd("U", strlen("U"));
 #endif
     int          incx = 1, incy = 1;
-    complex       alpha, beta;
+    singlecomplex       alpha, beta;
 #endif
 
     register int k, ksub;
     int          fsupc, nsupc, nsupr, nrow;
     int          krep, krep_ind;
-    complex       ukj, ukj1, ukj2;
+    singlecomplex       ukj, ukj1, ukj2;
     int_t        luptr, luptr1, luptr2;
     int          segsze;
     int          block_nrow;  /* no of rows in a block row */
@@ -96,15 +96,15 @@ cpanel_bmod (
     register int jj;	      /* Index through each column in the panel */
     int          *xsup, *supno;
     int_t        *lsub, *xlsub;
-    complex       *lusup;
+    singlecomplex       *lusup;
     int_t        *xlusup;
     int          *repfnz_col; /* repfnz[] for a column in the panel */
-    complex       *dense_col;  /* dense[] for a column in the panel */
-    complex       *tempv1;             /* Used in 1-D update */
-    complex       *TriTmp, *MatvecTmp; /* used in 2-D update */
-    complex      zero = {0.0, 0.0};
-    complex      one = {1.0, 0.0};
-    complex      comp_temp, comp_temp1;
+    singlecomplex       *dense_col;  /* dense[] for a column in the panel */
+    singlecomplex       *tempv1;             /* Used in 1-D update */
+    singlecomplex       *TriTmp, *MatvecTmp; /* used in 2-D update */
+    singlecomplex      zero = {0.0, 0.0};
+    singlecomplex      one = {1.0, 0.0};
+    singlecomplex      comp_temp, comp_temp1;
     register int ldaTmp;
     register int r_ind, r_hi;
     int  maxsuper, rowblk, colblk;
@@ -114,7 +114,7 @@ cpanel_bmod (
     supno   = Glu->supno;
     lsub    = Glu->lsub;
     xlsub   = Glu->xlsub;
-    lusup   = (complex *) Glu->lusup;
+    lusup   = (singlecomplex *) Glu->lusup;
     xlusup  = Glu->xlusup;
     
     maxsuper = SUPERLU_MAX( sp_ienv(3), sp_ienv(7) );

--- a/SRC/cpanel_dfs.c
+++ b/SRC/cpanel_dfs.c
@@ -73,7 +73,7 @@ cpanel_dfs (
 	   SuperMatrix *A,       /* in - original matrix */
 	   int        *perm_r,     /* in */
 	   int        *nseg,	   /* out */
-	   complex     *dense,      /* out */
+	   singlecomplex     *dense,      /* out */
 	   int        *panel_lsub, /* out */
 	   int        *segrep,     /* out */
 	   int        *repfnz,     /* out */
@@ -86,7 +86,7 @@ cpanel_dfs (
 {
 
     NCPformat *Astore;
-    complex    *a;
+    singlecomplex    *a;
     int_t     *asub;
     int_t     *xa_begin, *xa_end, k;
     int       krow, kmark, kperm;
@@ -95,7 +95,7 @@ cpanel_dfs (
     int       *marker1;	   /* marker1[jj] >= jcol if vertex jj was visited 
 			      by a previous column within this panel.   */
     int       *repfnz_col; /* start of each column in the panel */
-    complex    *dense_col;  /* start of each column in the panel */
+    singlecomplex    *dense_col;  /* start of each column in the panel */
     int_t     nextl_col;   /* next available position in panel_lsub[*,jj] */
     int       *xsup, *supno;
     int_t     *lsub, *xlsub;

--- a/SRC/cpivotL.c
+++ b/SRC/cpivotL.c
@@ -76,27 +76,27 @@ cpivotL(
        )
 {
 
-    complex one = {1.0, 0.0};
+    singlecomplex one = {1.0, 0.0};
     int          fsupc;	    /* first column in the supernode */
     int          nsupc;	    /* no of columns in the supernode */
     int          nsupr;     /* no of rows in the supernode */
     int_t        lptr;	    /* points to the starting subscript of the supernode */
     int          pivptr, old_pivptr, diag, diagind;
     float       pivmax, rtemp, thresh;
-    complex       temp;
-    complex       *lu_sup_ptr; 
-    complex       *lu_col_ptr;
+    singlecomplex       temp;
+    singlecomplex       *lu_sup_ptr; 
+    singlecomplex       *lu_col_ptr;
     int_t        *lsub_ptr;
     int_t        isub, icol, k, itemp;
     int_t        *lsub, *xlsub;
-    complex       *lusup;
+    singlecomplex       *lusup;
     int_t        *xlusup;
     flops_t      *ops = stat->ops;
 
     /* Initialize pointers */
     lsub       = Glu->lsub;
     xlsub      = Glu->xlsub;
-    lusup      = (complex *) Glu->lusup;
+    lusup      = (singlecomplex *) Glu->lusup;
     xlusup     = Glu->xlusup;
     fsupc      = (Glu->xsup)[(Glu->supno)[jcol]];
     nsupc      = jcol - fsupc;	        /* excluding jcol; nsupc >= 0 */

--- a/SRC/cpivotgrowth.c
+++ b/SRC/cpivotgrowth.c
@@ -63,14 +63,14 @@ cPivotGrowth(int ncols, SuperMatrix *A, int *perm_c,
     NCformat *Astore;
     SCformat *Lstore;
     NCformat *Ustore;
-    complex  *Aval, *Lval, *Uval;
+    singlecomplex  *Aval, *Lval, *Uval;
     int      fsupc, nsupr;
     int_t    luptr, nz_in_U;
     int_t    i, j, k, oldcol;
     int      *inv_perm_c;
     float   rpg, maxaj, maxuj;
     float   smlnum;
-    complex   *luval;
+    singlecomplex   *luval;
    
     /* Get machine constants. */
     smlnum = smach("S");

--- a/SRC/cpruneL.c
+++ b/SRC/cpruneL.c
@@ -57,20 +57,20 @@ cpruneL(
        )
 {
 
-    complex     utemp;
+    singlecomplex     utemp;
     int        jsupno, irep, irep1, kmin, kmax, krow, movnum;
     int_t      i, ktemp, minloc, maxloc;
     int        do_prune; /* logical variable */
     int        *xsup, *supno;
     int_t      *lsub, *xlsub;
-    complex     *lusup;
+    singlecomplex     *lusup;
     int_t      *xlusup;
 
     xsup       = Glu->xsup;
     supno      = Glu->supno;
     lsub       = Glu->lsub;
     xlsub      = Glu->xlsub;
-    lusup      = (complex *) Glu->lusup;
+    lusup      = (singlecomplex *) Glu->lusup;
     xlusup     = Glu->xlusup;
     
     /*

--- a/SRC/creadMM.c
+++ b/SRC/creadMM.c
@@ -33,10 +33,10 @@ at the top-level directory.
 
 void
 creadMM(FILE *fp, int *m, int *n, int_t *nonz,
-	    complex **nzval, int_t **rowind, int_t **colptr)
+	    singlecomplex **nzval, int_t **rowind, int_t **colptr)
 {
     int_t    j, k, jsize, nnz, nz, new_nonz;
-    complex *a, *val;
+    singlecomplex *a, *val;
     int_t    *asub, *xa;
     int      *row, *col;
     int    zero_base = 0;
@@ -126,7 +126,7 @@ creadMM(FILE *fp, int *m, int *n, int_t *nonz,
     asub = *rowind;
     xa   = *colptr;
 
-    if ( !(val = (complex *) SUPERLU_MALLOC(new_nonz * sizeof(double))) )
+    if ( !(val = (singlecomplex *) SUPERLU_MALLOC(new_nonz * sizeof(double))) )
         ABORT("Malloc fails for val[]");
     if ( !(row = int32Malloc(new_nonz)) )
         ABORT("Malloc fails for row[]");
@@ -220,7 +220,7 @@ creadMM(FILE *fp, int *m, int *n, int_t *nonz,
 }
 
 
-static void creadrhs(int m, complex *b)
+static void creadrhs(int m, singlecomplex *b)
 {
     FILE *fp = fopen("b.dat", "r");
     int i;

--- a/SRC/creadhb.c
+++ b/SRC/creadhb.c
@@ -158,7 +158,7 @@ static int ReadVector(FILE *fp, int_t n, int_t *where, int perline, int persize)
 }
 
 /*! \brief Read complex numbers as pairs of (real, imaginary) */
-int cReadValues(FILE *fp, int n, complex *destination, int perline, int persize)
+int cReadValues(FILE *fp, int n, singlecomplex *destination, int perline, int persize)
 {
     register int i, j, k, s, pair;
     register float realpart;
@@ -198,12 +198,12 @@ int cReadValues(FILE *fp, int n, complex *destination, int perline, int persize)
  * </pre>
  */
 static void
-FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
+FormFullA(int n, int_t *nonz, singlecomplex **nzval, int_t **rowind, int_t **colptr)
 {
     int_t i, j, k, col, new_nnz;
     int_t *t_rowind, *t_colptr, *al_rowind, *al_colptr, *a_rowind, *a_colptr;
     int_t *marker;
-    complex *t_val, *al_val, *a_val;
+    singlecomplex *t_val, *al_val, *a_val;
 
     al_rowind = *rowind;
     al_colptr = *colptr;
@@ -215,7 +215,7 @@ FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
 	ABORT("SUPERLU_MALLOC t_colptr[]");
     if ( !(t_rowind = intMalloc( *nonz ) ) )
 	ABORT("SUPERLU_MALLOC fails for t_rowind[]");
-    if ( !(t_val = (complex*) SUPERLU_MALLOC( *nonz * sizeof(complex)) ) )
+    if ( !(t_val = (singlecomplex*) SUPERLU_MALLOC( *nonz * sizeof(singlecomplex)) ) )
 	ABORT("SUPERLU_MALLOC fails for t_val[]");
 
     /* Get counts of each column of T, and set up column pointers */
@@ -244,7 +244,7 @@ FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
 	ABORT("SUPERLU_MALLOC a_colptr[]");
     if ( !(a_rowind = intMalloc( new_nnz ) ) )
 	ABORT("SUPERLU_MALLOC fails for a_rowind[]");
-    if ( !(a_val = (complex*) SUPERLU_MALLOC( new_nnz * sizeof(complex)) ) )
+    if ( !(a_val = (singlecomplex*) SUPERLU_MALLOC( new_nnz * sizeof(singlecomplex)) ) )
 	ABORT("SUPERLU_MALLOC fails for a_val[]");
     
     a_colptr[0] = 0;
@@ -291,7 +291,7 @@ FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
 
 void
 creadhb(FILE *fp, int *nrow, int *ncol, int_t *nonz,
-	complex **nzval, int_t **rowind, int_t **colptr)
+	singlecomplex **nzval, int_t **rowind, int_t **colptr)
 {
 
     register int i, numer_lines = 0, rhscrd = 0;

--- a/SRC/creadrb.c
+++ b/SRC/creadrb.c
@@ -154,7 +154,7 @@ static int ReadVector(FILE *fp, int n, int_t *where, int perline, int persize)
 }
 
 /*! \brief Read complex numbers as pairs of (real, imaginary) */
-static int cReadValues(FILE *fp, int n, complex *destination, int perline, int persize)
+static int cReadValues(FILE *fp, int n, singlecomplex *destination, int perline, int persize)
 {
     register int i, j, k, s, pair;
     register float realpart;
@@ -195,12 +195,12 @@ static int cReadValues(FILE *fp, int n, complex *destination, int perline, int p
  * </pre>
  */
 static void
-FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
+FormFullA(int n, int_t *nonz, singlecomplex **nzval, int_t **rowind, int_t **colptr)
 {
     int_t i, j, k, col, new_nnz;
     int_t *t_rowind, *t_colptr, *al_rowind, *al_colptr, *a_rowind, *a_colptr;
     int_t *marker;
-    complex *t_val, *al_val, *a_val;
+    singlecomplex *t_val, *al_val, *a_val;
 
     al_rowind = *rowind;
     al_colptr = *colptr;
@@ -212,7 +212,7 @@ FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
 	ABORT("SUPERLU_MALLOC t_colptr[]");
     if ( !(t_rowind = intMalloc( *nonz ) ) )
 	ABORT("SUPERLU_MALLOC fails for t_rowind[]");
-    if ( !(t_val = (complex*) SUPERLU_MALLOC( *nonz * sizeof(complex)) ) )
+    if ( !(t_val = (singlecomplex*) SUPERLU_MALLOC( *nonz * sizeof(singlecomplex)) ) )
 	ABORT("SUPERLU_MALLOC fails for t_val[]");
 
     /* Get counts of each column of T, and set up column pointers */
@@ -241,7 +241,7 @@ FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
 	ABORT("SUPERLU_MALLOC a_colptr[]");
     if ( !(a_rowind = intMalloc( new_nnz) ) )
 	ABORT("SUPERLU_MALLOC fails for a_rowind[]");
-    if ( !(a_val = (complex*) SUPERLU_MALLOC( new_nnz * sizeof(complex)) ) )
+    if ( !(a_val = (singlecomplex*) SUPERLU_MALLOC( new_nnz * sizeof(singlecomplex)) ) )
 	ABORT("SUPERLU_MALLOC fails for a_val[]");
     
     a_colptr[0] = 0;
@@ -288,7 +288,7 @@ FormFullA(int n, int_t *nonz, complex **nzval, int_t **rowind, int_t **colptr)
 
 void
 creadrb(int *nrow, int *ncol, int_t *nonz,
-        complex **nzval, int_t **rowind, int_t **colptr)
+        singlecomplex **nzval, int_t **rowind, int_t **colptr)
 {
 
     register int i, numer_lines = 0;

--- a/SRC/creadtriple.c
+++ b/SRC/creadtriple.c
@@ -23,7 +23,7 @@ at the top-level directory.
 
 void
 creadtriple(int *m, int *n, int_t *nonz,
-	    complex **nzval, int_t **rowind, int_t **colptr)
+	    singlecomplex **nzval, int_t **rowind, int_t **colptr)
 {
 /*
  * Output parameters
@@ -34,7 +34,7 @@ creadtriple(int *m, int *n, int_t *nonz,
  *
  */
     int    j, k, jsize, nnz, nz;
-    complex *a, *val;
+    singlecomplex *a, *val;
     int_t  *asub, *xa;
     int    *row, *col;
     int    zero_base = 0;
@@ -57,7 +57,7 @@ creadtriple(int *m, int *n, int_t *nonz,
     asub = *rowind;
     xa   = *colptr;
 
-    val = (complex *) SUPERLU_MALLOC(*nonz * sizeof(complex));
+    val = (singlecomplex *) SUPERLU_MALLOC(*nonz * sizeof(singlecomplex));
     row = int32Malloc(*nonz);
     col = int32Malloc(*nonz);
 
@@ -137,7 +137,7 @@ creadtriple(int *m, int *n, int_t *nonz,
 }
 
 
-void creadrhs(int m, complex *b)
+void creadrhs(int m, singlecomplex *b)
 {
     FILE *fp = fopen("b.dat", "r");
     int i;

--- a/SRC/csnode_bmod.c
+++ b/SRC/csnode_bmod.c
@@ -42,8 +42,8 @@ csnode_bmod (
 	    const int  jcol,	  /* in */
 	    const int  jsupno,    /* in */
 	    const int  fsupc,     /* in */
-	    complex     *dense,    /* in */
-	    complex     *tempv,    /* working array */
+	    singlecomplex     *dense,    /* in */
+	    singlecomplex     *tempv,    /* working array */
 	    GlobalLU_t *Glu,      /* modified */
 	    SuperLUStat_t *stat   /* output */
 	    )
@@ -55,21 +55,21 @@ csnode_bmod (
 	 ftcs3 = _cptofcd("U", strlen("U"));
 #endif
     int            incx = 1, incy = 1;
-    complex         alpha = {-1.0, 0.0},  beta = {1.0, 0.0};
+    singlecomplex         alpha = {-1.0, 0.0},  beta = {1.0, 0.0};
 #endif
 
-    complex   comp_zero = {0.0, 0.0};
+    singlecomplex   comp_zero = {0.0, 0.0};
     int     nsupc, nsupr, nrow;
     int_t   isub, irow;
     int_t   ufirst, nextlu;
     int_t   *lsub, *xlsub;
-    complex *lusup;
+    singlecomplex *lusup;
     int_t   *xlusup, luptr;
     flops_t *ops = stat->ops;
 
     lsub    = Glu->lsub;
     xlsub   = Glu->xlsub;
-    lusup   = (complex *) Glu->lusup;
+    lusup   = (singlecomplex *) Glu->lusup;
     xlusup  = Glu->xlusup;
 
     nextlu = xlusup[jcol];

--- a/SRC/csp_blas2.c
+++ b/SRC/csp_blas2.c
@@ -73,7 +73,7 @@ at the top-level directory.
  *	        The factor U from the factorization Pr*A*Pc=L*U.
  *	        U has types: Stype = NC, Dtype = SLU_C, Mtype = TRU.
  *    
- *   x       - (input/output) complex*
+ *   x       - (input/output) singlecomplex*
  *             Before entry, the incremented array X must contain the n   
  *             element right-hand side vector b. On exit, X is overwritten 
  *             with the solution vector x.
@@ -84,7 +84,7 @@ at the top-level directory.
  */
 int
 sp_ctrsv(char *uplo, char *trans, char *diag, SuperMatrix *L, 
-         SuperMatrix *U, complex *x, SuperLUStat_t *stat, int *info)
+         SuperMatrix *U, singlecomplex *x, SuperLUStat_t *stat, int *info)
 {
 #ifdef _CRAY
     _fcd ftcs1 = _cptofcd("L", strlen("L")),
@@ -93,15 +93,15 @@ sp_ctrsv(char *uplo, char *trans, char *diag, SuperMatrix *L,
 #endif
     SCformat *Lstore;
     NCformat *Ustore;
-    complex   *Lval, *Uval;
+    singlecomplex   *Lval, *Uval;
     int incx = 1, incy = 1;
-    complex temp;
-    complex alpha = {1.0, 0.0}, beta = {1.0, 0.0};
-    complex comp_zero = {0.0, 0.0};
+    singlecomplex temp;
+    singlecomplex alpha = {1.0, 0.0}, beta = {1.0, 0.0};
+    singlecomplex comp_zero = {0.0, 0.0};
     int nrow, irow, jcol;
     int fsupc, nsupr, nsupc;
     int_t luptr, istart, i, k, iptr;
-    complex *work;
+    singlecomplex *work;
     flops_t solve_ops;
 
     /* Test the input parameters */
@@ -421,14 +421,14 @@ sp_ctrsv(char *uplo, char *trans, char *diag, SuperMatrix *L,
  *               TRANS = 'T' or 't'   y := alpha*A'*x + beta*y.   
  *               TRANS = 'C' or 'c'   y := alpha*A^H*x + beta*y.   
  *
- *   ALPHA  - (input) complex
+ *   ALPHA  - (input) singlecomplex
  *            On entry, ALPHA specifies the scalar alpha.   
  *
  *   A      - (input) SuperMatrix*
  *            Before entry, the leading m by n part of the array A must   
  *            contain the matrix of coefficients.   
  *
- *   X      - (input) complex*, array of DIMENSION at least   
+ *   X      - (input) singlecomplex*, array of DIMENSION at least   
  *            ( 1 + ( n - 1 )*abs( INCX ) ) when TRANS = 'N' or 'n'   
  *           and at least   
  *            ( 1 + ( m - 1 )*abs( INCX ) ) otherwise.   
@@ -439,11 +439,11 @@ sp_ctrsv(char *uplo, char *trans, char *diag, SuperMatrix *L,
  *            On entry, INCX specifies the increment for the elements of   
  *            X. INCX must not be zero.   
  *
- *   BETA   - (input) complex
+ *   BETA   - (input) singlecomplex
  *            On entry, BETA specifies the scalar beta. When BETA is   
  *            supplied as zero then Y need not be set on input.   
  *
- *   Y      - (output) complex*,  array of DIMENSION at least   
+ *   Y      - (output) singlecomplex*,  array of DIMENSION at least   
  *            ( 1 + ( m - 1 )*abs( INCY ) ) when TRANS = 'N' or 'n'   
  *            and at least   
  *            ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.   
@@ -459,20 +459,20 @@ sp_ctrsv(char *uplo, char *trans, char *diag, SuperMatrix *L,
  * </pre>
 */
 int
-sp_cgemv(char *trans, complex alpha, SuperMatrix *A, complex *x, 
-	 int incx, complex beta, complex *y, int incy)
+sp_cgemv(char *trans, singlecomplex alpha, SuperMatrix *A, singlecomplex *x, 
+	 int incx, singlecomplex beta, singlecomplex *y, int incy)
 {
 
     /* Local variables */
     NCformat *Astore;
-    complex   *Aval;
+    singlecomplex   *Aval;
     int info;
-    complex temp, temp1;
+    singlecomplex temp, temp1;
     int lenx, leny, i, j, irow;
     int iy, jx, jy, kx, ky;
     int notran;
-    complex comp_zero = {0.0, 0.0};
-    complex comp_one = {1.0, 0.0};
+    singlecomplex comp_zero = {0.0, 0.0};
+    singlecomplex comp_one = {1.0, 0.0};
 
     notran = ( strncmp(trans, "N", 1)==0 || strncmp(trans, "n", 1)==0 );
     Astore = A->Store;
@@ -574,7 +574,7 @@ sp_cgemv(char *trans, complex alpha, SuperMatrix *A, complex *x,
 	}
     } else { /* trans == 'C' or 'c' */
 	/* Form  y := alpha * conj(A) * x + y. */
-	complex temp2;
+	singlecomplex temp2;
 	jy = ky;
 	if (incx == 1) {
 	    for (j = 0; j < A->ncol; ++j) {

--- a/SRC/csp_blas3.c
+++ b/SRC/csp_blas3.c
@@ -80,7 +80,7 @@ at the top-level directory.
  *	     be at least  zero.   
  *           Unchanged on exit.
  *      
- *   ALPHA  - (input) complex
+ *   ALPHA  - (input) singlecomplex
  *            On entry, ALPHA specifies the scalar alpha.   
  * 
  *   A      - (input) SuperMatrix*
@@ -102,7 +102,7 @@ at the top-level directory.
  *            in the calling (sub) program. LDB must be at least max( 1, n ).  
  *            Unchanged on exit.   
  * 
- *   BETA   - (input) complex
+ *   BETA   - (input) singlecomplex
  *            On entry, BETA specifies the scalar beta. When BETA is   
  *            supplied as zero then C need not be set on input.   
  *  
@@ -124,8 +124,8 @@ at the top-level directory.
 
 int
 sp_cgemm(char *transa, char *transb, int m, int n, int k, 
-         complex alpha, SuperMatrix *A, complex *b, int ldb, 
-         complex beta, complex *c, int ldc)
+         singlecomplex alpha, SuperMatrix *A, singlecomplex *b, int ldb, 
+         singlecomplex beta, singlecomplex *c, int ldc)
 {
     int    incx = 1, incy = 1;
     int    j;

--- a/SRC/cutil.c
+++ b/SRC/cutil.c
@@ -37,7 +37,7 @@ at the top-level directory.
 
 void
 cCreate_CompCol_Matrix(SuperMatrix *A, int m, int n, int_t nnz, 
-		       complex *nzval, int_t *rowind, int_t *colptr,
+		       singlecomplex *nzval, int_t *rowind, int_t *colptr,
 		       Stype_t stype, Dtype_t dtype, Mtype_t mtype)
 {
     NCformat *Astore;
@@ -58,7 +58,7 @@ cCreate_CompCol_Matrix(SuperMatrix *A, int m, int n, int_t nnz,
 
 void
 cCreate_CompRow_Matrix(SuperMatrix *A, int m, int n, int_t nnz, 
-		       complex *nzval, int_t *colind, int_t *rowptr,
+		       singlecomplex *nzval, int_t *colind, int_t *rowptr,
 		       Stype_t stype, Dtype_t dtype, Mtype_t mtype)
 {
     NRformat *Astore;
@@ -93,14 +93,14 @@ cCopy_CompCol_Matrix(SuperMatrix *A, SuperMatrix *B)
     Bstore   = (NCformat *) B->Store;
     Bstore->nnz = nnz = Astore->nnz;
     for (i = 0; i < nnz; ++i)
-	((complex *)Bstore->nzval)[i] = ((complex *)Astore->nzval)[i];
+	((singlecomplex *)Bstore->nzval)[i] = ((singlecomplex *)Astore->nzval)[i];
     for (i = 0; i < nnz; ++i) Bstore->rowind[i] = Astore->rowind[i];
     for (i = 0; i <= ncol; ++i) Bstore->colptr[i] = Astore->colptr[i];
 }
 
 
 void
-cCreate_Dense_Matrix(SuperMatrix *X, int m, int n, complex *x, int ldx,
+cCreate_Dense_Matrix(SuperMatrix *X, int m, int n, singlecomplex *x, int ldx,
 		    Stype_t stype, Dtype_t dtype, Mtype_t mtype)
 {
     DNformat    *Xstore;
@@ -114,12 +114,12 @@ cCreate_Dense_Matrix(SuperMatrix *X, int m, int n, complex *x, int ldx,
     if ( !(X->Store) ) ABORT("SUPERLU_MALLOC fails for X->Store");
     Xstore = (DNformat *) X->Store;
     Xstore->lda = ldx;
-    Xstore->nzval = (complex *) x;
+    Xstore->nzval = (singlecomplex *) x;
 }
 
 void
-cCopy_Dense_Matrix(int M, int N, complex *X, int ldx,
-			complex *Y, int ldy)
+cCopy_Dense_Matrix(int M, int N, singlecomplex *X, int ldx,
+			singlecomplex *Y, int ldy)
 {
 /*! \brief Copies a two-dimensional matrix X to another matrix Y.
  */
@@ -132,7 +132,7 @@ cCopy_Dense_Matrix(int M, int N, complex *X, int ldx,
 
 void
 cCreate_SuperNode_Matrix(SuperMatrix *L, int m, int n, int_t nnz, 
-			complex *nzval, int_t *nzval_colptr, int_t *rowind,
+			singlecomplex *nzval, int_t *nzval_colptr, int_t *rowind,
 			int_t *rowind_colptr, int *col_to_sup, int *sup_to_col,
 			Stype_t stype, Dtype_t dtype, Mtype_t mtype)
 {
@@ -162,14 +162,14 @@ cCreate_SuperNode_Matrix(SuperMatrix *L, int m, int n, int_t nnz,
  */
 void
 cCompRow_to_CompCol(int m, int n, int_t nnz, 
-		    complex *a, int_t *colind, int_t *rowptr,
-		    complex **at, int_t **rowind, int_t **colptr)
+		    singlecomplex *a, int_t *colind, int_t *rowptr,
+		    singlecomplex **at, int_t **rowind, int_t **colptr)
 {
     register int i, j, col, relpos;
     int_t *marker;
 
     /* Allocate storage for another copy of the matrix. */
-    *at = (complex *) complexMalloc(nnz);
+    *at = (singlecomplex *) complexMalloc(nnz);
     *rowind = (int_t *) intMalloc(nnz);
     *colptr = (int_t *) intMalloc(n+1);
     marker = (int_t *) intCalloc(n);
@@ -301,18 +301,18 @@ cprint_lu_col(char *msg, int jcol, int pivrow, int_t *xprune, GlobalLU_t *Glu)
     int_t    i, k;
     int     *xsup, *supno, fsupc;
     int_t   *xlsub, *lsub;
-    complex  *lusup;
+    singlecomplex  *lusup;
     int_t   *xlusup;
-    complex  *ucol;
+    singlecomplex  *ucol;
     int_t   *usub, *xusub;
 
     xsup    = Glu->xsup;
     supno   = Glu->supno;
     lsub    = Glu->lsub;
     xlsub   = Glu->xlsub;
-    lusup   = (complex *) Glu->lusup;
+    lusup   = (singlecomplex *) Glu->lusup;
     xlusup  = Glu->xlusup;
-    ucol    = (complex *) Glu->ucol;
+    ucol    = (singlecomplex *) Glu->ucol;
     usub    = Glu->usub;
     xusub   = Glu->xusub;
     
@@ -337,7 +337,7 @@ cprint_lu_col(char *msg, int jcol, int pivrow, int_t *xprune, GlobalLU_t *Glu)
 
 /*! \brief Check whether tempv[] == 0. This should be true before and after calling any numeric routines, i.e., "panel_bmod" and "column_bmod". 
  */
-void ccheck_tempv(int n, complex *tempv)
+void ccheck_tempv(int n, singlecomplex *tempv)
 {
     int i;
 	
@@ -352,7 +352,7 @@ void ccheck_tempv(int n, complex *tempv)
 
 
 void
-cGenXtrue(int n, int nrhs, complex *x, int ldx)
+cGenXtrue(int n, int nrhs, singlecomplex *x, int ldx)
 {
     int  i, j;
     for (j = 0; j < nrhs; ++j)
@@ -365,18 +365,18 @@ cGenXtrue(int n, int nrhs, complex *x, int ldx)
 /*! \brief Let rhs[i] = sum of i-th row of A, so the solution vector is all 1's
  */
 void
-cFillRHS(trans_t trans, int nrhs, complex *x, int ldx,
+cFillRHS(trans_t trans, int nrhs, singlecomplex *x, int ldx,
          SuperMatrix *A, SuperMatrix *B)
 {
     DNformat *Bstore;
-    complex   *rhs;
-    complex one = {1.0, 0.0};
-    complex zero = {0.0, 0.0};
+    singlecomplex   *rhs;
+    singlecomplex one = {1.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
     int      ldc;
     char transc[1];
 
     //Astore = A->Store;
-    //Aval   = (complex *) Astore->nzval;
+    //Aval   = (singlecomplex *) Astore->nzval;
     Bstore = B->Store;
     rhs    = Bstore->nzval;
     ldc    = Bstore->lda;
@@ -392,7 +392,7 @@ cFillRHS(trans_t trans, int nrhs, complex *x, int ldx,
 /*! \brief Fills a complex precision array with a given value.
  */
 void 
-cfill(complex *a, int alen, complex dval)
+cfill(singlecomplex *a, int alen, singlecomplex dval)
 {
     register int i;
     for (i = 0; i < alen; i++) a[i] = dval;
@@ -402,12 +402,12 @@ cfill(complex *a, int alen, complex dval)
 
 /*! \brief Check the inf-norm of the error vector 
  */
-void cinf_norm_error(int nrhs, SuperMatrix *X, complex *xtrue)
+void cinf_norm_error(int nrhs, SuperMatrix *X, singlecomplex *xtrue)
 {
     DNformat *Xstore;
     float err, xnorm;
-    complex *Xmat, *soln_work;
-    complex temp;
+    singlecomplex *Xmat, *soln_work;
+    singlecomplex temp;
     int i, j;
 
     Xstore = X->Store;
@@ -474,7 +474,7 @@ cPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 int
-print_complex_vec(char *what, int n, complex *vec)
+print_complex_vec(char *what, int n, singlecomplex *vec)
 {
     int i;
     printf("%s: n %d\n", what, n);

--- a/SRC/icmax1.c
+++ b/SRC/icmax1.c
@@ -51,7 +51,7 @@ at the top-level directory.
    ===================================================================== 
   </pre>
 */
-int icmax1_slu(int *n, complex *cx, int *incx)
+int icmax1_slu(int *n, singlecomplex *cx, int *incx)
 {
 /*
        NEXT LINE IS THE ONLY MODIFICATION.   

--- a/SRC/ilu_ccopy_to_ucol.c
+++ b/SRC/ilu_ccopy_to_ucol.c
@@ -26,10 +26,10 @@ at the top-level directory.
 int num_drop_U;
 #endif
 
-extern void ccopy_(int *, complex [], int *, complex [], int *);
+extern void ccopy_(int *, singlecomplex [], int *, singlecomplex [], int *);
 
 #if 0
-static complex *A;  /* used in _compare_ only */
+static singlecomplex *A;  /* used in _compare_ only */
 static int _compare_(const void *a, const void *b)
 {
     register int *x = (int *)a, *y = (int *)b;
@@ -47,12 +47,12 @@ ilu_ccopy_to_ucol(
 	      int	 *segrep,  /* in */
 	      int	 *repfnz,  /* in */
 	      int	 *perm_r,  /* in */
-	      complex	 *dense,   /* modified - reset to zero on return */
+	      singlecomplex	 *dense,   /* modified - reset to zero on return */
 	      int  	 drop_rule,/* in */
 	      milu_t	 milu,	   /* in */
 	      double	 drop_tol, /* in */
 	      int	 quota,    /* maximum nonzero entries allowed */
-	      complex	 *sum,	   /* out - the sum of dropped entries */
+	      singlecomplex	 *sum,	   /* out - the sum of dropped entries */
 	      int	 *nnzUj,   /* in - out */
 	      GlobalLU_t *Glu,	   /* modified */
 	      float	 *work	   /* working space with minimum size n,
@@ -69,20 +69,20 @@ ilu_ccopy_to_ucol(
     int_t     new_next, nextu, mem_error;
     int       *xsup, *supno;
     int_t     *lsub, *xlsub;
-    complex    *ucol;
+    singlecomplex    *ucol;
     int_t     *usub, *xusub;
     int_t     nzumax;
     int       m; /* number of entries in the nonzero U-segments */
     register float d_max = 0.0, d_min = 1.0 / smach("Safe minimum");
     register double tmp;
-    complex zero = {0.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
     int i_1 = 1;
 
     xsup    = Glu->xsup;
     supno   = Glu->supno;
     lsub    = Glu->lsub;
     xlsub   = Glu->xlsub;
-    ucol    = (complex *) Glu->ucol;
+    ucol    = (singlecomplex *) Glu->ucol;
     usub    = Glu->usub;
     xusub   = Glu->xusub;
     nzumax  = Glu->nzumax;

--- a/SRC/ilu_cdrop_row.c
+++ b/SRC/ilu_cdrop_row.c
@@ -23,14 +23,14 @@ at the top-level directory.
 #include <stdlib.h>
 #include "slu_cdefs.h"
 
-extern void cswap_(int *, complex [], int *, complex [], int *);
-extern void caxpy_(int *, complex *, complex [], int *, complex [], int *);
-extern void ccopy_(int *, complex [], int *, complex [], int *);
+extern void cswap_(int *, singlecomplex [], int *, singlecomplex [], int *);
+extern void caxpy_(int *, singlecomplex *, singlecomplex [], int *, singlecomplex [], int *);
+extern void ccopy_(int *, singlecomplex [], int *, singlecomplex [], int *);
 extern void scopy_(int *, float [], int *, float [], int *);
-extern float scasum_(int *, complex *, int *);
-extern float scnrm2_(int *, complex *, int *);
+extern float scasum_(int *, singlecomplex *, int *);
+extern float scnrm2_(int *, singlecomplex *, int *);
 extern double dnrm2_(int *, double [], int *);
-extern int icamax_(int *, complex [], int *);
+extern int icamax_(int *, singlecomplex [], int *);
 
 #if 0
 static float *A;  /* used in _compare_ only */
@@ -77,7 +77,7 @@ int ilu_cdrop_row(
     int m, n; /* m x n is the size of the supernode */
     int r = 0; /* number of dropped rows */
     register float *temp;
-    register complex *lusup = (complex *) Glu->lusup;
+    register singlecomplex *lusup = (singlecomplex *) Glu->lusup;
     int_t *lsub = Glu->lsub;
     int_t *xlsub = Glu->xlsub;
     int_t *xlusup = Glu->xlusup;
@@ -85,8 +85,8 @@ int ilu_cdrop_row(
     int    drop_rule = options->ILU_DropRule;
     milu_t milu = options->ILU_MILU;
     norm_t nrm = options->ILU_Norm;
-    complex one = {1.0, 0.0};
-    complex none = {-1.0, 0.0};
+    singlecomplex one = {1.0, 0.0};
+    singlecomplex none = {-1.0, 0.0};
     int i_1 = 1;
     int inc_diag; /* inc_diag = m + 1 */
     int nzp = 0;  /* number of zero pivots */
@@ -271,7 +271,7 @@ int ilu_cdrop_row(
     if (milu != SILU)
     {
 	register int j;
-	complex t;
+	singlecomplex t;
 	float omega;
 	for (j = 0; j < n; j++)
 	{

--- a/SRC/ilu_cpanel_dfs.c
+++ b/SRC/ilu_cpanel_dfs.c
@@ -60,7 +60,7 @@ ilu_cpanel_dfs(
    SuperMatrix *A,	   /* in - original matrix */
    int	      *perm_r,	   /* in */
    int	      *nseg,	   /* out */
-   complex     *dense,	   /* out */
+   singlecomplex     *dense,	   /* out */
    float     *amax,	   /* out - max. abs. value of each column in panel */
    int	      *panel_lsub, /* out */
    int	      *segrep,	   /* out */
@@ -73,7 +73,7 @@ ilu_cpanel_dfs(
 {
 
     NCPformat *Astore;
-    complex    *a;
+    singlecomplex    *a;
     int_t     *asub;
     int_t     *xa_begin, *xa_end;
     int       krep, chperm, chmark, chrep, oldrep, kchild, myfnz;
@@ -83,7 +83,7 @@ ilu_cpanel_dfs(
     int       *marker1;    /* marker1[jj] >= jcol if vertex jj was visited
 			      by a previous column within this panel. */
     int       *repfnz_col; /* start of each column in the panel */
-    complex    *dense_col;  /* start of each column in the panel */
+    singlecomplex    *dense_col;  /* start of each column in the panel */
     int_t     nextl_col;   /* next available position in panel_lsub[*,jj] */
     int       *xsup, *supno;
     int_t     *lsub, *xlsub;

--- a/SRC/ilu_cpivotL.c
+++ b/SRC/ilu_cpivotL.c
@@ -68,7 +68,7 @@ ilu_cpivotL(
 	double	   fill_tol, /* in - fill tolerance of current column
 			      * used for a singular column */
 	milu_t	   milu,     /* in */
-	complex	   drop_sum, /* in - computed in ilu_ccopy_to_ucol()
+	singlecomplex	   drop_sum, /* in - computed in ilu_ccopy_to_ucol()
                                 (MILU only) */
 	GlobalLU_t *Glu,     /* modified - global LU data structures */
 	SuperLUStat_t *stat  /* output */
@@ -84,23 +84,23 @@ ilu_cpivotL(
     int		 old_pivptr, diag, ptr0;
     register float  pivmax, rtemp;
     float	 thresh;
-    complex	 temp;
-    complex	 *lu_sup_ptr;
-    complex	 *lu_col_ptr;
+    singlecomplex	 temp;
+    singlecomplex	 *lu_sup_ptr;
+    singlecomplex	 *lu_col_ptr;
     int_t	 *lsub_ptr;
     register int	 isub, icol, k, itemp;
     int_t	 *lsub, *xlsub;
-    complex	 *lusup;
+    singlecomplex	 *lusup;
     int_t	 *xlusup;
     flops_t	 *ops = stat->ops;
     int		 info;
-    complex one = {1.0, 0.0};
+    singlecomplex one = {1.0, 0.0};
 
     /* Initialize pointers */
     n	       = Glu->n;
     lsub       = Glu->lsub;
     xlsub      = Glu->xlsub;
-    lusup      = (complex *) Glu->lusup;
+    lusup      = (singlecomplex *) Glu->lusup;
     xlusup     = Glu->xlusup;
     fsupc      = (Glu->xsup)[(Glu->supno)[jcol]];
     nsupc      = jcol - fsupc;		/* excluding jcol; nsupc >= 0 */

--- a/SRC/scomplex.c
+++ b/SRC/scomplex.c
@@ -29,7 +29,7 @@ at the top-level directory.
 
 
 /*! \brief Complex Division c = a/b */
-void c_div(complex *c, complex *a, complex *b)
+void c_div(singlecomplex *c, singlecomplex *a, singlecomplex *b)
 {
     float ratio, den;
     float abr, abi, cr, ci;
@@ -59,7 +59,7 @@ void c_div(complex *c, complex *a, complex *b)
 
 
 /*! \brief Returns sqrt(z.r^2 + z.i^2) */
-double c_abs(complex *z)
+double c_abs(singlecomplex *z)
 {
     float temp;
     float real = z->r;
@@ -81,7 +81,7 @@ double c_abs(complex *z)
 
 
 /*! \brief Approximates the abs. Returns abs(z.r) + abs(z.i) */
-double c_abs1(complex *z)
+double c_abs1(singlecomplex *z)
 {
     float real = z->r;
     float imag = z->i;
@@ -93,7 +93,7 @@ double c_abs1(complex *z)
 }
 
 /*! \brief Return the exponentiation */
-void c_exp(complex *r, complex *z)
+void c_exp(singlecomplex *r, singlecomplex *z)
 {
     float expx;
 
@@ -103,24 +103,24 @@ void c_exp(complex *r, complex *z)
 }
 
 /*! \brief Return the complex conjugate */
-void r_cnjg(complex *r, complex *z)
+void r_cnjg(singlecomplex *r, singlecomplex *z)
 {
     r->r = z->r;
     r->i = -z->i;
 }
 
 /*! \brief Return the imaginary part */
-double r_imag(complex *z)
+double r_imag(singlecomplex *z)
 {
     return (z->i);
 }
 
 
 /*! \brief SIGN functions for complex number. Returns z/abs(z) */
-complex c_sgn(complex *z)
+singlecomplex c_sgn(singlecomplex *z)
 {
     register float t = c_abs(z);
-    register complex retval;
+    register singlecomplex retval;
 
     if (t == 0.0) {
 	retval.r = 1.0, retval.i = 0.0;
@@ -132,9 +132,9 @@ complex c_sgn(complex *z)
 }
 
 /*! \brief Square-root of a complex number. */
-complex c_sqrt(complex *z)
+singlecomplex c_sqrt(singlecomplex *z)
 {
-    complex retval;
+    singlecomplex retval;
     register float cr, ci, real, imag;
 
     real = z->r;

--- a/SRC/scsum1.c
+++ b/SRC/scsum1.c
@@ -50,12 +50,12 @@ at the top-level directory.
     ===================================================================== 
 </pre>
 */
-double scsum1_slu(int *n, complex *cx, int *incx)
+double scsum1_slu(int *n, singlecomplex *cx, int *incx)
 {
     /* System generated locals */
     float ret_val;
     /* Builtin functions */
-    double c_abs(complex *);
+    double c_abs(singlecomplex *);
     /* Local variables */
     int i, nincx;
     float stemp;

--- a/SRC/slu_cdefs.h
+++ b/SRC/slu_cdefs.h
@@ -126,54 +126,54 @@ cgsisx(superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
 
 /*! \brief Supernodal LU factor related */
 extern void
-cCreate_CompCol_Matrix(SuperMatrix *, int, int, int_t, complex *,
+cCreate_CompCol_Matrix(SuperMatrix *, int, int, int_t, singlecomplex *,
 		       int_t *, int_t *, Stype_t, Dtype_t, Mtype_t);
 extern void
-cCreate_CompRow_Matrix(SuperMatrix *, int, int, int_t, complex *,
+cCreate_CompRow_Matrix(SuperMatrix *, int, int, int_t, singlecomplex *,
 		       int_t *, int_t *, Stype_t, Dtype_t, Mtype_t);
-extern void cCompRow_to_CompCol(int, int, int_t, complex*, int_t*, int_t*,
-		                   complex **, int_t **, int_t **);
+extern void cCompRow_to_CompCol(int, int, int_t, singlecomplex*, int_t*, int_t*,
+		                   singlecomplex **, int_t **, int_t **);
 extern void
 cCopy_CompCol_Matrix(SuperMatrix *, SuperMatrix *);
 extern void
-cCreate_Dense_Matrix(SuperMatrix *, int, int, complex *, int,
+cCreate_Dense_Matrix(SuperMatrix *, int, int, singlecomplex *, int,
 		     Stype_t, Dtype_t, Mtype_t);
 extern void
-cCreate_SuperNode_Matrix(SuperMatrix *, int, int, int_t, complex *, 
+cCreate_SuperNode_Matrix(SuperMatrix *, int, int, int_t, singlecomplex *, 
 		         int_t *, int_t *, int_t *, int *, int *,
 			 Stype_t, Dtype_t, Mtype_t);
 extern void
-cCopy_Dense_Matrix(int, int, complex *, int, complex *, int);
+cCopy_Dense_Matrix(int, int, singlecomplex *, int, singlecomplex *, int);
 
-extern void    callocateA (int, int_t, complex **, int_t **, int_t **);
+extern void    callocateA (int, int_t, singlecomplex **, int_t **, int_t **);
 extern void    cgstrf (superlu_options_t*, SuperMatrix*,
                        int, int, int*, void *, int_t, int *, int *, 
                        SuperMatrix *, SuperMatrix *, GlobalLU_t *,
 		       SuperLUStat_t*, int_t *info);
 extern int_t   csnode_dfs (const int, const int, const int_t *, const int_t *,
 			     const int_t *, int_t *, int *, GlobalLU_t *);
-extern int     csnode_bmod (const int, const int, const int, complex *,
-                              complex *, GlobalLU_t *, SuperLUStat_t*);
+extern int     csnode_bmod (const int, const int, const int, singlecomplex *,
+                              singlecomplex *, GlobalLU_t *, SuperLUStat_t*);
 extern void    cpanel_dfs (const int, const int, const int, SuperMatrix *,
-			   int *, int *, complex *, int *, int *, int *,
+			   int *, int *, singlecomplex *, int *, int *, int *,
 			   int_t *, int *, int *, int_t *, GlobalLU_t *);
 extern void    cpanel_bmod (const int, const int, const int, const int,
-                           complex *, complex *, int *, int *,
+                           singlecomplex *, singlecomplex *, int *, int *,
 			   GlobalLU_t *, SuperLUStat_t*);
 extern int     ccolumn_dfs (const int, const int, int *, int *, int *, int *,
 			   int *, int_t *, int *, int *, int_t *, GlobalLU_t *);
-extern int     ccolumn_bmod (const int, const int, complex *,
-			   complex *, int *, int *, int,
+extern int     ccolumn_bmod (const int, const int, singlecomplex *,
+			   singlecomplex *, int *, int *, int,
                            GlobalLU_t *, SuperLUStat_t*);
 extern int     ccopy_to_ucol (int, int, int *, int *, int *,
-                              complex *, GlobalLU_t *);         
+                              singlecomplex *, GlobalLU_t *);         
 extern int     cpivotL (const int, const double, int *, int *, 
                          int *, int *, int *, GlobalLU_t *, SuperLUStat_t*);
 extern void    cpruneL (const int, const int *, const int, const int,
 			  const int *, const int *, int_t *, GlobalLU_t *);
-extern void    creadmt (int *, int *, int_t *, complex **, int_t **, int_t **);
-extern void    cGenXtrue (int, int, complex *, int);
-extern void    cFillRHS (trans_t, int, complex *, int, SuperMatrix *,
+extern void    creadmt (int *, int *, int_t *, singlecomplex **, int_t **, int_t **);
+extern void    cGenXtrue (int, int, singlecomplex *, int);
+extern void    cFillRHS (trans_t, int, singlecomplex *, int, SuperMatrix *,
 			  SuperMatrix *);
 extern void    cgstrs (trans_t, SuperMatrix *, SuperMatrix *, int *, int *,
                         SuperMatrix *, SuperLUStat_t*, int *);
@@ -181,21 +181,21 @@ extern void    cgstrs (trans_t, SuperMatrix *, SuperMatrix *, int *, int *,
 extern void    cgsitrf (superlu_options_t*, SuperMatrix*, int, int, int*,
 		        void *, int_t, int *, int *, SuperMatrix *, SuperMatrix *,
                         GlobalLU_t *, SuperLUStat_t*, int_t *info);
-extern int     cldperm(int, int, int_t, int_t [], int_t [], complex [],
+extern int     cldperm(int, int, int_t, int_t [], int_t [], singlecomplex [],
                         int [],	float [], float []);
 extern int     ilu_csnode_dfs (const int, const int, const int_t *, const int_t *,
 			       const int_t *, int *, GlobalLU_t *);
 extern void    ilu_cpanel_dfs (const int, const int, const int, SuperMatrix *,
-			       int *, int *, complex *, float *, int *, int *,
+			       int *, int *, singlecomplex *, float *, int *, int *,
 			       int *, int *, int *, int_t *, GlobalLU_t *);
 extern int     ilu_ccolumn_dfs (const int, const int, int *, int *, int *,
 				int *, int *, int *, int *, int_t *, GlobalLU_t *);
 extern int     ilu_ccopy_to_ucol (int, int, int *, int *, int *,
-                                  complex *, int, milu_t, double, int,
-                                  complex *, int *, GlobalLU_t *, float *);
+                                  singlecomplex *, int, milu_t, double, int,
+                                  singlecomplex *, int *, GlobalLU_t *, float *);
 extern int     ilu_cpivotL (const int, const double, int *, int *, int, int *,
 			    int *, int *, int *, double, milu_t,
-                            complex, GlobalLU_t *, SuperLUStat_t*);
+                            singlecomplex, GlobalLU_t *, SuperLUStat_t*);
 extern int     ilu_cdrop_row (superlu_options_t *, int, int, double,
                               int, int *, double *, GlobalLU_t *, 
                               float *, float *, int);
@@ -217,25 +217,25 @@ extern void    cgsrfs (trans_t, SuperMatrix *, SuperMatrix *,
                        float *, float *, SuperLUStat_t*, int *);
 
 extern int     sp_ctrsv (char *, char *, char *, SuperMatrix *,
-			SuperMatrix *, complex *, SuperLUStat_t*, int *);
-extern int     sp_cgemv (char *, complex, SuperMatrix *, complex *,
-			int, complex, complex *, int);
+			SuperMatrix *, singlecomplex *, SuperLUStat_t*, int *);
+extern int     sp_cgemv (char *, singlecomplex, SuperMatrix *, singlecomplex *,
+			int, singlecomplex, singlecomplex *, int);
 
-extern int     sp_cgemm (char *, char *, int, int, int, complex,
-			SuperMatrix *, complex *, int, complex, 
-			complex *, int);
+extern int     sp_cgemm (char *, char *, int, int, int, singlecomplex,
+			SuperMatrix *, singlecomplex *, int, singlecomplex, 
+			singlecomplex *, int);
 extern         float smach(char *);   /* from C99 standard, in float.h */
 
 /*! \brief Memory-related */
 extern int_t   cLUMemInit (fact_t, void *, int_t, int, int, int_t, int,
                             float, SuperMatrix *, SuperMatrix *,
-                            GlobalLU_t *, int **, complex **);
-extern void    cSetRWork (int, int, complex *, complex **, complex **);
-extern void    cLUWorkFree (int *, complex *, GlobalLU_t *);
+                            GlobalLU_t *, int **, singlecomplex **);
+extern void    cSetRWork (int, int, singlecomplex *, singlecomplex **, singlecomplex **);
+extern void    cLUWorkFree (int *, singlecomplex *, GlobalLU_t *);
 extern int_t   cLUMemXpand (int, int_t, MemType, int_t *, GlobalLU_t *);
 
-extern complex  *complexMalloc(size_t);
-extern complex  *complexCalloc(size_t);
+extern singlecomplex  *complexMalloc(size_t);
+extern singlecomplex  *complexCalloc(size_t);
 extern float  *floatMalloc(size_t);
 extern float  *floatCalloc(size_t);
 extern int_t   cmemory_usage(const int_t, const int_t, const int_t, const int);
@@ -243,12 +243,12 @@ extern int     cQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 extern int     ilu_cQuerySpace (SuperMatrix *, SuperMatrix *, mem_usage_t *);
 
 /*! \brief Auxiliary routines */
-extern void    creadhb(FILE *, int *, int *, int_t *, complex **, int_t **, int_t **);
-extern void    creadrb(int *, int *, int_t *, complex **, int_t **, int_t **);
-extern void    creadtriple(int *, int *, int_t *, complex **, int_t **, int_t **);
-extern void    creadMM(FILE *, int *, int *, int_t *, complex **, int_t **, int_t **);
-extern void    cfill (complex *, int, complex);
-extern void    cinf_norm_error (int, SuperMatrix *, complex *);
+extern void    creadhb(FILE *, int *, int *, int_t *, singlecomplex **, int_t **, int_t **);
+extern void    creadrb(int *, int *, int_t *, singlecomplex **, int_t **, int_t **);
+extern void    creadtriple(int *, int *, int_t *, singlecomplex **, int_t **, int_t **);
+extern void    creadMM(FILE *, int *, int *, int_t *, singlecomplex **, int_t **, int_t **);
+extern void    cfill (singlecomplex *, int, singlecomplex);
+extern void    cinf_norm_error (int, SuperMatrix *, singlecomplex *);
 extern float  sqselect(int, float *, int);
 
 
@@ -258,23 +258,23 @@ extern void    cPrint_SuperNode_Matrix(char *, SuperMatrix *);
 extern void    cPrint_Dense_Matrix(char *, SuperMatrix *);
 extern void    cprint_lu_col(char *, int, int, int_t *, GlobalLU_t *);
 extern int     print_double_vec(char *, int, double *);
-extern void    ccheck_tempv(int, complex *);
+extern void    ccheck_tempv(int, singlecomplex *);
 
 /*! \brief BLAS */
 
 extern int cgemm_(const char*, const char*, const int*, const int*, const int*,
-                  const complex*, const complex*, const int*, const complex*,
-		  const int*, const complex*, complex*, const int*);
-extern int ctrsv_(char*, char*, char*, int*, complex*, int*,
-                  complex*, int*);
+                  const singlecomplex*, const singlecomplex*, const int*, const singlecomplex*,
+		  const int*, const singlecomplex*, singlecomplex*, const int*);
+extern int ctrsv_(char*, char*, char*, int*, singlecomplex*, int*,
+                  singlecomplex*, int*);
 extern int ctrsm_(char*, char*, char*, char*, int*, int*,
-                  complex*, complex*, int*, complex*, int*);
-extern int cgemv_(char *, int *, int *, complex *, complex *a, int *,
-                  complex *, int *, complex *, complex *, int *);
+                  singlecomplex*, singlecomplex*, int*, singlecomplex*, int*);
+extern int cgemv_(char *, int *, int *, singlecomplex *, singlecomplex *a, int *,
+                  singlecomplex *, int *, singlecomplex *, singlecomplex *, int *);
 
-extern void cusolve(int, int, complex*, complex*);
-extern void clsolve(int, int, complex*, complex*);
-extern void cmatvec(int, int, int, complex*, complex*, complex*);
+extern void cusolve(int, int, singlecomplex*, singlecomplex*);
+extern void clsolve(int, int, singlecomplex*, singlecomplex*);
+extern void cmatvec(int, int, int, singlecomplex*, singlecomplex*, singlecomplex*);
 
 #ifdef __cplusplus
   }

--- a/SRC/slu_scomplex.h
+++ b/SRC/slu_scomplex.h
@@ -28,7 +28,7 @@ at the top-level directory.
 #ifndef SCOMPLEX_INCLUDE
 #define SCOMPLEX_INCLUDE
 
-typedef struct { float r, i; } complex;
+typedef struct { float r, i; } singlecomplex;
 
 
 /* Macro definitions */
@@ -68,14 +68,14 @@ extern "C" {
 #endif
 
 /* Prototypes for functions in scomplex.c */
-void c_div(complex *, complex *, complex *);
-double c_abs(complex *);     /* exact */
-double c_abs1(complex *);    /* approximate */
-void c_exp(complex *, complex *);
-void r_cnjg(complex *, complex *);
-double r_imag(complex *);
-complex c_sgn(complex *);
-complex c_sqrt(complex *);
+void c_div(singlecomplex *, singlecomplex *, singlecomplex *);
+double c_abs(singlecomplex *);     /* exact */
+double c_abs1(singlecomplex *);    /* approximate */
+void c_exp(singlecomplex *, singlecomplex *);
+void r_cnjg(singlecomplex *, singlecomplex *);
+double r_imag(singlecomplex *);
+singlecomplex c_sgn(singlecomplex *);
+singlecomplex c_sqrt(singlecomplex *);
 
 
 

--- a/SRC/superlu_config.h
+++ b/SRC/superlu_config.h
@@ -9,7 +9,7 @@
 /* #undef HAVE_COLAMD */
 
 /* enable 64bit index mode */
-#define XSDK_INDEX_SIZE 64
+/* #undef XSDK_INDEX_SIZE */
 
 /* Integer type for indexing sparse matrix meta structure */
 #if (XSDK_INDEX_SIZE == 64)

--- a/TESTING/MATGEN/cdotc.c
+++ b/TESTING/MATGEN/cdotc.c
@@ -1,19 +1,19 @@
 /*  -- translated by f2c (version 19940927).
 */
 
-/* Complex */ void cdotc_(complex * ret_val, int *n, complex *cx, int
-	*incx, complex *cy, int *incy)
+/* Complex */ void cdotc_(singlecomplex * ret_val, int *n, singlecomplex *cx, int
+	*incx, singlecomplex *cy, int *incy)
 {
     /* System generated locals */
     int i__1, i__2;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int i;
-    static complex ctemp;
+    static singlecomplex ctemp;
     static int ix, iy;
 
 

--- a/TESTING/MATGEN/clacgv.c
+++ b/TESTING/MATGEN/clacgv.c
@@ -1,6 +1,6 @@
 #include "../../SRC/slu_scomplex.h"
 
-/* Subroutine */ int clacgv_slu(int *n, complex *x, int *incx)
+/* Subroutine */ int clacgv_slu(int *n, singlecomplex *x, int *incx)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -11,7 +11,7 @@
     Purpose   
     =======   
 
-    CLACGV conjugates a complex vector of length N.   
+    CLACGV conjugates a singlecomplex vector of length N.   
 
     Arguments   
     =========   
@@ -35,9 +35,9 @@
    Parameter adjustments   
        Function Body */
     /* System generated locals */
-    complex q__1;
+    singlecomplex q__1;
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
     /* Local variables */
     static int ioff, i;
 

--- a/TESTING/MATGEN/clagge.c
+++ b/TESTING/MATGEN/clagge.c
@@ -6,38 +6,38 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
-static complex c_b2 = {1.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
+static singlecomplex c_b2 = {1.f,0.f};
 static int c__3 = 3;
 static int c__1 = 1;
 
 /* Subroutine */ int clagge_slu(int *m, int *n, int *kl, int *ku,
-	 float *d, complex *a, int *lda, int *iseed, complex *work,
+	 float *d, singlecomplex *a, int *lda, int *iseed, singlecomplex *work,
 	int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1, i__2, i__3;
     double d__1;
-    complex q__1;
+    singlecomplex q__1;
 
     /* Builtin functions */
-    double c_abs(complex *);
-    void c_div(complex *, complex *, complex *);
+    double c_abs(singlecomplex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int i, j;
-    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, int *),
-	     cscal_(int *, complex *, complex *, int *), cgemv_(char *
-	    , int *, int *, complex *, complex *, int *, complex *
-	    , int *, complex *, complex *, int *);
-    extern float scnrm2_(int *, complex *, int *);
-    static complex wa, wb;
-    extern /* Subroutine */ int clacgv_slu(int *, complex *, int *);
+    extern /* Subroutine */ int cgerc_(int *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, int *),
+	     cscal_(int *, singlecomplex *, singlecomplex *, int *), cgemv_(char *
+	    , int *, int *, singlecomplex *, singlecomplex *, int *, singlecomplex *
+	    , int *, singlecomplex *, singlecomplex *, int *);
+    extern float scnrm2_(int *, singlecomplex *, int *);
+    static singlecomplex wa, wb;
+    extern /* Subroutine */ int clacgv_slu(int *, singlecomplex *, int *);
     static float wn;
-    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, singlecomplex *);
     extern int input_error(char *, int *);
-    static complex tau;
+    static singlecomplex tau;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/claghe.c
+++ b/TESTING/MATGEN/claghe.c
@@ -6,46 +6,46 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
-static complex c_b2 = {1.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
+static singlecomplex c_b2 = {1.f,0.f};
 static int c__3 = 3;
 static int c__1 = 1;
 
-/* Subroutine */ int claghe_slu(int *n, int *k, float *d, complex *a,
-	int *lda, int *iseed, complex *work, int *info)
+/* Subroutine */ int claghe_slu(int *n, int *k, float *d, singlecomplex *a,
+	int *lda, int *iseed, singlecomplex *work, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1, i__2, i__3;
     double d__1;
-    complex q__1, q__2, q__3, q__4;
+    singlecomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    double c_abs(complex *);
-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
+    double c_abs(singlecomplex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *), r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
-    extern /* Subroutine */ int cher2_(char *, int *, complex *, complex *
-	    , int *, complex *, int *, complex *, int *);
+    extern /* Subroutine */ int cher2_(char *, int *, singlecomplex *, singlecomplex *
+	    , int *, singlecomplex *, int *, singlecomplex *, int *);
     static int i, j;
-    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, int *);
-    static complex alpha;
-    extern /* Subroutine */ int cscal_(int *, complex *, complex *,
+    extern /* Subroutine */ int cgerc_(int *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, int *);
+    static singlecomplex alpha;
+    extern /* Subroutine */ int cscal_(int *, singlecomplex *, singlecomplex *,
 	    int *);
-    extern /* Complex */ void cdotc_(complex *, int *, complex *, int
-	    *, complex *, int *);
-    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
-	    , complex *, int *, complex *, int *, complex *, complex *
-	    , int *), chemv_(char *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, complex *,
-	    int *), caxpy_(int *, complex *, complex *,
-	    int *, complex *, int *);
-    extern float scnrm2_(int *, complex *, int *);
-    static complex wa, wb;
+    extern /* Complex */ void cdotc_(singlecomplex *, int *, singlecomplex *, int
+	    *, singlecomplex *, int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, singlecomplex *
+	    , singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, singlecomplex *
+	    , int *), chemv_(char *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, singlecomplex *,
+	    int *), caxpy_(int *, singlecomplex *, singlecomplex *,
+	    int *, singlecomplex *, int *);
+    extern float scnrm2_(int *, singlecomplex *, int *);
+    static singlecomplex wa, wb;
     static float wn;
-    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, singlecomplex *);
     extern int input_error(char *, int *);
-    static complex tau;
+    static singlecomplex tau;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clagsy.c
+++ b/TESTING/MATGEN/clagsy.c
@@ -6,47 +6,47 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
-static complex c_b2 = {1.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
+static singlecomplex c_b2 = {1.f,0.f};
 static int c__3 = 3;
 static int c__1 = 1;
 
-/* Subroutine */ int clagsy_slu(int *n, int *k, float *d, complex *a,
-	int *lda, int *iseed, complex *work, int *info)
+/* Subroutine */ int clagsy_slu(int *n, int *k, float *d, singlecomplex *a,
+	int *lda, int *iseed, singlecomplex *work, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6, i__7, i__8,
 	    i__9;
     double d__1;
-    complex q__1, q__2, q__3, q__4;
+    singlecomplex q__1, q__2, q__3, q__4;
 
     /* Builtin functions */
-    double c_abs(complex *);
-    void c_div(complex *, complex *, complex *);
+    double c_abs(singlecomplex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int i, j;
-    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, int *);
-    static complex alpha;
-    extern /* Subroutine */ int cscal_(int *, complex *, complex *,
+    extern /* Subroutine */ int cgerc_(int *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, int *);
+    static singlecomplex alpha;
+    extern /* Subroutine */ int cscal_(int *, singlecomplex *, singlecomplex *,
 	    int *);
-    extern /* Complex */ void cdotc_(complex *, int *, complex *, int
-	    *, complex *, int *);
-    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
-	    , complex *, int *, complex *, int *, complex *, complex *
-	    , int *), caxpy_(int *, complex *, complex *,
-	    int *, complex *, int *), csymv_sluslu(char *, int *,
-	    complex *, complex *, int *, complex *, int *, complex *,
-	    complex *, int *);
-    extern float scnrm2_(int *, complex *, int *);
+    extern /* Complex */ void cdotc_(singlecomplex *, int *, singlecomplex *, int
+	    *, singlecomplex *, int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, singlecomplex *
+	    , singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, singlecomplex *
+	    , int *), caxpy_(int *, singlecomplex *, singlecomplex *,
+	    int *, singlecomplex *, int *), csymv_sluslu(char *, int *,
+	    singlecomplex *, singlecomplex *, int *, singlecomplex *, int *, singlecomplex *,
+	    singlecomplex *, int *);
+    extern float scnrm2_(int *, singlecomplex *, int *);
     static int ii, jj;
-    static complex wa, wb;
-    extern /* Subroutine */ int clacgv_slu(int *, complex *, int *);
+    static singlecomplex wa, wb;
+    extern /* Subroutine */ int clacgv_slu(int *, singlecomplex *, int *);
     static float wn;
-    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, singlecomplex *);
     extern int input_error(char *, int *);
-    static complex tau;
+    static singlecomplex tau;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clarge.c
+++ b/TESTING/MATGEN/clarge.c
@@ -6,36 +6,36 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
-static complex c_b2 = {1.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
+static singlecomplex c_b2 = {1.f,0.f};
 static int c__3 = 3;
 static int c__1 = 1;
 
-/* Subroutine */ int clarge_slu(int *n, complex *a, int *lda, int *
-	iseed, complex *work, int *info)
+/* Subroutine */ int clarge_slu(int *n, singlecomplex *a, int *lda, int *
+	iseed, singlecomplex *work, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1;
     double d__1;
-    complex q__1;
+    singlecomplex q__1;
 
     /* Builtin functions */
-    double c_abs(complex *);
-    void c_div(complex *, complex *, complex *);
+    double c_abs(singlecomplex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int i;
-    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, int *),
-	     cscal_(int *, complex *, complex *, int *), cgemv_(char *
-	    , int *, int *, complex *, complex *, int *, complex *
-	    , int *, complex *, complex *, int *);
-    extern float scnrm2_(int *, complex *, int *);
-    static complex wa, wb;
+    extern /* Subroutine */ int cgerc_(int *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, int *),
+	     cscal_(int *, singlecomplex *, singlecomplex *, int *), cgemv_(char *
+	    , int *, int *, singlecomplex *, singlecomplex *, int *, singlecomplex *
+	    , int *, singlecomplex *, singlecomplex *, int *);
+    extern float scnrm2_(int *, singlecomplex *, int *);
+    static singlecomplex wa, wb;
     static float wn;
-    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, complex *);
+    extern /* Subroutine */ int clarnv_slu(int *, int *, int *, singlecomplex *);
     extern int input_error(char *, int *);
-    static complex tau;
+    static singlecomplex tau;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clarnd.c
+++ b/TESTING/MATGEN/clarnd.c
@@ -4,14 +4,14 @@
 #include <math.h>
 #include "../../SRC/slu_scomplex.h"
 
-/* Complex */ void clarnd_slu(complex * ret_val, int *idist, int *iseed)
+/* Complex */ void clarnd_slu(singlecomplex * ret_val, int *idist, int *iseed)
 {
     /* System generated locals */
     double d__1, d__2;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void c_exp(complex *, complex *);
+    void c_exp(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static float t1, t2;

--- a/TESTING/MATGEN/clarnv.c
+++ b/TESTING/MATGEN/clarnv.c
@@ -2,7 +2,7 @@
 #include "../../SRC/slu_sdefs.h"
 
 /* Subroutine */ int clarnv_slu(int *idist, int *iseed, int *n,
-	complex *x)
+	singlecomplex *x)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -59,9 +59,9 @@
     /* System generated locals */
     int i__2, i__3;
     double d__1, d__2;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
     /* Builtin functions */
-    void c_exp(complex *, complex *);
+    void c_exp(singlecomplex *, singlecomplex *);
     /* Local variables */
     static int i;
     static float u[128];

--- a/TESTING/MATGEN/claror.c
+++ b/TESTING/MATGEN/claror.c
@@ -7,43 +7,43 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
-static complex c_b2 = {1.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
+static singlecomplex c_b2 = {1.f,0.f};
 static int c__3 = 3;
 static int c__1 = 1;
 
 /* Subroutine */ int claror_slu(char *side, char *init, int *m, int *n,
-	complex *a, int *lda, int *iseed, complex *x, int *info)
+	singlecomplex *a, int *lda, int *iseed, singlecomplex *x, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1, i__2, i__3;
-    complex q__1, q__2;
+    singlecomplex q__1, q__2;
 
     /* Builtin functions */
-    double c_abs(complex *);
-    void r_cnjg(complex *, complex *);
+    double c_abs(singlecomplex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int kbeg, jcol;
     static float xabs;
     static int irow, j;
-    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, int *),
-	     cscal_(int *, complex *, complex *, int *);
-    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
-	    , complex *, int *, complex *, int *, complex *, complex *
+    extern /* Subroutine */ int cgerc_(int *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, int *),
+	     cscal_(int *, singlecomplex *, singlecomplex *, int *);
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, singlecomplex *
+	    , singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, singlecomplex *
 	    , int *);
-    static complex csign;
+    static singlecomplex csign;
     static int ixfrm, itype, nxfrm;
     static float xnorm;
-    extern float scnrm2_(int *, complex *, int *);
-    extern /* Subroutine */ int clacgv_slu(int *, complex *, int *);
-    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
-    extern /* Subroutine */ int claset_slu(char *, int *, int *, complex
-	    *, complex *, complex *, int *);
+    extern float scnrm2_(int *, singlecomplex *, int *);
+    extern /* Subroutine */ int clacgv_slu(int *, singlecomplex *, int *);
+    extern /* Complex */ void clarnd_slu(singlecomplex *, int *, int *);
+    extern /* Subroutine */ int claset_slu(char *, int *, int *, singlecomplex
+	    *, singlecomplex *, singlecomplex *, int *);
     extern int input_error(char *, int *);
     static float factor;
-    static complex xnorms;
+    static singlecomplex xnorms;
 
 
 /*  -- LAPACK auxiliary test routine (version 2.0) --   

--- a/TESTING/MATGEN/clarot.c
+++ b/TESTING/MATGEN/clarot.c
@@ -11,21 +11,21 @@ static int c__8 = 8;
 
 /* Subroutine */
 int clarot_slu(bool *lrows, bool *lleft, bool *lright,
-	int *nl, complex *c, complex *s, complex *a, int *lda,
-	complex *xleft, complex *xright)
+	int *nl, singlecomplex *c, singlecomplex *s, singlecomplex *a, int *lda,
+	singlecomplex *xleft, singlecomplex *xright)
 {
     /* System generated locals */
     int i__1, i__2, i__3, i__4;
-    complex q__1, q__2, q__3, q__4, q__5, q__6;
+    singlecomplex q__1, q__2, q__3, q__4, q__5, q__6;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int iinc, j, inext;
-    static complex tempx;
+    static singlecomplex tempx;
     static int ix, iy, nt;
-    static complex xt[2], yt[2];
+    static singlecomplex xt[2], yt[2];
     extern int input_error(char *, int *);
     static int iyt;
 

--- a/TESTING/MATGEN/clartg.c
+++ b/TESTING/MATGEN/clartg.c
@@ -1,7 +1,7 @@
 #include <math.h>
 #include "../../SRC/slu_scomplex.h"
 
-/* Subroutine */ int clartg_slu(complex *f, complex *g, float *cs, complex *sn, complex *r)
+/* Subroutine */ int clartg_slu(singlecomplex *f, singlecomplex *g, float *cs, singlecomplex *sn, singlecomplex *r)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
@@ -51,13 +51,13 @@
     /* System generated locals */
     float r__1, r__2;
     double d__1;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
-    double c_abs(complex *), r_imag(complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
+    double c_abs(singlecomplex *), r_imag(singlecomplex *);
     /* Local variables */
     static float d, f1, f2, g1, g2, fa, ga, di;
-    static complex fs, gs, ss;
+    static singlecomplex fs, gs, ss;
 
 
     if (g->r == 0.f && g->i == 0.f) {

--- a/TESTING/MATGEN/claset.c
+++ b/TESTING/MATGEN/claset.c
@@ -2,8 +2,8 @@
 #include "../../SRC/slu_scomplex.h"
 #include "../../SRC/slu_sdefs.h"
 
-/* Subroutine */ int claset_slu(char *uplo, int *m, int *n, complex *
-	alpha, complex *beta, complex *a, int *lda)
+/* Subroutine */ int claset_slu(char *uplo, int *m, int *n, singlecomplex *
+	alpha, singlecomplex *beta, singlecomplex *a, int *lda)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
        Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   

--- a/TESTING/MATGEN/clatm2.c
+++ b/TESTING/MATGEN/clatm2.c
@@ -3,22 +3,22 @@
 
 #include "../../SRC/slu_scomplex.h"
 
-/* Complex */ void clatm2_slu(complex * ret_val, int *m, int *n, int
+/* Complex */ void clatm2_slu(singlecomplex * ret_val, int *m, int *n, int
 	*i, int *j, int *kl, int *ku, int *idist, int *
-	iseed, complex *d, int *igrade, complex *dl, complex *dr, int
+	iseed, singlecomplex *d, int *igrade, singlecomplex *dl, singlecomplex *dr, int
 	*ipvtng, int *iwork, float *sparse)
 {
     /* System generated locals */
     int i__1, i__2;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *), r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int isub, jsub;
-    static complex ctemp;
-    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    static singlecomplex ctemp;
+    extern /* Complex */ void clarnd_slu(singlecomplex *, int *, int *);
     extern double dlaran_sluslu(int *);
 
 

--- a/TESTING/MATGEN/clatm3.c
+++ b/TESTING/MATGEN/clatm3.c
@@ -3,22 +3,22 @@
 
 #include "../../SRC/slu_scomplex.h"
 
-/* Complex */ void clatm3_slu(complex * ret_val, int *m, int *n, int
+/* Complex */ void clatm3_slu(singlecomplex * ret_val, int *m, int *n, int
 	*i, int *j, int *isub, int *jsub, int *kl, int *
-	ku, int *idist, int *iseed, complex *d, int *igrade,
-	complex *dl, complex *dr, int *ipvtng, int *iwork, float *
+	ku, int *idist, int *iseed, singlecomplex *d, int *igrade,
+	singlecomplex *dl, singlecomplex *dr, int *ipvtng, int *iwork, float *
 	sparse)
 {
     /* System generated locals */
     int i__1, i__2;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
 
     /* Builtin functions */
-    void c_div(complex *, complex *, complex *), r_cnjg(complex *, complex *);
+    void c_div(singlecomplex *, singlecomplex *, singlecomplex *), r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
-    static complex ctemp;
-    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    static singlecomplex ctemp;
+    extern /* Complex */ void clarnd_slu(singlecomplex *, int *, int *);
     extern double dlaran_sluslu(int *);
 
 

--- a/TESTING/MATGEN/clatme.c
+++ b/TESTING/MATGEN/clatme.c
@@ -8,69 +8,69 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
-static complex c_b2 = {1.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
+static singlecomplex c_b2 = {1.f,0.f};
 static int c__1 = 1;
 static int c__0 = 0;
 static int c__5 = 5;
 
-/* Subroutine */ int clatme_slu(int *n, char *dist, int *iseed, complex *
-	d, int *mode, float *cond, complex *dmax__, char *ei, char *rsign,
+/* Subroutine */ int clatme_slu(int *n, char *dist, int *iseed, singlecomplex *
+	d, int *mode, float *cond, singlecomplex *dmax__, char *ei, char *rsign,
 	char *upper, char *sim, float *ds, int *modes, float *conds,
-	int *kl, int *ku, float *anorm, complex *a, int *lda,
-	complex *work, int *info)
+	int *kl, int *ku, float *anorm, singlecomplex *a, int *lda,
+	singlecomplex *work, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1, i__2;
     float r__1, r__2;
-    complex q__1, q__2;
+    singlecomplex q__1, q__2;
 
     /* Builtin functions */
-    double c_abs(complex *);
-    void r_cnjg(complex *, complex *);
+    double c_abs(singlecomplex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static bool bads;
     static int isim;
     static float temp;
     static int i, j;
-    extern /* Subroutine */ int cgerc_(int *, int *, complex *,
-	    complex *, int *, complex *, int *, complex *, int *);
-    static complex alpha;
-    extern /* Subroutine */ int cscal_(int *, complex *, complex *,
+    extern /* Subroutine */ int cgerc_(int *, int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, int *);
+    static singlecomplex alpha;
+    extern /* Subroutine */ int cscal_(int *, singlecomplex *, singlecomplex *,
 	    int *);
-    extern /* Subroutine */ int cgemv_(char *, int *, int *, complex *
-	    , complex *, int *, complex *, int *, complex *, complex *
+    extern /* Subroutine */ int cgemv_(char *, int *, int *, singlecomplex *
+	    , singlecomplex *, int *, singlecomplex *, int *, singlecomplex *, singlecomplex *
 	    , int *);
     static int iinfo;
     static float tempa[1];
     static int icols, idist;
-    extern /* Subroutine */ int ccopy_(int *, complex *, int *,
-	    complex *, int *);
+    extern /* Subroutine */ int ccopy_(int *, singlecomplex *, int *,
+	    singlecomplex *, int *);
     static int irows;
     extern /* Subroutine */ int clatm1_(int *, float *, int *, int
-	    *, int *, complex *, int *, int *), slatm1_slu(int *,
+	    *, int *, singlecomplex *, int *, int *), slatm1_slu(int *,
 	     float *, int *, int *, int *, float *, int *,
 	    int *);
     static int ic, jc;
-    extern double clange_(char *, int *, int *, complex *,
+    extern double clange_(char *, int *, int *, singlecomplex *,
 	    int *, float *);
     static int ir;
-    extern /* Subroutine */ int clarge_slu(int *, complex *, int *,
-	    int *, complex *, int *), clarfg_(int *, complex *,
-	    complex *, int *, complex *), clacgv_slu(int *, complex *,
+    extern /* Subroutine */ int clarge_slu(int *, singlecomplex *, int *,
+	    int *, singlecomplex *, int *), clarfg_(int *, singlecomplex *,
+	    singlecomplex *, int *, singlecomplex *), clacgv_slu(int *, singlecomplex *,
 	    int *);
-    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    extern /* Complex */ void clarnd_slu(singlecomplex *, int *, int *);
     static float ralpha;
-    extern /* Subroutine */ int csscal_(int *, float *, complex *, int
-	    *), claset_slu(char *, int *, int *, complex *, complex *,
-	    complex *, int *),
-	     clarnv_slu(int *, int *, int *, complex *);
+    extern /* Subroutine */ int csscal_(int *, float *, singlecomplex *, int
+	    *), claset_slu(char *, int *, int *, singlecomplex *, singlecomplex *,
+	    singlecomplex *, int *),
+	     clarnv_slu(int *, int *, int *, singlecomplex *);
     extern int input_error(char *, int *);
     static int irsign, iupper;
-    static complex xnorms;
+    static singlecomplex xnorms;
     static int jcr;
-    static complex tau;
+    static singlecomplex tau;
 
 
 /*  -- LAPACK test routine (version 2.0) --   

--- a/TESTING/MATGEN/clatms.c
+++ b/TESTING/MATGEN/clatms.c
@@ -9,7 +9,7 @@
 
 /* Table of constant values */
 
-static complex c_b1 = {0.f,0.f};
+static singlecomplex c_b1 = {0.f,0.f};
 static int c__1 = 1;
 static int c__5 = 5;
 static bool c_true = true;
@@ -17,59 +17,59 @@ static bool c_false = false;
 
 /* Subroutine */ int clatms_slu(int *m, int *n, char *dist, int *
 	iseed, char *sym, float *d, int *mode, float *cond, float *dmax__,
-	int *kl, int *ku, char *pack, complex *a, int *lda,
-	complex *work, int *info)
+	int *kl, int *ku, char *pack, singlecomplex *a, int *lda,
+	singlecomplex *work, int *info)
 {
     /* System generated locals */
     int a_dim1, a_offset, i__1, i__2, i__3, i__4, i__5, i__6;
     float r__1, r__2, r__3;
     double d__1;
-    complex q__1, q__2, q__3;
+    singlecomplex q__1, q__2, q__3;
     bool L__1;
 
     /* Builtin functions */
-    void r_cnjg(complex *, complex *);
+    void r_cnjg(singlecomplex *, singlecomplex *);
 
     /* Local variables */
     static int ilda, icol;
     static float temp;
     static bool csym;
     static int irow, isym;
-    static complex c;
+    static singlecomplex c;
     static int i, j, k;
-    static complex s;
+    static singlecomplex s;
     static float alpha, angle;
     static int ipack;
     static float floatc;
     static int ioffg;
     static int iinfo;
     extern /* Subroutine */ int sscal_(int *, float *, float *, int *);
-    static complex ctemp;
+    static singlecomplex ctemp;
     static int idist, mnmin, iskew;
-    static complex extra, dummy;
+    static singlecomplex extra, dummy;
     extern /* Subroutine */ int slatm1_slu(int *, float *, int *, int
 	    *, int *, float *, int *, int *);
     static int ic, jc, nc;
     extern /* Subroutine */ int clagge_slu(int *, int *, int *,
-	    int *, float *, complex *, int *, int *, complex *,
-	    int *), claghe_slu(int *, int *, float *, complex *,
-	    int *, int *, complex *, int *);
+	    int *, float *, singlecomplex *, int *, int *, singlecomplex *,
+	    int *), claghe_slu(int *, int *, float *, singlecomplex *,
+	    int *, int *, singlecomplex *, int *);
     static int il;
-    static complex ct;
+    static singlecomplex ct;
     static int iendch, ir, jr, ipackg, mr;
-    extern /* Complex */ void clarnd_slu(complex *, int *, int *);
+    extern /* Complex */ void clarnd_slu(singlecomplex *, int *, int *);
     static int minlda;
-    static complex st;
-    extern /* Subroutine */ int claset_slu(char *, int *, int *, complex
-	    *, complex *, complex *, int *), clartg_slu(complex *,
-	    complex *, float *, complex *, complex *),
-	    clagsy_slu(int *, int *, float *, complex *,
-	    int *, int *, complex *, int *);
+    static singlecomplex st;
+    extern /* Subroutine */ int claset_slu(char *, int *, int *, singlecomplex
+	    *, singlecomplex *, singlecomplex *, int *), clartg_slu(singlecomplex *,
+	    singlecomplex *, float *, singlecomplex *, singlecomplex *),
+	    clagsy_slu(int *, int *, float *, singlecomplex *,
+	    int *, int *, singlecomplex *, int *);
     extern int input_error(char *, int *);
     extern double slarnd_slu(int *, int *);
     extern /* Subroutine */ int clarot_slu(bool *, bool *, bool *,
-	    int *, complex *, complex *, complex *, int *, complex *,
-	    complex *);
+	    int *, singlecomplex *, singlecomplex *, singlecomplex *, int *, singlecomplex *,
+	    singlecomplex *);
     static bool iltemp, givens;
     static int ioffst, irsign;
     static bool ilextr, topdwn;

--- a/TESTING/MATGEN/csymv.c
+++ b/TESTING/MATGEN/csymv.c
@@ -2,8 +2,8 @@
 #include "../../SRC/slu_scomplex.h"
 #include "../../SRC/slu_sdefs.h"
 
-/* Subroutine */ int csymv_sluslu(char *uplo, int *n, complex *alpha, complex *
-	a, int *lda, complex *x, int *incx, complex *beta, complex *y,
+/* Subroutine */ int csymv_sluslu(char *uplo, int *n, singlecomplex *alpha, singlecomplex *
+	a, int *lda, singlecomplex *x, int *incx, singlecomplex *beta, singlecomplex *y,
 	 int *incy)
 {
 /*  -- LAPACK auxiliary routine (version 2.0) --   
@@ -105,10 +105,10 @@
        Function Body */
     /* System generated locals */
 
-    complex q__1, q__2, q__3, q__4;
+    singlecomplex q__1, q__2, q__3, q__4;
     /* Local variables */
     static int info;
-    static complex temp1, temp2;
+    static singlecomplex temp1, temp2;
     static int i, j;
     static int ix, iy, jx, jy, kx, ky;
     extern int input_error(char *, int *);

--- a/TESTING/MATGEN/matgen.h
+++ b/TESTING/MATGEN/matgen.h
@@ -5,8 +5,8 @@
 
 int clatms_slu(int *m, int *n, char *dist, int * iseed,
                char *sym, float *d, int *mode, float *cond, float *dmax__,
-               int *kl, int *ku, char *pack, complex *a, int *lda,
-               complex *work, int *info);
+               int *kl, int *ku, char *pack, singlecomplex *a, int *lda,
+               singlecomplex *work, int *info);
 
 int clatb4_slu(char *path, int *imat, int *m, int * n,
                char *type, int *kl, int *ku, float *anorm, int *mode,

--- a/TESTING/cdrive.c
+++ b/TESTING/cdrive.c
@@ -50,7 +50,7 @@ parse_command_line(int argc, char *argv[], char *matrix_type,
  */
 int main(int argc, char *argv[])
 {
-    complex         *a, *a_save;
+    singlecomplex         *a, *a_save;
     int_t          *asub, *asub_save;
     int_t          *xa, *xa_save;
     SuperMatrix  A, B, X, L, U;
@@ -60,17 +60,17 @@ int main(int argc, char *argv[])
     int            *perm_r; /* row permutation from partial pivoting */
     int            *perm_c, *pc_save; /* column permutation */
     int            *etree;
-    complex  zero = {0.0, 0.0};
+    singlecomplex  zero = {0.0, 0.0};
     float         *R, *C;
     float         *ferr, *berr;
     float         *rwork;
-    complex	   *wwork;
+    singlecomplex	   *wwork;
     void           *work = NULL;
     int            nrhs, panel_size, relax;
     int            m, n, info1;
     int_t          nnz, lwork, info;
-    complex         *xact;
-    complex         *rhsb, *solx, *bsav;
+    singlecomplex         *xact;
+    singlecomplex         *rhsb, *solx, *bsav;
     int            ldb, ldx;
     float         rpg, rcond;
     int            i, j, k1;
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     int            zerot, izero, ioff;
     double         u;
     float         anorm, cndnum;
-    complex         *Afull;
+    singlecomplex         *Afull;
     float         result[NTESTS];
     superlu_options_t options;
     fact_t         fact;
@@ -103,15 +103,15 @@ int main(int argc, char *argv[])
     /* Some function prototypes */ 
     extern int cgst01(int, int, SuperMatrix *, SuperMatrix *, 
 		      SuperMatrix *, int *, int *, float *);
-    extern int cgst02(trans_t, int, int, int, SuperMatrix *, complex *,
-                      int, complex *, int, float *resid);
-    extern int cgst04(int, int, complex *, int, 
-                      complex *, int, float rcond, float *resid);
-    extern int cgst07(trans_t, int, int, SuperMatrix *, complex *, int,
-                         complex *, int, complex *, int, 
+    extern int cgst02(trans_t, int, int, int, SuperMatrix *, singlecomplex *,
+                      int, singlecomplex *, int, float *resid);
+    extern int cgst04(int, int, singlecomplex *, int, 
+                      singlecomplex *, int, float rcond, float *resid);
+    extern int cgst07(trans_t, int, int, SuperMatrix *, singlecomplex *, int,
+                         singlecomplex *, int, singlecomplex *, int, 
                          float *, float *, float *);
-    extern int sp_cconvert(int, int, complex *, int, int, int,
-	                   complex *a, int_t *, int_t *, int_t *);
+    extern int sp_cconvert(int, int, singlecomplex *, int, int, int,
+	                   singlecomplex *a, int_t *, int_t *, int_t *);
 
 
     /* Executable statements */

--- a/TESTING/cgst01.c
+++ b/TESTING/cgst01.c
@@ -48,17 +48,17 @@ int cgst01(int m, int n, SuperMatrix *A, SuperMatrix *L,
            SuperMatrix *U, int *perm_c, int *perm_r, float *resid)
 {
     /* Local variables */
-    complex zero = {0.0, 0.0};
+    singlecomplex zero = {0.0, 0.0};
     int i, j, k, arow, superno, fsupc, u_part;
     int_t urow, lptr, isub;
-    complex utemp;
-    complex comp_temp;
+    singlecomplex utemp;
+    singlecomplex comp_temp;
     float anorm, tnorm, cnorm;
     float eps;
-    complex *work;
+    singlecomplex *work;
     SCformat *Lstore;
     NCformat *Astore, *Ustore;
-    complex *Aval, *Lval, *Uval;
+    singlecomplex *Aval, *Lval, *Uval;
     int_t *colbeg, *colend;
 
     /* Function prototypes */
@@ -71,7 +71,7 @@ int cgst01(int m, int n, SuperMatrix *A, SuperMatrix *L,
 	return 0;
     }
 
-    work = (complex *)complexCalloc(m);
+    work = (singlecomplex *)complexCalloc(m);
 
     Astore = A->Store;
     Aval = Astore->nzval;

--- a/TESTING/cgst02.c
+++ b/TESTING/cgst02.c
@@ -57,11 +57,11 @@ at the top-level directory.
  *                    norm(B - A*X) / ( norm(A) * norm(X) * EPS ).
  */
 int cgst02(trans_t trans, int m, int n, int nrhs, SuperMatrix *A,
-           complex *x, int ldx, complex *b, int ldb, float *resid)
+           singlecomplex *x, int ldx, singlecomplex *b, int ldb, float *resid)
 {
     /* Table of constant values */
-    complex alpha = {-1., 0.0};
-    complex beta  = {1., 0.0};
+    singlecomplex alpha = {-1., 0.0};
+    singlecomplex beta  = {1., 0.0};
     int    c__1  = 1;
     
     /* System generated locals */
@@ -77,7 +77,7 @@ int cgst02(trans_t trans, int m, int n, int nrhs, SuperMatrix *A,
 
     /* Function prototypes */
     extern float clangs(char *, SuperMatrix *);
-    extern float scasum_(int *, complex *, int *);
+    extern float scasum_(int *, singlecomplex *, int *);
     
     /* Function Body */
     if ( m <= 0 || n <= 0 || nrhs == 0) {

--- a/TESTING/cgst04.c
+++ b/TESTING/cgst04.c
@@ -48,7 +48,7 @@ at the top-level directory.
  * \param[out] resid  The maximum over the NRHS solution vectors of
  *                    ( norm(X-XACT) * RCOND ) / ( norm(XACT) * EPS )
  */
-int cgst04(int n, int nrhs, complex *x, int ldx, complex *xact,
+int cgst04(int n, int nrhs, singlecomplex *x, int ldx, singlecomplex *xact,
            int ldxact, float rcond, float *resid)
 {
     /* Table of constant values */
@@ -65,7 +65,7 @@ int cgst04(int n, int nrhs, complex *x, int ldx, complex *xact,
     float diffnm;
 
     /* Function prototypes */
-    extern int icamax_(int *, complex *, int *);
+    extern int icamax_(int *, singlecomplex *, int *);
 
     /* Quick exit if N = 0 or NRHS = 0. */
    if ( n <= 0 || nrhs <= 0 ) {

--- a/TESTING/cgst07.c
+++ b/TESTING/cgst07.c
@@ -69,8 +69,8 @@ at the top-level directory.
  *                    RESLTS(1) = norm(X - XACT) / ( norm(X) * FERR )
  *                    RESLTS(2) = BERR / ( (n+1)*EPS + (*) )
  */
-int cgst07(trans_t trans, int n, int nrhs, SuperMatrix *A, complex *b,
-           int ldb, complex *x, int ldx, complex *xact,
+int cgst07(trans_t trans, int n, int nrhs, SuperMatrix *A, singlecomplex *b,
+           int ldb, singlecomplex *x, int ldx, singlecomplex *xact,
            int ldxact, float *ferr, float *berr, float *reslts)
 {
     /* Table of constant values */
@@ -90,11 +90,11 @@ int cgst07(trans_t trans, int n, int nrhs, SuperMatrix *A, complex *b,
     int    notran;
     float eps, tmp;
     float *rwork;
-    complex *Aval;
+    singlecomplex *Aval;
     NCformat *Astore;
 
     /* Function prototypes */
-    extern int    icamax_(int *, complex *, int *);
+    extern int    icamax_(int *, singlecomplex *, int *);
 
 
     /* Quick exit if N = 0 or NRHS = 0. */
@@ -112,7 +112,7 @@ int cgst07(trans_t trans, int n, int nrhs, SuperMatrix *A, complex *b,
     rwork  = (float *) SUPERLU_MALLOC(n*sizeof(float));
     if ( !rwork ) ABORT("SUPERLU_MALLOC fails for rwork");
     Astore = A->Store;
-    Aval   = (complex *) Astore->nzval;
+    Aval   = (singlecomplex *) Astore->nzval;
     
     /* Test 1:  Compute the maximum of   
        norm(X - XACT) / ( norm(X) * FERR )   

--- a/TESTING/sp_cconvert.c
+++ b/TESTING/sp_cconvert.c
@@ -31,13 +31,13 @@ at the top-level directory.
  * For complex float.
  */
 int
-sp_cconvert(int m, int n, complex *A, int lda, int kl, int ku,
-	   complex *a, int_t *asub, int_t *xa, int_t *nnz)
+sp_cconvert(int m, int n, singlecomplex *A, int lda, int kl, int ku,
+	   singlecomplex *a, int_t *asub, int_t *xa, int_t *nnz)
 {
     int_t     lasta = 0;
     int_t     i, j, ilow, ihigh;
     int_t     *row;
-    complex  *val;
+    singlecomplex  *val;
 
     for (j = 0; j < n; ++j) {
 	xa[j] = lasta;


### PR DESCRIPTION
- This is to avoid conflicts in packages that use both the `complex.h` header and SuperLU.
- Changes all occurences of `complex` to `singlecomplex`.
- Adds a patch file to `CBLAS`, so that it's easy to apply, in case the vendored version needs to be updated.

Closes #115.