### PR TITLE
[ci] Re-enable running tests on Windows as segfaults in tests got fixed"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,5 +80,4 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Test
-        run: echo "Testing disabled due to known segfaults"
-        #run: ctest --test-dir build -C Release --output-on-failure
+        run: ctest --test-dir build -C Release --output-on-failure


### PR DESCRIPTION
This reverts commit 0559d56084de64c7d2384e49165f79b2fd0a601f.
Fixes #134.