### PR TITLE
Bounds-check `pivptr` in `*pivotL.c` before accessing `lsub_ptr` on singular matrix

### DIFF
--- a/SRC/cpivotL.c
+++ b/SRC/cpivotL.c
@@ -135,13 +135,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let cgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/dpivotL.c
+++ b/SRC/dpivotL.c
@@ -134,13 +134,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let dgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/spivotL.c
+++ b/SRC/spivotL.c
@@ -134,13 +134,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let sgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }

--- a/SRC/zpivotL.c
+++ b/SRC/zpivotL.c
@@ -135,13 +135,14 @@ if ( jcol == MIN_COL ) {
 
     /* Test for singularity */
     if ( pivmax == 0.0 ) {
-#if 0
-        // There is no valid pivot.
-        // jcol represents the rank of U, 
-        // report the rank, let dgstrf handle the pivot
-	*pivrow = lsub_ptr[pivptr];
-	perm_r[*pivrow] = jcol;
-#endif
+	/* There is no valid pivot. jcol represents the rank of U,
+	   report the rank, let zgstrf handle the pivot. */
+	if (pivptr < nsupr) {
+	    *pivrow = lsub_ptr[pivptr];
+	}
+	else {
+	    *pivrow = diagind;
+	}
 	*usepr = 0;
 	return (jcol+1);
     }


### PR DESCRIPTION
When the matrix is singular (`pivmax == 0.0`), `pivptr` may be out of bounds for `lsub_ptr` (`pivptr >= nsupr`). Add a guard to use `diagind` as the pivot row when `pivptr` is out of range.

Upstreamed from SciPy, which has carried this patch for a long time.

Also cleans up some code that was `ifdef`'d out already.

Split off from PR gh-174, since that one is current blocked on performance-related concerns of unrelated commits.