### PR TITLE
Replace #define complex by optional typedef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(enable_doc       "Add target 'doc' to build Doxygen documentation" OFF)
 option(enable_examples  "Build examples" ON)
 option(enable_fortran   "Build Fortran interface" ${enable_fortran_xSDK})
 option(enable_tests     "Build tests" ON)
+option(enable_compatibility_complex "Provide typdef 'complex' for compatibility with older SuperLU version" OFF)
 
 include(CTest)
 include(GNUInstallDirs)
@@ -99,6 +100,11 @@ if (enable_fortran)
 endif()
 set(SUPERLU_VERSION "${PROJECT_VERSION}")
 set(SUPERLU_REV "${PROJECT_REV}")
+
+if(enable_compatibility_complex)
+  add_compile_definitions(SUPERLU_TYPEDEF_COMPLEX)
+endif()
+
 
 #-- BLAS
 option(TPL_ENABLE_INTERNAL_BLASLIB  "Build the CBLAS library" ${enable_internal_blaslib})

--- a/SRC/slu_scomplex.h
+++ b/SRC/slu_scomplex.h
@@ -30,7 +30,11 @@ at the top-level directory.
 
 typedef struct { float r, i; } singlecomplex;
 
-#define complex singlecomplex  // backward compatibility
+#if defined(SUPERLU_TYPEDEF_COMPLEX) || DOXYGEN
+//! \brief backward compatibility with older versions of SuperLU
+//! Add -D enable_compatibility_complex=ON to your CMake call
+typedef singlecomplex complex;
+#endif
 
 /* Macro definitions */
 


### PR DESCRIPTION
The macro #define complex broke code that used complex. The typedef is only provided, when enbaled with the CMake option enable_compatibility_complex.