### PR TITLE
Rank Deficient Matrices

### DIFF
--- a/MATLAB/mexsuperlu.c
+++ b/MATLAB/mexsuperlu.c
@@ -91,7 +91,7 @@ void mexFunction(
 
     /* Read the Sparse Monitor Flag */
     X = mxCreateString("spumoni");
-    mexerr = mexCallMATLAB(1, &Y, 1, &X, "sparsfun");
+    mexerr = mexCallMATLAB(1, &Y, 1, &X, "spparms");
     SPUMONI = mxGetScalar(Y);
     mxDestroyArray(Y);
     mxDestroyArray(X);
@@ -224,8 +224,8 @@ LUextract(SuperMatrix *L, SuperMatrix *U, double *Lval, mwIndex *Lrow,
     NCformat    *Ustore;
     double      *SNptr;
 
-    Lstore = L->Store;
-    Ustore = U->Store;
+	Lstore = (SCformat*)L->Store;
+	Ustore = (NCformat*)U->Store;
     Lcol[0] = 0;
     Ucol[0] = 0;
     

--- a/MATLAB/mexsuperlu.c
+++ b/MATLAB/mexsuperlu.c
@@ -256,7 +256,7 @@ LUextract(SuperMatrix *L, SuperMatrix *U, double *Lval, mwIndex *Lrow,
 
 	    /* Extract L */
 	    Lval[lastl] = 1.0; /* unit diagonal */
-	    Lrow[lastl++] = L_SUB(istart + upper - 1);
+			Lrow[lastl++] = j;
 	    for (i = upper; i < nsupr; ++i) {
 		Lval[lastl] = SNptr[i];
  		/* Matlab doesn't like explicit zero. */
@@ -264,7 +264,8 @@ LUextract(SuperMatrix *L, SuperMatrix *U, double *Lval, mwIndex *Lrow,
 	    }
 	    Lcol[j+1] = lastl;
 
-	    ++upper;
+			/* prevent upper from being larger than nsupr */
+			if(upper < nsupr) ++upper;
 	    
 	} /* for j ... */
 	

--- a/MATLAB/mexsuperlu.c
+++ b/MATLAB/mexsuperlu.c
@@ -171,7 +171,7 @@ void mexFunction(
 	Lval = mxGetPr(L_out);
 	Lrow_64 = mxGetIr(L_out);
 	Lcol_64 = mxGetJc(L_out);
-	U_out = mxCreateSparse(m, n, nnzU, mxREAL);
+	U_out = mxCreateSparse(n, n, nnzU, mxREAL);
 	Uval = mxGetPr(U_out);
 	Urow_64 = mxGetIr(U_out);
 	Ucol_64 = mxGetJc(U_out);

--- a/MATLAB/superlu.m
+++ b/MATLAB/superlu.m
@@ -64,9 +64,6 @@ function [L,U,prow,pcol] = superlu(A,psparse)
 
 
 [m,n] = size(A);
-if m ~= n 
-    error('matrix must be square.'); 
-end;
 if n == 0
     L = []; U = []; prow = []; pcol = [];
     return;
@@ -104,8 +101,9 @@ end;
 
 % The output permutations from the mex-file are dense permutation vectors.
 [L,U,prowInv,pcolInv] = mexsuperlu(A,Psparse);
-prow = zeros(1,n);
-prow(prowInv) = 1:n;
+
+prow = zeros(1,m);
+prow(prowInv) = 1:m;
 pcol = zeros(1,n);
 pcol(pcolInv) = 1:n;
 

--- a/SRC/dgstrf.c
+++ b/SRC/dgstrf.c
@@ -409,13 +409,20 @@ dgstrf (superlu_options_t *options, SuperMatrix *A,
 
     *info = iinfo;
     
-    if ( m > n ) {
-	k = 0;
-        for (i = 0; i < m; ++i) 
-            if ( perm_r[i] == EMPTY ) {
-    		perm_r[i] = n + k;
-		++k;
-	    }
+    /* k is the rank of U
+       pivots have been completed for rows < r
+       Now fill in the pivots for rows r to m */
+    k = iinfo == 0 ? n : (int)iinfo - 1;
+    if (m > k) {
+        /* if k == m, then all the row permutations are complete and
+           we can short circuit looking through the rest of the vector */
+        for (i = 0; i < m && k < m; ++i) {
+            if (perm_r[i] == EMPTY) {
+                perm_r[i] = k;
+                ++k;
+            }
+
+        }
     }
 
     countnz(min_mn, xprune, &nnzL, &nnzU, Glu);

--- a/SRC/dpivotL.c
+++ b/SRC/dpivotL.c
@@ -122,25 +122,30 @@ if ( jcol == MIN_COL ) {
     diag = EMPTY;
     old_pivptr = nsupc;
     for (isub = nsupc; isub < nsupr; ++isub) {
-	rtemp = fabs (lu_col_ptr[isub]);
+	    rtemp = fabs (lu_col_ptr[isub]);
 	if ( rtemp > pivmax ) {
-	    pivmax = rtemp;
-	    pivptr = isub;
-	}
-	if ( *usepr && lsub_ptr[isub] == *pivrow ) old_pivptr = isub;
-	if ( lsub_ptr[isub] == diagind ) diag = isub;
+	        pivmax = rtemp;
+	        pivptr = isub;
+	    }
+    	if ( *usepr && lsub_ptr[isub] == *pivrow ) old_pivptr = isub;
+	    if ( lsub_ptr[isub] == diagind ) diag = isub;
     }
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
+#if 0
+        // There is no valid pivot.  
+        // jcol represents the rank of U
+        // report the rank let dgstrf handle the pivot
 #if 1
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
+    *pivrow = lsub_ptr[pivptr];
+    perm_r[*pivrow] = jcol;
 #else
-	perm_r[diagind] = jcol;
+    perm_r[diagind] = jcol;
 #endif
-	*usepr = 0;
-	return (jcol+1);
+#endif
+	    *usepr = 0;
+	    return (jcol+1);
     }
 
     thresh = u * pivmax;


### PR DESCRIPTION
@xiaoyeli 

As I communicated to you via email on July 24th, the current version of sequential SuperLU has a bug where rank deficient rectangular matrices are not computed properly.  This is an important application as the LU decomposition of a sparse matrix is required for the Null Space Method of solving the Karush–Kuhn–Tucker (KKT) matrix which arises in Quadratic Programming applications such as constrained numerical minimization (see attached reference paper).

https://www.numerical.rl.ac.uk/people/rees/pdf/RAL-TR-2014-016.pdf

After doing some more testing, the bug does not occur for all rank deficient rectangular matrices, nor is it limited to rectangular matrices.  A minimum example of a matrix in which this problem arises is (given in (row, col, value) notation):
(0, 0, 1.0)
(1, 0, 1.0)
(2, 1, 1.0)
(2, 2, 1.0)

After factoring the above matrix using dgstrf, the row permutations are given as (0, -1, 2), which are invalid permutations.

This pull request provides a fix for this issue.  I have verified that the proposed solution passes your cmake test suite.  In addition, I have ran the attached 9 test cases using the Matlab interface (modification also required and provided in this pull request).  Some of these work using the current master branch, while others demonstrate the bug.  All 9 test cases pass with the proposed changes.

[TestMatrices.zip](https://github.com/xiaoyeli/superlu/files/12373323/TestMatrices.zip)

I have not checked whether this issue is present using single precision of complex versions of the factorization.

Regards,
Evan
