### PR TITLE
Replace commented-out `exit(1)` with `ABORT()` in `ilu_*pivotL.c`

### DIFF
--- a/SRC/ilu_cpivotL.c
+++ b/SRC/ilu_cpivotL.c
@@ -147,11 +147,7 @@ ilu_cpivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -164,11 +160,7 @@ ilu_cpivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/ilu_dpivotL.c
+++ b/SRC/ilu_dpivotL.c
@@ -145,11 +145,7 @@ ilu_dpivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -162,11 +158,7 @@ ilu_dpivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/ilu_spivotL.c
+++ b/SRC/ilu_spivotL.c
@@ -145,11 +145,7 @@ ilu_spivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -162,11 +158,7 @@ ilu_spivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];

--- a/SRC/ilu_zpivotL.c
+++ b/SRC/ilu_zpivotL.c
@@ -147,11 +147,7 @@ ilu_zpivotL(
 
     /* Test for singularity */
     if (pivmax < 0.0) {
-    	/*fprintf(stderr, "[0]: jcol=%d, SINGULAR!!!\n", jcol);
-	fflush(stderr);
-	exit(1); */
-	*usepr = 0;
-	return (jcol+1);
+	ABORT("[0]: matrix is singular");
     }
     if ( pivmax == 0.0 ) {
 	if (diag != SLU_EMPTY)
@@ -164,11 +160,7 @@ ilu_zpivotL(
 	    for (icol = jcol; icol < n; icol++)
 		if (marker[swap[icol]] <= jcol) break;
 	    if (icol >= n) {
-		/* fprintf(stderr, "[1]: jcol=%d, SINGULAR!!!\n", jcol);
-		fflush(stderr);
-		exit(1); */
-   	        *usepr = 0;
-	        return (jcol+1);
+		ABORT("[1]: matrix is singular");
 	    }
 
 	    *pivrow = swap[icol];


### PR DESCRIPTION
The ILU pivot routines had two singularity checks with commented-out `fprintf`/`exit` calls that silently continued. Replace these with `ABORT()` to fail with a clear error message instead.

Upstreamed from SciPy, which has carried this patch for a long time.

Split off from PR gh-174, since that one is current blocked on performance-related concerns of unrelated commits.