### PR TITLE
Fix usage of uninitialized variable `value`

### DIFF
--- a/SRC/clangs.c
+++ b/SRC/clangs.c
@@ -75,25 +75,21 @@ float clangs(char *norm, SuperMatrix *A)
     NCformat *Astore;
     singlecomplex   *Aval;
     int      i, j, irow;
-    float   value, sum;
+    float   value = 0., sum;
     float   *rwork;
 
     Astore = A->Store;
     Aval   = Astore->nzval;
     
     if ( SUPERLU_MIN(A->nrow, A->ncol) == 0) {
-	value = 0.;
-	
     } else if (strncmp(norm, "M", 1)==0) {
 	/* Find max(abs(A(i,j))). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j)
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++)
 		value = SUPERLU_MAX( value, c_abs( &Aval[i]) );
 	
     } else if (strncmp(norm, "O", 1)==0 || *(unsigned char *)norm == '1') {
 	/* Find norm1(A). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j) {
 	    sum = 0.;
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++) 
@@ -111,7 +107,6 @@ float clangs(char *norm, SuperMatrix *A)
 		irow = Astore->rowind[i];
 		rwork[irow] += c_abs( &Aval[i] );
 	    }
-	value = 0.;
 	for (i = 0; i < A->nrow; ++i)
 	    value = SUPERLU_MAX(value, rwork[i]);
 	

--- a/SRC/dlangs.c
+++ b/SRC/dlangs.c
@@ -75,25 +75,21 @@ double dlangs(char *norm, SuperMatrix *A)
     NCformat *Astore;
     double   *Aval;
     int      i, j, irow;
-    double   value, sum;
+    double   value = 0., sum;
     double   *rwork;
 
     Astore = A->Store;
     Aval   = Astore->nzval;
     
     if ( SUPERLU_MIN(A->nrow, A->ncol) == 0) {
-	value = 0.;
-	
     } else if (strncmp(norm, "M", 1)==0) {
 	/* Find max(abs(A(i,j))). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j)
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++)
 		value = SUPERLU_MAX( value, fabs( Aval[i]) );
 	
     } else if (strncmp(norm, "O", 1)==0 || *(unsigned char *)norm == '1') {
 	/* Find norm1(A). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j) {
 	    sum = 0.;
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++) 
@@ -111,7 +107,6 @@ double dlangs(char *norm, SuperMatrix *A)
 		irow = Astore->rowind[i];
 		rwork[irow] += fabs(Aval[i]);
 	    }
-	value = 0.;
 	for (i = 0; i < A->nrow; ++i)
 	    value = SUPERLU_MAX(value, rwork[i]);
 	

--- a/SRC/slangs.c
+++ b/SRC/slangs.c
@@ -75,25 +75,21 @@ float slangs(char *norm, SuperMatrix *A)
     NCformat *Astore;
     float   *Aval;
     int      i, j, irow;
-    float   value, sum;
+    float   value = 0., sum;
     float   *rwork;
 
     Astore = A->Store;
     Aval   = Astore->nzval;
     
     if ( SUPERLU_MIN(A->nrow, A->ncol) == 0) {
-	value = 0.;
-	
     } else if (strncmp(norm, "M", 1)==0) {
 	/* Find max(abs(A(i,j))). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j)
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++)
 		value = SUPERLU_MAX( value, fabs( Aval[i]) );
 	
     } else if (strncmp(norm, "O", 1)==0 || *(unsigned char *)norm == '1') {
 	/* Find norm1(A). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j) {
 	    sum = 0.;
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++) 
@@ -111,7 +107,6 @@ float slangs(char *norm, SuperMatrix *A)
 		irow = Astore->rowind[i];
 		rwork[irow] += fabs(Aval[i]);
 	    }
-	value = 0.;
 	for (i = 0; i < A->nrow; ++i)
 	    value = SUPERLU_MAX(value, rwork[i]);
 	

--- a/SRC/zlangs.c
+++ b/SRC/zlangs.c
@@ -75,25 +75,21 @@ double zlangs(char *norm, SuperMatrix *A)
     NCformat *Astore;
     doublecomplex   *Aval;
     int      i, j, irow;
-    double   value, sum;
+    double   value = 0., sum;
     double   *rwork;
 
     Astore = A->Store;
     Aval   = Astore->nzval;
     
     if ( SUPERLU_MIN(A->nrow, A->ncol) == 0) {
-	value = 0.;
-	
     } else if (strncmp(norm, "M", 1)==0) {
 	/* Find max(abs(A(i,j))). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j)
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++)
 		value = SUPERLU_MAX( value, z_abs( &Aval[i]) );
 	
     } else if (strncmp(norm, "O", 1)==0 || *(unsigned char *)norm == '1') {
 	/* Find norm1(A). */
-	value = 0.;
 	for (j = 0; j < A->ncol; ++j) {
 	    sum = 0.;
 	    for (i = Astore->colptr[j]; i < Astore->colptr[j+1]; i++) 
@@ -111,7 +107,6 @@ double zlangs(char *norm, SuperMatrix *A)
 		irow = Astore->rowind[i];
 		rwork[irow] += z_abs( &Aval[i] );
 	    }
-	value = 0.;
 	for (i = 0; i < A->nrow; ++i)
 	    value = SUPERLU_MAX(value, rwork[i]);
 	


### PR DESCRIPTION
Fixes a usage of uninitialized variable `value` in `[cdsz]langs.c` if the abort conditions are triggered. Yes this isn't a true usage since `ABORT` will call `exit()` but it still causes a compiler warning in some cases.

This pops up whenever SciPy is compiled with LLVM, which happens to be configured to emit this warning:

```
[504/1606] Compiling C object scipy/sparse/linalg/_dsolve/libsuperlu_lib.a.p/SuperLU_SRC_clangs.c.o
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/clangs.c:104:16: warning: variable 'value' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
    } else if (strncmp(norm, "I", 1)==0) {
               ^~~~~~~~~~~~~~~~~~~~~~~~
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/clangs.c:126:13: note: uninitialized use occurs here
    return (value);
            ^~~~~
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/clangs.c:104:12: note: remove the 'if' if its condition is always true
    } else if (strncmp(norm, "I", 1)==0) {
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/clangs.c:78:18: note: initialize the variable 'value' to silence this warning
    float   value, sum;
                 ^
                  = 0.0
1 warning generated.
```

and of course 3 more copies, one each for the other 3 files.