### PR TITLE
BUG: explicitly convert the return value of SUPERLU_MALLOC

### DIFF
--- a/SRC/cgsitrf.c
+++ b/SRC/cgsitrf.c
@@ -300,7 +300,7 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
     amax = (float *) SUPERLU_MALLOC(panel_size * sizeof(float));
     if (drop_rule & DROP_SECONDARY)
-	swork2 = SUPERLU_MALLOC(n * sizeof(float));
+	swork2 = (float *) SUPERLU_MALLOC(n * sizeof(float));
     else
 	swork2 = NULL;
 

--- a/SRC/dgsitrf.c
+++ b/SRC/dgsitrf.c
@@ -299,7 +299,7 @@ dgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
     amax = (double *) SUPERLU_MALLOC(panel_size * sizeof(double));
     if (drop_rule & DROP_SECONDARY)
-	dwork2 = SUPERLU_MALLOC(n * sizeof(double));
+	dwork2 = (double *) SUPERLU_MALLOC(n * sizeof(double));
     else
 	dwork2 = NULL;
 

--- a/SRC/sgsitrf.c
+++ b/SRC/sgsitrf.c
@@ -299,7 +299,7 @@ sgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
     amax = (float *) SUPERLU_MALLOC(panel_size * sizeof(float));
     if (drop_rule & DROP_SECONDARY)
-	swork2 = SUPERLU_MALLOC(n * sizeof(float));
+	swork2 = (float *) SUPERLU_MALLOC(n * sizeof(float));
     else
 	swork2 = NULL;
 

--- a/SRC/zgsitrf.c
+++ b/SRC/zgsitrf.c
@@ -300,7 +300,7 @@ zgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
     amax = (double *) SUPERLU_MALLOC(panel_size * sizeof(double));
     if (drop_rule & DROP_SECONDARY)
-	dwork2 = SUPERLU_MALLOC(n * sizeof(double));
+	dwork2 = (double *) SUPERLU_MALLOC(n * sizeof(double));
     else
 	dwork2 = NULL;
 


### PR DESCRIPTION
A small fix that explicitly converts the return value of `SUPERLU_MALLOC` to match the assigned variable.

This is normally not an issue in native build, but in Emscripten build, which requires a stricter type checking, the compiler is not happy because of the type mismatch.

I was experiencing this issue while I was building scipy to Emscripten. (https://github.com/scipy/scipy/pull/24408)

```
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c:302:9: error: incompatible pointer types assigning to 'float *' from 'int *' [-Wincompatible-pointer-types]                                                                                                                        
  302 |         swork2 = SUPERLU_MALLOC(n * sizeof(float));                                                                                                                                                                                                                             
      |                ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```