### PR TITLE
Fix `-Wpointer-to-int-cast` warnings in `*memory.c` on Windows

### DIFF
--- a/SRC/cmemory.c
+++ b/SRC/cmemory.c
@@ -660,8 +660,8 @@ cStackCompress(GlobalLU_t *Glu)
     
     last = (char*)usub + xusub[ndim] * iword;
     fragment = (char*) (((char*)Glu->stack.array + Glu->stack.top1) - last);
-    Glu->stack.used -= (long int) fragment;
-    Glu->stack.top1 -= (long int) fragment;
+    Glu->stack.used -= (int_t)(intptr_t) fragment;
+    Glu->stack.top1 -= (int_t)(intptr_t) fragment;
 
     Glu->ucol = ucol;
     Glu->lsub = lsub;

--- a/SRC/dmemory.c
+++ b/SRC/dmemory.c
@@ -660,8 +660,8 @@ dStackCompress(GlobalLU_t *Glu)
     
     last = (char*)usub + xusub[ndim] * iword;
     fragment = (char*) (((char*)Glu->stack.array + Glu->stack.top1) - last);
-    Glu->stack.used -= (long int) fragment;
-    Glu->stack.top1 -= (long int) fragment;
+    Glu->stack.used -= (int_t)(intptr_t) fragment;
+    Glu->stack.top1 -= (int_t)(intptr_t) fragment;
 
     Glu->ucol = ucol;
     Glu->lsub = lsub;

--- a/SRC/smemory.c
+++ b/SRC/smemory.c
@@ -660,8 +660,8 @@ sStackCompress(GlobalLU_t *Glu)
     
     last = (char*)usub + xusub[ndim] * iword;
     fragment = (char*) (((char*)Glu->stack.array + Glu->stack.top1) - last);
-    Glu->stack.used -= (long int) fragment;
-    Glu->stack.top1 -= (long int) fragment;
+    Glu->stack.used -= (int_t)(intptr_t) fragment;
+    Glu->stack.top1 -= (int_t)(intptr_t) fragment;
 
     Glu->ucol = ucol;
     Glu->lsub = lsub;

--- a/SRC/zmemory.c
+++ b/SRC/zmemory.c
@@ -660,8 +660,8 @@ zStackCompress(GlobalLU_t *Glu)
     
     last = (char*)usub + xusub[ndim] * iword;
     fragment = (char*) (((char*)Glu->stack.array + Glu->stack.top1) - last);
-    Glu->stack.used -= (long int) fragment;
-    Glu->stack.top1 -= (long int) fragment;
+    Glu->stack.used -= (int_t)(intptr_t) fragment;
+    Glu->stack.top1 -= (int_t)(intptr_t) fragment;
 
     Glu->ucol = ucol;
     Glu->lsub = lsub;


### PR DESCRIPTION
On Windows, `long int` will be 32-bit, and `stack.used` is `int_t` which can be 64-bit. This results in warnings like (from https://github.com/scipy/scipy/issues/24924):
```
[37/344] Compiling C object scipy/sparse/linalg/_dsolve/libsuperlu_lib.a.p/SuperLU_SRC_cmemory.c.obj
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/cmemory.c(663,24): warning: cast to smaller integer type 'long' from 'char *' [-Wpointer-to-int-cast]
  663 |     Glu->stack.used -= (long int) fragment;
      |                        ^~~~~~~~~~~~~~~~~~~
../scipy/sparse/linalg/_dsolve/SuperLU/SRC/cmemory.c(664,24): warning: cast to smaller integer type 'long' from 'char *' [-Wpointer-to-int-cast]
  664 |     Glu->stack.top1 -= (long int) fragment;
      |                        ^~~~~~~~~~~~~~~~~~~
```

The fix needs to use a double cast for correctness: only `intptr_t` is defined for pointer to integer casting, and then we need to cast again to `int_t` to match `stack.used`.