### PR TITLE
[cmake] Disable finding Doxygen only for CMake < 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,8 @@ endif()
 
 add_subdirectory(EXAMPLE)
 
-if (enable_doc)
+# To work around CMake bug #18708 that got fixed in 3.28.0, for
+# older CMake disable finding Doxygen unless explicitly enabled
+if (enable_doc OR (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28.0"))
    add_subdirectory(DOC)
 endif()


### PR DESCRIPTION
This allows building the documentation without setting a flag only by running "make doc" / "ninja doc".  
The currently implemented solution by 2c8ef7da153e87745f04f968eb2a995d735e64ec is a bit drastic.