### PR TITLE
[cmake] Improve generating of superlu_config.fh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,23 @@ if (TPL_METIS_INCLUDE_DIRS)
   include_directories(${TPL_METIS_INCLUDE_DIRS})  ## metis
 endif ()
 
+# Generate various configure files with proper definitions
+
+# file(WRITE "make.defs" "# can be exposed to users"
+#  ${CMAKE_C_COMPILER}  )
+# configure_file(${CMAKE_SOURCE_DIR}/make.inc.in ${CMAKE_SOURCE_DIR}/make.inc)
+configure_file(${SuperLU_SOURCE_DIR}/make.inc.in ${SuperLU_SOURCE_DIR}/make.inc)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/superlu.pc.in ${CMAKE_CURRENT_BINARY_DIR}/superlu.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/superlu.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_BINARY_DIR}/SRC/superlu_config.h)
+configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_SOURCE_DIR}/SRC/superlu_config.h)
+
+# Following is to configure a header file for FORTRAN code
+configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_BINARY_DIR}/FORTRAN/superlu_config.h)
+
 ######################################################################
 #
 # Add subdirectories
@@ -240,20 +257,3 @@ add_subdirectory(EXAMPLE)
 if (enable_doc)
    add_subdirectory(DOC)
 endif()
-
-# Generate various configure files with proper definitions
-
-# file(WRITE "make.defs" "# can be exposed to users"
-#  ${CMAKE_C_COMPILER}  )
-# configure_file(${CMAKE_SOURCE_DIR}/make.inc.in ${CMAKE_SOURCE_DIR}/make.inc)
-configure_file(${SuperLU_SOURCE_DIR}/make.inc.in ${SuperLU_SOURCE_DIR}/make.inc)
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/superlu.pc.in ${CMAKE_CURRENT_BINARY_DIR}/superlu.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/superlu.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-
-configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_BINARY_DIR}/SRC/superlu_config.h)
-configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_SOURCE_DIR}/SRC/superlu_config.h)
-
-# Following is to configure a header file for FORTRAN code
-configure_file(${SuperLU_SOURCE_DIR}/SRC/superlu_config.h.in ${SuperLU_BINARY_DIR}/FORTRAN/superlu_config.h)

--- a/FORTRAN/CMakeLists.txt
+++ b/FORTRAN/CMakeLists.txt
@@ -31,8 +31,6 @@ set_target_properties(superlu_fortran-static PROPERTIES SOVERSION ${superlu_sove
 target_link_libraries(superlu_fortran-static superlu)
 
 # depends on FPP defs
-add_dependencies(superlu_fortran config_f)
-add_dependencies(superlu_fortran-static config_f)
 add_dependencies(superlu_fortran-static superlu_fortran)
 
 install(TARGETS superlu_fortran
@@ -91,10 +89,9 @@ if(enable_examples)
 endif() # enable_example
 
 # Format superlu_config.fh from superlu_config.h in C
-add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/FORTRAN/superlu_config.fh
-  COMMAND sed;'s/\\/.*$$//';<;superlu_config.h;>;temp.fh
-  COMMAND sed;'/typedef/;d';<;temp.fh;>;superlu_config.fh
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/FORTRAN
-)
-add_custom_target(config_f DEPENDS ${CMAKE_BINARY_DIR}/FORTRAN/superlu_config.fh)
+file(READ "${CMAKE_BINARY_DIR}/SRC/superlu_config.h" CONFIG_FILE_H)
+# remove C comments /* */
+string(REGEX REPLACE "/\\*[^(\\*/)]*\\*/" " " CONFIG_FILE_H_NO_COMMENTS "${CONFIG_FILE_H}")
+# remove typedefs
+string(REGEX REPLACE "typedef[^;]*;" " " CONFIG_FILE_FH "${CONFIG_FILE_H_NO_COMMENTS}")
+file(WRITE "${CMAKE_BINARY_DIR}/FORTRAN/superlu_config.fh" "${CONFIG_FILE_FH}")


### PR DESCRIPTION
Do not rely on external sed, use CMake regex instead.
Do not create intermediate files temp.fh and copy of superlu_config.h
Create config file on CMake run and not with target of its own