### PR TITLE
Wherever possible declared parameter as pointer to const

### DIFF
--- a/SRC/colamd.c
+++ b/SRC/colamd.c
@@ -892,7 +892,7 @@ PRIVATE Int garbage_collection
     Colamd_Row Row [],
     Colamd_Col Col [],
     Int A [],
-    Int *pfree
+    const Int *pfree
 ) ;
 
 PRIVATE Int clear_mark
@@ -905,7 +905,7 @@ PRIVATE Int clear_mark
 
 PRIVATE void print_report
 (
-    char *method,
+    const char *method,
     Int stats [COLAMD_STATS]
 ) ;
 
@@ -3002,7 +3002,7 @@ PRIVATE Int garbage_collection  /* returns the new value of pfree */
     Colamd_Row Row [],		/* row info */
     Colamd_Col Col [],		/* column info */
     Int A [],			/* A [0 ... Alen-1] holds the matrix */
-    Int *pfree			/* &A [0] ... pfree is in use */
+    const Int *pfree			/* &A [0] ... pfree is in use */
 )
 {
     /* === Local variables ================================================== */
@@ -3162,7 +3162,7 @@ PRIVATE Int clear_mark	/* return the new value for tag_mark */
 
 PRIVATE void print_report
 (
-    char *method,
+    const char *method,
     Int stats [COLAMD_STATS]
 )
 {

--- a/SRC/dcomplex.c
+++ b/SRC/dcomplex.c
@@ -29,7 +29,7 @@ at the top-level directory.
 
 
 /*! \brief Complex Division c = a/b */
-void z_div(doublecomplex *c, doublecomplex *a, doublecomplex *b)
+void z_div(doublecomplex *c, const doublecomplex *a, const doublecomplex *b)
 {
     double ratio, den;
     double abr, abi, cr, ci;

--- a/SRC/dgstrs.c
+++ b/SRC/dgstrs.c
@@ -91,7 +91,7 @@ at the top-level directory.
 
 void
 dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
-        int *perm_c, int *perm_r, SuperMatrix *B,
+        const int *perm_c, const int *perm_r, SuperMatrix *B,
         SuperLUStat_t *stat, int *info)
 {
 
@@ -112,7 +112,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
     int      jcol, n, ldb, nrhs;
     double   *work, *rhs_work, *soln;
     flops_t  solve_ops;
-    void dprint_soln(int n, int nrhs, double *soln);
+    void dprint_soln(int n, int nrhs, const double *soln);
 
     /* Test input parameters ... */
     *info = 0;
@@ -331,7 +331,7 @@ dgstrs (trans_t trans, SuperMatrix *L, SuperMatrix *U,
  * Diagnostic print of the solution vector 
  */
 void
-dprint_soln(int n, int nrhs, double *soln)
+dprint_soln(int n, int nrhs, const double *soln)
 {
     int i;
 

--- a/SRC/get_perm_c.c
+++ b/SRC/get_perm_c.c
@@ -40,7 +40,7 @@ extern int genmmd_(int *neqns, int_t *xadj, int_t *adjncy,
  * \param[out] perm_c Column permutation vector.
  */
 void get_colamd(const int m, const int n, const int_t nnz,
-                int_t *colptr, int_t *rowind, int *perm_c)
+                const int_t *colptr, const int_t *rowind, int *perm_c)
 {
     size_t Alen;
     int_t *A, i, *p;
@@ -77,8 +77,8 @@ void get_colamd(const int m, const int n, const int_t nnz,
  * \param[in]  b_rowind Row indices of size bnz for matrix B.
  * \param[out] perm_c Column permutation vector.
  */
-void get_metis(int n, int_t bnz, int_t *b_colptr,
-               int_t *b_rowind, int *perm_c)
+void get_metis(int n, int_t bnz, const int_t *b_colptr,
+               const int_t *b_rowind, const int *perm_c)
 {
 #ifdef HAVE_METIS
     /*#define METISOPTIONS 8*/
@@ -151,7 +151,7 @@ void get_metis(int n, int_t bnz, int_t *b_colptr,
  * \param[out] ata_colptr column pointer of size n+1 for matrix A'*A.
  * \param[out] ata_rowind row indices of size atanz for matrix A'*A.
  */
-void getata(const int m, const int n, const int_t nz, int_t *colptr, int_t *rowind,
+void getata(const int m, const int n, const int_t nz, const int_t *colptr, const int_t *rowind,
             int_t *atanz, int_t **ata_colptr, int_t **ata_rowind)
 {
     register int_t i, j, k, col, num_nz, ti, trow;
@@ -280,7 +280,7 @@ void getata(const int m, const int n, const int_t nz, int_t *colptr, int_t *rowi
  * \param[out] b_colptr column pointer of size n+1 for matrix A'+A.
  * \param[out] b_rowind row indices of size bnz for matrix A'+A.
  */
-void at_plus_a(const int n, const int_t nz, int_t *colptr, int_t *rowind,
+void at_plus_a(const int n, const int_t nz, const int_t *colptr, const int_t *rowind,
                int_t *bnz, int_t **b_colptr, int_t **b_rowind)
 {
     register int_t i, j, k, col, num_nz;

--- a/SRC/ilu_relax_snode.c
+++ b/SRC/ilu_relax_snode.c
@@ -33,7 +33,7 @@ at the top-level directory.
 void
 ilu_relax_snode (
 	      const	int n,
-	      int	*et,	       /* column elimination tree */
+	      const int	*et,	       /* column elimination tree */
 	      const int relax_columns, /* max no of columns allowed in a
 					  relaxed snode */
 	      int	*descendants,  /* no of descendants of each node

--- a/SRC/mark_relax.c
+++ b/SRC/mark_relax.c
@@ -29,16 +29,16 @@ at the top-level directory.
  */
 int mark_relax(
 	int n,		    /* order of the matrix A */
-	int *relax_end,     /* last column in a relaxed supernode.
+	const int *relax_end,     /* last column in a relaxed supernode.
 			     * if j-th column starts a relaxed supernode,
 			     * relax_end[j] represents the last column of
 			     * this supernode. */
-	int *relax_fsupc,   /* first column in a relaxed supernode.
+	const int *relax_fsupc,   /* first column in a relaxed supernode.
 			     * relax_fsupc[j] represents the first column of
 			     * j-th supernode. */
-	int_t *xa_begin,    /* Astore->colbeg */
-	int_t *xa_end,	    /* Astore->colend */
-	int_t *asub,	    /* row index of A */
+	const int_t *xa_begin,    /* Astore->colbeg */
+	const int_t *xa_end,	    /* Astore->colend */
+	const int_t *asub,	    /* row index of A */
 	int   *marker	    /* marker[j] is the maximum column index if j-th
 			     * row belongs to a relaxed supernode. */ )
 {

--- a/SRC/mmd.c
+++ b/SRC/mmd.c
@@ -75,17 +75,17 @@ typedef int_t shortint;
     /* Local variables */
     int_t mdeg, ehead, i, mdlmt, mdnode;
     extern /* Subroutine */
-	int slu_mmdelm_(int_t *mdnode, int_t *xadj, shortint *adjncy,
-			shortint *dhead, int *dforw, int *dbakw, shortint *qsize, 
-			shortint *llist, shortint *marker, int_t *maxint, int_t *tag),
-	slu_mmdupd_(int_t *ehead, int *neqns, int_t *xadj, 
-		    shortint *adjncy, int_t *delta, int_t *mdeg, shortint *dhead, 
-		    int *dforw, int *dbakw, shortint *qsize, shortint *llist, 
-		    shortint *marker, int_t *maxint, int_t *tag),
-	slu_mmdint_(int *neqns, int_t *xadj, shortint *adjncy, 
-			shortint *dhead, int *dforw, int *dbakw, shortint *qsize, 
-			shortint *llist, shortint *marker),
-	slu_mmdnum_(int *neqns, int *perm, int *invp, shortint *qsize);
+    int slu_mmdelm_(const int_t *mdnode, int_t *xadj, shortint *adjncy,
+                    shortint *dhead, int *dforw, int *dbakw, shortint *qsize,
+                    shortint *llist, shortint *marker, const int_t *maxint, const int_t *tag),
+    slu_mmdupd_(const int_t *ehead, const int *neqns, int_t *xadj,
+                shortint *adjncy, const int_t *delta, int_t *mdeg, shortint *dhead,
+                int *dforw, int *dbakw, shortint *qsize, shortint *llist,
+                shortint *marker, const int_t *maxint, int_t *tag),
+    slu_mmdint_(const int *neqns, int_t *xadj, shortint *adjncy,
+                shortint *dhead, int *dforw, int *dbakw, shortint *qsize,
+                shortint *llist, shortint *marker),
+    slu_mmdnum_(const int *neqns, int *perm, int *invp, shortint *qsize);
 
     int_t nextmd, tag, num;
 
@@ -255,7 +255,8 @@ L1000:
 
 /* *************************************************************** */
 
-/* Subroutine */ int slu_mmdint_(int *neqns, int_t *xadj, shortint *adjncy, 
+/* Subroutine */
+int slu_mmdint_(const int *neqns, int_t *xadj, shortint *adjncy,
 	shortint *dhead, int *dforw, int *dbakw, shortint *qsize, 
 	shortint *llist, shortint *marker)
 {
@@ -335,9 +336,10 @@ L1000:
 
 /* *************************************************************** */
 
-/* Subroutine */ int slu_mmdelm_(int_t *mdnode, int_t *xadj, shortint *adjncy,
-	 shortint *dhead, int *dforw, int *dbakw, shortint *qsize, 
-	shortint *llist, shortint *marker, int_t *maxint, int_t *tag)
+/* Subroutine */
+int slu_mmdelm_(const int_t *mdnode, int_t *xadj, shortint *adjncy,
+                shortint *dhead, int *dforw, int *dbakw, shortint *qsize,
+                shortint *llist, shortint *marker, const int_t *maxint, const int_t *tag)
 {
     /* System generated locals */
     int_t i__1, i__2;
@@ -583,10 +585,11 @@ L1800:
 /* *************************************************************** */
 
 
-/* Subroutine */ int slu_mmdupd_(int_t *ehead, int *neqns, int_t *xadj, 
-	shortint *adjncy, int_t *delta, int_t *mdeg, shortint *dhead, 
-        int *dforw, int *dbakw, shortint *qsize, shortint *llist, 
-	shortint *marker, int_t *maxint, int_t *tag)
+/* Subroutine */
+int slu_mmdupd_(const int_t *ehead, const int *neqns, int_t *xadj,
+                shortint *adjncy, const int_t *delta, int_t *mdeg, shortint *dhead,
+                int *dforw, int *dbakw, shortint *qsize, shortint *llist,
+                shortint *marker, const int_t *maxint, int_t *tag)
 {
     /* System generated locals */
     int_t i__1, i__2;
@@ -939,8 +942,8 @@ L2300:
 
 /* *************************************************************** */
 
-/* Subroutine */ int slu_mmdnum_(int *neqns, int *perm, int *invp, 
-	shortint *qsize)
+/* Subroutine */
+int slu_mmdnum_(const int *neqns, int *perm, int *invp, shortint *qsize)
 {
     /* System generated locals */
 

--- a/SRC/relax_snode.c
+++ b/SRC/relax_snode.c
@@ -44,7 +44,7 @@ at the top-level directory.
 void
 relax_snode (
 	     const     int n,
-	     int       *et,           /* column elimination tree */
+                  const int *et,           /* column elimination tree */
 	     const int relax_columns, /* max no of columns allowed in a
 					 relaxed snode */
 	     int       *descendants,  /* no of descendants of each node

--- a/SRC/slu_dcomplex.h
+++ b/SRC/slu_dcomplex.h
@@ -68,7 +68,7 @@ extern "C" {
 #endif
 
 /* Prototypes for functions in dcomplex.c */
-void z_div(doublecomplex *, doublecomplex *, doublecomplex *);
+void z_div(doublecomplex *, const doublecomplex *, const doublecomplex *);
 double z_abs(doublecomplex *);     /* exact */
 double z_abs1(doublecomplex *);    /* approximate */
 void z_exp(doublecomplex *, doublecomplex *);

--- a/SRC/slu_ddefs.h
+++ b/SRC/slu_ddefs.h
@@ -175,7 +175,7 @@ extern void    dreadmt (int *, int *, int_t *, double **, int_t **, int_t **);
 extern void    dGenXtrue (int, int, double *, int);
 extern void    dFillRHS (trans_t, int, double *, int, SuperMatrix *,
 			  SuperMatrix *);
-extern void    dgstrs (trans_t, SuperMatrix *, SuperMatrix *, int *, int *,
+extern void    dgstrs (trans_t, SuperMatrix *, SuperMatrix *, const int *, const int *,
                         SuperMatrix *, SuperLUStat_t*, int *);
 /* ILU */
 extern void    dgsitrf (superlu_options_t*, SuperMatrix*, int, int, int*,

--- a/SRC/slu_util.h
+++ b/SRC/slu_util.h
@@ -375,9 +375,9 @@ extern void    Destroy_Dense_Matrix(SuperMatrix *);
 extern void    get_perm_c(int, SuperMatrix *, int *);
 extern void    set_default_options(superlu_options_t *options);
 extern void    ilu_set_default_options(superlu_options_t *options);
-extern void    sp_preorder (superlu_options_t *, SuperMatrix*, int*, int*,
-			    SuperMatrix*);
-extern void    superlu_abort_and_exit(char*);
+extern void    sp_preorder (const superlu_options_t *, SuperMatrix*, int*, int*,
+                            SuperMatrix*);
+extern void    superlu_abort_and_exit(const char*);
 extern void    *superlu_malloc (size_t);
 extern int     *int32Malloc (int);
 extern int     *int32Calloc (int);
@@ -386,14 +386,14 @@ extern int_t   *intCalloc (int_t);
 extern void    superlu_free (void*);
 extern void    SetIWork (int, int, int, int *, int **, int **, int_t **xplore,
                          int **, int **, int_t **xprune, int **);
-extern int     sp_coletree (int_t *, int_t *, int_t *, int, int, int *);
-extern void    relax_snode (const int, int *, const int, int *, int *);
+extern int     sp_coletree (const int_t *, const int_t *, const int_t *, int, int, int *);
+extern void    relax_snode (const int, const int *, const int, int *, int *);
 extern void    heap_relax_snode (const int, int *, const int, int *, int *);
-extern int     mark_relax(int, int *, int *, int_t *, int_t *, int_t *, int *);
+extern int     mark_relax(int, const int *, const int *, const int_t *, const int_t *, const int_t *, int *);
 extern void    countnz(const int n, int_t *xprune, int_t *nnzL, int_t *nnzU, GlobalLU_t *);
 extern void    ilu_countnz (const int, int_t *, int_t *, GlobalLU_t *);
 extern void    fixupL (const int, const int *, GlobalLU_t *);
-extern void    ilu_relax_snode (const int, int *, const int, int *,
+extern void    ilu_relax_snode (const int, const int *, const int, int *,
 				int *, int *);
 extern void    ilu_heap_relax_snode (const int, int *, const int, int *,
 				     int *, int*);
@@ -405,16 +405,16 @@ extern int     sp_ienv (int);
 extern int     xerbla_ (char *, int *);
 extern void    ifill (int *, int, int);
 extern void    snode_profile (int, int *);
-extern void    super_stats (int, int *);
-extern void    check_repfnz(int, int, int, int *);
-extern void    PrintSumm (char *, int, int, int);
+extern void    super_stats (int, const int *);
+extern void    check_repfnz(int, int, int, const int *);
+extern void    PrintSumm (const char *, int, int, int);
 extern void    StatInit(SuperLUStat_t *);
 extern void    StatPrint (SuperLUStat_t *);
 extern void    StatFree(SuperLUStat_t *);
-extern void    print_panel_seg(int, int, int, int, int *, int *);
-extern void    print_int_vec(char *what, int n, int *vec);
-extern void    slu_PrintInt10(char *name, int len, int *x);
-extern void    check_perm(char *what, int n, int *perm);
+extern void    print_panel_seg(int, int, int, int, const int *, const int *);
+extern void    print_int_vec(const char *what, int n, const int *vec);
+extern void    slu_PrintInt10(const char *name, int len, const int *x);
+extern void    check_perm(const char *what, int n, const int *perm);
 
 #ifdef __cplusplus
   }

--- a/SRC/sp_coletree.c
+++ b/SRC/sp_coletree.c
@@ -166,13 +166,11 @@ void finalize_disjoint_sets (
 /*
  * Nonsymmetric elimination tree
  */
-int
-sp_coletree(
-	    int_t *acolst, int_t *acolend, /* column start and end past 1 */
-	    int_t *arow,                 /* row indices of A */
-	    int nr, int nc,            /* dimension of A */
-	    int *parent	               /* parent in elim tree */
-	    )
+int sp_coletree(
+                const int_t *acolst, const int_t *acolend, /* column start and end past 1 */
+                const int_t *arow,                 /* row indices of A */
+                int nr, int nc,            /* dimension of A */
+                int *parent)               /* parent in elim tree */
 {
 	int	*root;			/* root of subtee of etree 	*/
 	int     *firstcol;		/* first nonzero col in each row*/
@@ -275,8 +273,8 @@ static
  * Depth-first search from vertex n.  No recursion.
  * This routine was contributed by Cédric Doucet, CEDRAT Group, Meylan, France.
  */
-void nr_etdfs (int n, int *parent,
-	       int *first_kid, int *next_kid,
+void nr_etdfs (int n, const int *parent,
+	       const int *first_kid, const int *next_kid,
 	       int *post, int postnum)
 {
     int current = n, first, next;
@@ -391,13 +389,11 @@ int *TreePostorder(
 /*
  * Symmetric elimination tree
  */
-int
-sp_symetree(
-	    int *acolst, int *acolend, /* column starts and ends past 1 */
-	    int *arow,            /* row indices of A */
-	    int n,                /* dimension of A */
-	    int *parent	    /* parent in elim tree */
-	    )
+int sp_symetree(
+                const int *acolst, const int *acolend, /* column starts and ends past 1 */
+                const int *arow,            /* row indices of A */
+                int n,                /* dimension of A */
+                int *parent)    /* parent in elim tree */
 {
 	int	*root;		    /* root of subtree of etree 	*/
 	int	rset, cset;             

--- a/SRC/sp_preorder.c
+++ b/SRC/sp_preorder.c
@@ -70,15 +70,14 @@ at the top-level directory.
  *         Stype = SLU_NCP; Dtype = A->Dtype; Mtype = SLU_GE.
  * </pre>
  */
-void
-sp_preorder(superlu_options_t *options,  SuperMatrix *A, int *perm_c, 
-	    int *etree, SuperMatrix *AC)
+void sp_preorder(const superlu_options_t *options,  SuperMatrix *A, int *perm_c,
+                 int *etree, SuperMatrix *AC)
 {
     NCformat  *Astore;
     NCPformat *ACstore;
     int       *iwork, *post;
     register  int n, i;
-    extern void check_perm(char *what, int n, int *perm);
+    extern void check_perm(const char *what, int n, const int *perm);
 	
     n = A->ncol;
     

--- a/SRC/sutil.c
+++ b/SRC/sutil.c
@@ -428,7 +428,7 @@ void sinf_norm_error(int nrhs, SuperMatrix *X, float *xtrue)
 void
 sPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
            float rpg, float rcond, float *ferr,
-           float *berr, char *equed, SuperLUStat_t *stat)
+           const float *berr, const char *equed, SuperLUStat_t *stat)
 {
     SCformat *Lstore;
     NCformat *Ustore;
@@ -470,7 +470,7 @@ sPrintPerf(SuperMatrix *L, SuperMatrix *U, mem_usage_t *mem_usage,
 
 
 int
-print_float_vec(char *what, int n, float *vec)
+print_float_vec(const char *what, int n, const float *vec)
 {
     int i;
     printf("%s: n %d\n", what, n);

--- a/SRC/util.c
+++ b/SRC/util.c
@@ -38,7 +38,7 @@ at the top-level directory.
  *
  * \param[in] mgs Message that is printed to error stream.
  */
-void superlu_abort_and_exit(char* msg)
+void superlu_abort_and_exit(const char* msg)
 {
     fprintf(stderr, "%s", msg);
     exit (-1);
@@ -86,7 +86,7 @@ void ilu_set_default_options(superlu_options_t *options)
  *
  * \param[in] options Options struct that is printed.
  */
-void print_options(superlu_options_t *options)
+void print_options(const superlu_options_t *options)
 {
     printf(".. options:\n");
     printf("\tFact\t %8d\n", options->Fact);
@@ -105,7 +105,7 @@ void print_options(superlu_options_t *options)
  *
  * \param[in] options Options struct that is printed.
  */
-void print_ilu_options(superlu_options_t *options)
+void print_ilu_options(const superlu_options_t *options)
 {
     printf(".. ILU options:\n");
     printf("\tDiagPivotThresh\t%6.2e\n", options->DiagPivotThresh);
@@ -339,8 +339,8 @@ fixupL(const int n, const int *perm_r, GlobalLU_t *Glu)
 
 /*! \brief Diagnostic print of segment info after panel_dfs().
  */
-void print_panel_seg(int n, int w, int jcol, int nseg, 
-		     int *segrep, int *repfnz)
+void print_panel_seg(int n, int w, int jcol, int nseg,
+                     const int *segrep, const int *repfnz)
 {
     int j, k;
     
@@ -476,7 +476,7 @@ void ifill(int *a, int alen, int ival)
  */
 #define NBUCKS 10
 
-void super_stats(int nsuper, int *xsup)
+void super_stats(int nsuper, const int *xsup)
 {
     register int nsup1 = 0;
     int    i, isize, whichb, bl, bh;
@@ -524,7 +524,7 @@ float DenseSize(int n, float sum_nw)
 
 /*! \brief Check whether repfnz[] == EMPTY after reset.
  */
-void check_repfnz(int n, int w, int jcol, int *repfnz)
+void check_repfnz(int n, int w, int jcol, const int *repfnz)
 {
     int jj, k;
 
@@ -545,7 +545,7 @@ void check_repfnz(int n, int w, int jcol, int *repfnz)
  * \param[in] nerrs Number of error messages recorded.
  */
 void
-PrintSumm(char *type, int nfail, int nrun, int nerrs)
+PrintSumm(const char *type, int nfail, int nrun, int nerrs)
 {
     if ( nfail > 0 )
 	printf("%3s driver: %d out of %d tests failed to pass the threshold\n",
@@ -563,7 +563,7 @@ PrintSumm(char *type, int nfail, int nrun, int nerrs)
  * \param[in] n Number of elements in array.
  * \param[in] vec Array of ints to be printed
  */
-void print_int_vec(char *what, int n, int *vec)
+void print_int_vec(const char *what, int n, const int *vec)
 {
     int i;
     printf("%s\n", what);
@@ -579,7 +579,7 @@ void print_int_vec(char *what, int n, int *vec)
  * \param[in] len Number of elements in array.
  * \param[in] x Array of ints to be printed.
  */
-void slu_PrintInt10(char *name, int len, int *x)
+void slu_PrintInt10(const char *name, int len, const int *x)
 {
     register int i;
     
@@ -598,7 +598,7 @@ void slu_PrintInt10(char *name, int len, int *x)
  * \param[in] n Number of elements in permutation \a perm.
  * \param[in] perm Array describing the permutation.
  */
-void check_perm(char *what, int n, int *perm)
+void check_perm(const char *what, int n, const int *perm)
 {
     register int i;
     int          *marker;


### PR DESCRIPTION
Found by Cppcheck (constParameterPointer).

More details why this is a good idea: https://wiki.sei.cmu.edu/confluence/display/c/DCL13-C.+Declare+function+parameters+that+are+pointers+to+values+not+changed+by+the+function+as+const