### PR TITLE
Fixes broken Windows CI builds.

### DIFF
--- a/EXAMPLE/citersol.c
+++ b/EXAMPLE/citersol.c
@@ -38,7 +38,6 @@ at the top-level directory.
  * \ingroup Example
  */
 
-#include <unistd.h>
 #include "slu_cdefs.h"
 
 superlu_options_t *GLOBAL_OPTIONS;

--- a/EXAMPLE/ditersol.c
+++ b/EXAMPLE/ditersol.c
@@ -38,7 +38,6 @@ at the top-level directory.
  * \ingroup Example
  */
 
-#include <unistd.h>
 #include "slu_ddefs.h"
 
 superlu_options_t *GLOBAL_OPTIONS;

--- a/EXAMPLE/sitersol.c
+++ b/EXAMPLE/sitersol.c
@@ -38,7 +38,6 @@ at the top-level directory.
  * \ingroup Example
  */
 
-#include <unistd.h>
 #include "slu_sdefs.h"
 
 superlu_options_t *GLOBAL_OPTIONS;

--- a/EXAMPLE/zitersol.c
+++ b/EXAMPLE/zitersol.c
@@ -38,7 +38,6 @@ at the top-level directory.
  * \ingroup Example
  */
 
-#include <unistd.h>
 #include "slu_zdefs.h"
 
 superlu_options_t *GLOBAL_OPTIONS;


### PR DESCRIPTION
[example] Remove unnecessary include unistd.h from ?itersol.c