### PR TITLE
Fix typo in documentation of gstrs

### DIFF
--- a/SRC/cgscon.c
+++ b/SRC/cgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   CGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by CGETRF.   *
+ *   the LU factorization computed by CGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   

--- a/SRC/dgscon.c
+++ b/SRC/dgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   DGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by DGETRF.   *
+ *   the LU factorization computed by DGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   

--- a/SRC/sgscon.c
+++ b/SRC/sgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   SGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by SGETRF.   *
+ *   the LU factorization computed by SGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   

--- a/SRC/zgscon.c
+++ b/SRC/zgscon.c
@@ -37,7 +37,7 @@ at the top-level directory.
  *
  *   ZGSCON estimates the reciprocal of the condition number of a general 
  *   real matrix A, in either the 1-norm or the infinity-norm, using   
- *   the LU factorization computed by ZGETRF.   *
+ *   the LU factorization computed by ZGSTRF.   *
  *
  *   An estimate is obtained for norm(inv(A)), and the reciprocal of the   
  *   condition number is computed as   


### PR DESCRIPTION
The documentation of [dgscon](https://github.com/xiaoyeli/superlu/blob/86ea4b3cf0c7b31ecc58038428515b92f78571c0/SRC/dgscon.c#L40) gives conflicting information about how its input arguments `L` and `U` have to be computed:
- In the main text, it refers to a function `DGETRF` which, to my knowledge, does not exist in SuperLU. 
- In the description of the arguments, it refers to [`dgstrf`](https://github.com/xiaoyeli/superlu/blob/86ea4b3cf0c7b31ecc58038428515b92f78571c0/SRC/dgstrf.c).

The proposed change replaces `DGETRF` by `DGSTRF` in the comments in the code. It seems that the html documentation are also part of the repo, and would therefore need to be rebuilt.

As a side question, I was wondering if it is possible to use `dgscon` with an incomplete LU decomposition formed by `dgsitrf`?

I'm interested because I'm currently trying to extend the SciPy wrapper for SuperLU in response to scipy/scipy#18969.