### PR TITLE
[cmake] Revert "make use of "enable_examples" in CMakeLists.txt"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,14 +255,12 @@ if(enable_tests)
   add_subdirectory(TESTING)
 endif()
 
-if (enable_examples)
-  add_custom_target(examples)
-  add_subdirectory(EXAMPLE)
-endif()
-
+add_custom_target(examples)
 if (enable_fortran)
   add_subdirectory(FORTRAN)
 endif()
+
+add_subdirectory(EXAMPLE)
 
 if (enable_doc)
    add_subdirectory(DOC)


### PR DESCRIPTION
This reverts parts of commit 367fd39713dc8efe1edea95b5bafb4863b9b6d0b.

The use of `enable_examples` is in EXAMPLES/CMakeLists.txt. The advantage of the solution is that even with disabled enable_examples the examples can be manually built.