### PR TITLE
Avoid calling `*trsv` and `*gemv` with invalid parameter values

### DIFF
--- a/SRC/cpanel_bmod.c
+++ b/SRC/cpanel_bmod.c
@@ -235,10 +235,14 @@ cpanel_bmod (
 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, TriTmp, &incx );
 #else
-		    ctrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    ctrsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, TriTmp, &incx );
 #endif
-#else		
+#else
 		    clsolve ( nsupr, segsze, &lusup[luptr], TriTmp );
 #endif
 		    
@@ -428,10 +432,14 @@ cpanel_bmod (
 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, tempv, &incx );
 #else
-		    ctrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    ctrsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, tempv, &incx );
 #endif
-		    
+
 		    luptr += segsze;	/* Dense matrix-vector */
 		    tempv1 = &tempv[segsze];
                     alpha = one;

--- a/SRC/cpivotL.c
+++ b/SRC/cpivotL.c
@@ -135,13 +135,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let cgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/csnode_bmod.c
+++ b/SRC/csnode_bmod.c
@@ -105,7 +105,11 @@ csnode_bmod (
 	CGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
-	ctrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
+	if (nsupr < nsupc) {
+	    /* Fail early rather than passing in invalid parameters to TRSV. */
+	    ABORT("failed to factorize matrix");
+	}
+	ctrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr,
 	      &lusup[ufirst], &incx );
 	cgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );

--- a/SRC/dpanel_bmod.c
+++ b/SRC/dpanel_bmod.c
@@ -221,10 +221,14 @@ dpanel_bmod (
 		    STRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, TriTmp, &incx );
 #else
-		    dtrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    dtrsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, TriTmp, &incx );
 #endif
-#else		
+#else
 		    dlsolve ( nsupr, segsze, &lusup[luptr], TriTmp );
 #endif
 		    
@@ -400,7 +404,11 @@ dpanel_bmod (
 		    STRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, tempv, &incx );
 #else
-		    dtrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    dtrsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, tempv, &incx );
 #endif
 		    

--- a/SRC/dpivotL.c
+++ b/SRC/dpivotL.c
@@ -134,13 +134,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let dgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/dsnode_bmod.c
+++ b/SRC/dsnode_bmod.c
@@ -104,7 +104,11 @@ dsnode_bmod (
 	SGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
-	dtrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
+	if (nsupr < nsupc) {
+	    /* Fail early rather than passing in invalid parameters to TRSV. */
+	    ABORT("failed to factorize matrix");
+	}
+	dtrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr,
 	      &lusup[ufirst], &incx );
 	dgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );

--- a/SRC/ilu_cpivotL.c
+++ b/SRC/ilu_cpivotL.c
@@ -147,11 +147,7 @@ ilu_cpivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -164,11 +160,7 @@ ilu_cpivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/ilu_dpivotL.c
+++ b/SRC/ilu_dpivotL.c
@@ -145,11 +145,7 @@ ilu_dpivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -162,11 +158,7 @@ ilu_dpivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/ilu_spivotL.c
+++ b/SRC/ilu_spivotL.c
@@ -145,11 +145,7 @@ ilu_spivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -162,11 +158,7 @@ ilu_spivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/ilu_zpivotL.c
+++ b/SRC/ilu_zpivotL.c
@@ -147,11 +147,7 @@ ilu_zpivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -164,11 +160,7 @@ ilu_zpivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/spanel_bmod.c
+++ b/SRC/spanel_bmod.c
@@ -221,10 +221,14 @@ spanel_bmod (
 		    STRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, TriTmp, &incx );
 #else
-		    strsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    strsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, TriTmp, &incx );
 #endif
-#else		
+#else
 		    slsolve ( nsupr, segsze, &lusup[luptr], TriTmp );
 #endif
 		    
@@ -400,7 +404,11 @@ spanel_bmod (
 		    STRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, tempv, &incx );
 #else
-		    strsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    strsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, tempv, &incx );
 #endif
 		    

--- a/SRC/spivotL.c
+++ b/SRC/spivotL.c
@@ -134,13 +134,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let sgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/ssnode_bmod.c
+++ b/SRC/ssnode_bmod.c
@@ -104,7 +104,11 @@ ssnode_bmod (
 	SGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
-	strsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
+	if (nsupr < nsupc) {
+	    /* Fail early rather than passing in invalid parameters to TRSV. */
+	    ABORT("failed to factorize matrix");
+	}
+	strsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr,
 	      &lusup[ufirst], &incx );
 	sgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );

--- a/SRC/zpanel_bmod.c
+++ b/SRC/zpanel_bmod.c
@@ -235,10 +235,14 @@ zpanel_bmod (
 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, TriTmp, &incx );
 #else
-		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, TriTmp, &incx );
 #endif
-#else		
+#else
 		    zlsolve ( nsupr, segsze, &lusup[luptr], TriTmp );
 #endif
 		    
@@ -428,10 +432,14 @@ zpanel_bmod (
 		    CTRSV( ftcs1, ftcs2, ftcs3, &segsze, &lusup[luptr], 
 			   &nsupr, tempv, &incx );
 #else
-		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr], 
+		    if (nsupr < segsze) {
+			/* Fail early rather than passing in invalid parameters to TRSV. */
+			ABORT("failed to factorize matrix");
+		    }
+		    ztrsv_( "L", "N", "U", &segsze, &lusup[luptr],
 			   &nsupr, tempv, &incx );
 #endif
-		    
+
 		    luptr += segsze;	/* Dense matrix-vector */
 		    tempv1 = &tempv[segsze];
                     alpha = one;

--- a/SRC/zpivotL.c
+++ b/SRC/zpivotL.c
@@ -135,13 +135,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let zgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/zsnode_bmod.c
+++ b/SRC/zsnode_bmod.c
@@ -105,7 +105,11 @@ zsnode_bmod (
 	CGEMV( ftcs2, &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );
 #else
-	ztrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr, 
+	if (nsupr < nsupc) {
+	    /* Fail early rather than passing in invalid parameters to TRSV. */
+	    ABORT("failed to factorize matrix");
+	}
+	ztrsv_( "L", "N", "U", &nsupc, &lusup[luptr], &nsupr,
 	      &lusup[ufirst], &incx );
 	zgemv_( "N", &nrow, &nsupc, &alpha, &lusup[luptr+nsupc], &nsupr, 
 		&lusup[ufirst], &incx, &beta, &lusup[ufirst+nsupc], &incy );


### PR DESCRIPTION
This upstreams patches that SciPy has carried for a long time, as discussed in gh-167. There are four separate fixes - this PR has them all, one commit per issue. The commit messages have more detailed explanation.

I also investigated moving the fixes around as suggested in gh-167, but that doesn't quite work as commented on in https://github.com/xiaoyeli/superlu/issues/167#issuecomment-4074229554.